### PR TITLE
feat(map): create the viewmodel for the list of hike routes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,9 @@ dependencies {
     // ----------        FireBase       ------------
     implementation(platform(libs.firebase.bom))
 
+    // ---------- OpenStreetMap ------------
+    implementation(libs.osmdroid)
+
     // Adds a remote binary dependency only for local tests.
     testImplementation(libs.junit)
 

--- a/app/src/main/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModel.kt
@@ -2,9 +2,14 @@ package ch.hikemate.app.model.map
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.osmdroid.util.BoundingBox
 
 /**
  * ViewModel for the list of hike routes
@@ -21,6 +26,8 @@ open class ListOfHikeRoutesViewModel() : ViewModel() {
   private val selectedHikeRoute_ = MutableStateFlow<String?>(null) // TODO: should be a Route object
   open val selectedHikeRoute: StateFlow<String?> = selectedHikeRoute_.asStateFlow()
 
+  private val area_ = MutableStateFlow<BoundingBox?>(null)
+
   // Creates a factory
   companion object {
     val Factory: ViewModelProvider.Factory =
@@ -32,12 +39,26 @@ open class ListOfHikeRoutesViewModel() : ViewModel() {
         }
   }
 
+  private suspend fun getRoutesAsync() {
+    // TODO: Should call the API repository to get all the routes filtered by the area
+    withContext(Dispatchers.IO) { Thread.sleep(100) }
+    hikeRoutes_.value = listOf("Route 1", "Route 2", "Route 3")
+  }
+
   /** Gets all the routes from the database and updates the routes_ variable */
   fun getRoutes() {
-    // TODO: should call the repository to get all the routes
-    // repository.getRoutes(onSuccess = { routes_.value = it }, onFailure = {})
+    viewModelScope.launch(Dispatchers.IO) { getRoutesAsync() }
+  }
 
-    hikeRoutes_.value = listOf("Route 1", "Route 2", "Route 3")
+  /**
+   * Sets the current displayed area on the map and updates the list of routes displayed in the
+   * list.
+   *
+   * @param area The area to be displayed
+   */
+  fun setArea(area: BoundingBox) {
+    area_.value = area
+    getRoutes()
   }
 
   /**

--- a/app/src/main/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModel.kt
@@ -1,0 +1,51 @@
+package ch.hikemate.app.model.map
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * ViewModel for the list of hike routes
+ *
+ * @param TODO: should take a repository as a parameter
+ */
+open class ListOfHikeRoutesViewModel() : ViewModel() {
+  // List of all routes in the database
+  private val hikeRoutes_ =
+      MutableStateFlow<List<String>>(emptyList()) // TODO: should be a list of Route objects
+  val hikeRoutes: StateFlow<List<String>> = hikeRoutes_.asStateFlow()
+
+  // Selected route, i.e the route for the detail view
+  private val selectedHikeRoute_ = MutableStateFlow<String?>(null) // TODO: should be a Route object
+  open val selectedHikeRoute: StateFlow<String?> = selectedHikeRoute_.asStateFlow()
+
+  // Creates a factory
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ListOfHikeRoutesViewModel() as T
+          }
+        }
+  }
+
+  /** Gets all the routes from the database and updates the routes_ variable */
+  fun getRoutes() {
+    // TODO: should call the repository to get all the routes
+    // repository.getRoutes(onSuccess = { routes_.value = it }, onFailure = {})
+
+    hikeRoutes_.value = listOf("Route 1", "Route 2", "Route 3")
+  }
+
+  /**
+   * Selects a route to be displayed in the detail view
+   *
+   * @param hikeRoute The route to be displayed
+   */
+  fun selectRoute(hikeRoute: String) { // TODO: should take a Route object
+    selectedHikeRoute_.value = hikeRoute
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModelTest.kt
@@ -3,6 +3,7 @@ package ch.hikemate.app.model.map
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.osmdroid.util.BoundingBox
 
 /** Testing the ListOfRoutesViewModel class */
 class ListOfHikeRoutesViewModelTest {
@@ -23,6 +24,8 @@ class ListOfHikeRoutesViewModelTest {
   @Test
   fun canGetRoutes() {
     listOfHikeRoutesViewModel.getRoutes()
+    // Wait for the coroutine to finish
+    Thread.sleep(500)
     assertNotEquals(listOfHikeRoutesViewModel.hikeRoutes.value.size, 0)
   }
 
@@ -30,5 +33,13 @@ class ListOfHikeRoutesViewModelTest {
   fun canSelectRoute() {
     listOfHikeRoutesViewModel.selectRoute("Route 1")
     assertEquals(listOfHikeRoutesViewModel.selectedHikeRoute.value, "Route 1")
+  }
+
+  @Test
+  fun canSetArea() {
+    listOfHikeRoutesViewModel.setArea(BoundingBox(0.0, 0.0, 0.0, 0.0))
+    // Wait for the coroutine to finish
+    Thread.sleep(500)
+    assertNotEquals(listOfHikeRoutesViewModel.hikeRoutes.value.size, 0)
   }
 }

--- a/app/src/test/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/map/ListOfHikeRoutesViewModelTest.kt
@@ -1,0 +1,34 @@
+package ch.hikemate.app.model.map
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/** Testing the ListOfRoutesViewModel class */
+class ListOfHikeRoutesViewModelTest {
+  private lateinit var listOfHikeRoutesViewModel: ListOfHikeRoutesViewModel
+
+  @Before
+  fun setUp() {
+    listOfHikeRoutesViewModel = ListOfHikeRoutesViewModel()
+  }
+
+  @Test
+  fun canBeCreatedAsFactory() {
+    val factory = ListOfHikeRoutesViewModel.Factory
+    val viewModel = factory.create(ListOfHikeRoutesViewModel::class.java)
+    assertNotNull(viewModel)
+  }
+
+  @Test
+  fun canGetRoutes() {
+    listOfHikeRoutesViewModel.getRoutes()
+    assertNotEquals(listOfHikeRoutesViewModel.hikeRoutes.value.size, 0)
+  }
+
+  @Test
+  fun canSelectRoute() {
+    listOfHikeRoutesViewModel.selectRoute("Route 1")
+    assertEquals(listOfHikeRoutesViewModel.selectedHikeRoute.value, "Route 1")
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+osmdroid = { module = "org.osmdroid:osmdroid-android", version = "6.1.14" }
 
 # Firebase Libraries
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }


### PR DESCRIPTION
Implemented the ListOfHikeRoutesViewModel to later retrieve the hike routes from the repository.

# Summary
The objective was to habe a basic view model with hardcoded values in order to create the map screen.
The following were done:
- Created a `ListOfHikeRoutesViewModel` with the said view model
- Created a `ListOfHikeRoutesViewModelTest` to test it (coverage achieved on the viewmodel: **100%**)

For now, the view model will return hike routes as hardcoded `Strings` ("Route 1", "Route 2", "Route 3"). This will be changed when the `HikeRoute` model will be created.