### PR TITLE
fix(ci): add the jacoco coverage to sonar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,10 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
+            
+      # Generate coverage report
+      - name: Generate coverage
+        run: ./gradlew jacocoTestReport
 
       - name: Build and analyze
         env:


### PR DESCRIPTION
Added the step to generate the jacoco coverage

# Summary
The CI job would not create the Jacoco coverage report. Sonar would then always return a 0.0% coverage.
I added the task to generate the Jacoco coverage report in order for Sonar to watch it.
