### PR TITLE
Fixes for organization name changes and adding PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+# Summary
+
+# Details
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,9 @@
 # Summary
 
+- What is the objective? What is fixed/what feature is added/what was documented?
+- How is the objective implemented? What classes/doc files/CI were changed?
 # Details
 
+Depends on the nature of the PR :
+- **Code changes :** describe the conceptual approach taken in the code and tell the reviewer what part of the changes does what, so that it's easier to read the code
+- **Other changes :** Add details if relevant, or remove this section if not useful

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    namespace = "com.android.sample"
+    namespace = "ch.hikemate.app"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.android.sample"
+        applicationId = "ch.hikemate.app"
         minSdk = 28
         targetSdk = 34
         versionCode = 1
@@ -93,9 +93,9 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectName", "flepRename")
-        property("sonar.projectKey", "FLEPMate_flepRename")
-        property("sonar.organization", "flepmate")
+        property("sonar.projectName", "HikeMate")
+        property("sonar.projectKey", "HikeMate_hikeMateApp")
+        property("sonar.organization", "hikemate")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")

--- a/app/src/androidTest/java/ch/hikemate/app/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ExampleInstrumentedTest.kt
@@ -1,10 +1,11 @@
-package com.android.sample
+package ch.hikemate.app
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.screen.SecondScreen
+import ch.hikemate.app.screen.MainScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,17 +16,17 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class SecondActivityTest : TestCase() {
+class MainActivityTest : TestCase() {
 
-  @get:Rule val composeTestRule = createAndroidComposeRule<SecondActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
 
   @Test
   fun test() = run {
-    step("Start Second Activity") {
-      ComposeScreen.onComposeScreen<SecondScreen>(composeTestRule) {
+    step("Start Main Activity") {
+      ComposeScreen.onComposeScreen<MainScreen>(composeTestRule) {
         simpleText {
           assertIsDisplayed()
-          assertTextEquals("Hello Robolectric!")
+          assertTextEquals("Hello Android!")
         }
       }
     }

--- a/app/src/androidTest/java/ch/hikemate/app/screen/MainScreen.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/screen/MainScreen.kt
@@ -1,7 +1,7 @@
-package com.android.sample.screen
+package ch.hikemate.app.screen
 
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
-import com.android.sample.resources.C
+import ch.hikemate.app.resources.C
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 

--- a/app/src/main/java/ch/hikemate/app/MainActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.android.sample
+package ch.hikemate.app
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import com.android.sample.resources.C
-import com.android.sample.ui.theme.SampleAppTheme
+import ch.hikemate.app.resources.C
+import ch.hikemate.app.ui.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/ch/hikemate/app/SecondActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/SecondActivity.kt
@@ -1,4 +1,4 @@
-package com.android.sample
+package ch.hikemate.app
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import com.android.sample.resources.C
-import com.android.sample.ui.theme.SampleAppTheme
+import ch.hikemate.app.resources.C
+import ch.hikemate.app.ui.theme.SampleAppTheme
 
 class SecondActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/ch/hikemate/app/SimpleData.kt
+++ b/app/src/main/java/ch/hikemate/app/SimpleData.kt
@@ -1,4 +1,4 @@
-package com.android.sample
+package ch.hikemate.app
 
 import kotlin.math.sqrt
 

--- a/app/src/main/java/ch/hikemate/app/resources/C.kt
+++ b/app/src/main/java/ch/hikemate/app/resources/C.kt
@@ -1,4 +1,4 @@
-package com.android.sample.resources
+package ch.hikemate.app.resources
 
 // Like R, but C
 object C {

--- a/app/src/main/java/ch/hikemate/app/ui/theme/Color.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.android.sample.ui.theme
+package ch.hikemate.app.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/ch/hikemate/app/ui/theme/Theme.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.android.sample.ui.theme
+package ch.hikemate.app.ui.theme
 
 import android.app.Activity
 import android.os.Build

--- a/app/src/main/java/ch/hikemate/app/ui/theme/Type.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.android.sample.ui.theme
+package ch.hikemate.app.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/test/java/ch/hikemate/app/ExampleRobolectricTest.kt
+++ b/app/src/test/java/ch/hikemate/app/ExampleRobolectricTest.kt
@@ -1,11 +1,10 @@
-package com.android.sample
+package ch.hikemate.app
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.screen.MainScreen
+import ch.hikemate.app.screen.SecondScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,17 +15,17 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class MainActivityTest : TestCase() {
+class SecondActivityTest : TestCase() {
 
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<SecondActivity>()
 
   @Test
   fun test() = run {
-    step("Start Main Activity") {
-      ComposeScreen.onComposeScreen<MainScreen>(composeTestRule) {
+    step("Start Second Activity") {
+      ComposeScreen.onComposeScreen<SecondScreen>(composeTestRule) {
         simpleText {
           assertIsDisplayed()
-          assertTextEquals("Hello Android!")
+          assertTextEquals("Hello Robolectric!")
         }
       }
     }

--- a/app/src/test/java/ch/hikemate/app/ExampleUnitTest.kt
+++ b/app/src/test/java/ch/hikemate/app/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.android.sample
+package ch.hikemate.app
 
 import org.junit.Assert.*
 import org.junit.Test

--- a/app/src/test/java/ch/hikemate/app/PointTest.kt
+++ b/app/src/test/java/ch/hikemate/app/PointTest.kt
@@ -1,4 +1,4 @@
-package com.android.sample
+package ch.hikemate.app
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/app/src/test/java/ch/hikemate/app/screen/SecondScreen.kt
+++ b/app/src/test/java/ch/hikemate/app/screen/SecondScreen.kt
@@ -1,7 +1,7 @@
-package com.android.sample.screen
+package ch.hikemate.app.screen
 
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
-import com.android.sample.resources.C
+import ch.hikemate.app.resources.C
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 


### PR DESCRIPTION
# Summary

The project was renamed from FlepMate to HikeMate, leading to token invalidation. Also finally defined the app namespace to change it from the example one.

# Details

- Changed the CI tokens
- Added a PR template