### PR TITLE
feat(navigation): add NavigationActions and the composable SideBarNavigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,10 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
+            
+      # Generate coverage report
+      - name: Generate coverage
+        run: ./gradlew jacocoTestReport
 
       - name: Build and analyze
         env:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,7 +158,9 @@ dependencies {
 
     // Adds a remote binary dependency only for local tests.
     testImplementation(libs.junit)
-
+    testImplementation (libs.mockito.core)
+    testImplementation (libs.mockito.inline)
+    testImplementation (libs.mockito.android)
 
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,7 +161,6 @@ dependencies {
 
     testImplementation (libs.mockito.inline)
     testImplementation (libs.mockito.android)
-    //noinspection GradleDependency
     testImplementation (libs.mockito.core)
     testImplementation (libs.mockito.kotlin)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -185,13 +184,9 @@ dependencies {
     testImplementation(libs.compose.test.manifest)
 
     // Mockito
-    //noinspection GradleDependency
     testImplementation(libs.mockito.mockito.core.v3124)
-    //noinspection GradleDependency
     testImplementation(libs.kotlin.mockito.kotlin.v320)
-    //noinspection GradleDependency
     androidTestImplementation(libs.mockito.android.v3124)
-    //noinspection GradleDependency
     androidTestImplementation(libs.mockito.kotlin)
 
     // Robolectric (for unit tests that require Android framework)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))
     implementation(libs.firebase.firestore.ktx)
+    implementation(libs.androidx.navigation.runtime.ktx)
+    implementation(libs.androidx.navigation.common.ktx)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,13 +157,39 @@ dependencies {
     implementation(platform(libs.firebase.bom))
 
     // Adds a remote binary dependency only for local tests.
-    testImplementation(libs.junit)
-    testImplementation (libs.mockito.core)
+
     testImplementation (libs.mockito.inline)
     testImplementation (libs.mockito.android)
+    testImplementation ("org.mockito:mockito-core:3.12.4")
+    testImplementation ("org.mockito.kotlin:mockito-kotlin:3.2.0")
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation (libs.ui.test.junit4)
+    androidTestImplementation (libs.mockito.mockito.kotlin)
+    debugImplementation (libs.ui.test.manifest)
+    // JUnit
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.junit)
 
+    // AndroidX Test
+    androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
+    // Compose UI Testing
+    androidTestImplementation(libs.compose.test.junit)
+    debugImplementation(libs.compose.test.manifest)
+
+    // For both unit and instrumented tests
+    testImplementation(libs.compose.test.junit)
+    testImplementation(libs.compose.test.manifest)
+
+    // Mockito
+    testImplementation("org.mockito:mockito-core:3.12.4")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
+    androidTestImplementation("org.mockito:mockito-android:3.12.4")
+    androidTestImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
+
+    // Robolectric (for unit tests that require Android framework)
+    testImplementation(libs.robolectric)
     // To fix an issue with Firebase and the Protobuf library
     configurations.configureEach {
         exclude(group = "com.google.protobuf", module = "protobuf-lite")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
     implementation(libs.firebase.firestore.ktx)
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.navigation.common.ktx)
+    implementation(libs.androidx.navigation.testing)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,12 +52,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     packaging {
@@ -161,8 +161,9 @@ dependencies {
 
     testImplementation (libs.mockito.inline)
     testImplementation (libs.mockito.android)
-    testImplementation ("org.mockito:mockito-core:3.12.4")
-    testImplementation ("org.mockito.kotlin:mockito-kotlin:3.2.0")
+    //noinspection GradleDependency
+    testImplementation (libs.mockito.core)
+    testImplementation (libs.mockito.kotlin)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation (libs.ui.test.junit4)
     androidTestImplementation (libs.mockito.mockito.kotlin)
@@ -184,10 +185,14 @@ dependencies {
     testImplementation(libs.compose.test.manifest)
 
     // Mockito
-    testImplementation("org.mockito:mockito-core:3.12.4")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
-    androidTestImplementation("org.mockito:mockito-android:3.12.4")
-    androidTestImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
+    //noinspection GradleDependency
+    testImplementation(libs.mockito.mockito.core.v3124)
+    //noinspection GradleDependency
+    testImplementation(libs.kotlin.mockito.kotlin.v320)
+    //noinspection GradleDependency
+    androidTestImplementation(libs.mockito.android.v3124)
+    //noinspection GradleDependency
+    androidTestImplementation(libs.mockito.kotlin)
 
     // Robolectric (for unit tests that require Android framework)
     testImplementation(libs.robolectric)

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -348,4 +348,19 @@ class SideBarNavigationTest {
       assertEquals(destination, selectedDestination)
     }
   }
+
+  @Test
+  fun navigationItemDrawer_displaysLabel() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
+      composeTestRule
+          .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route)
+          .assertTextEquals(tab.textId)
+    }
+  }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -176,15 +176,16 @@ class SideBarNavigationTest {
       assertEquals(tab.route, selectedItem)
     }
   }
+
   @Test
-  fun sideBarNavigation_drawerStaysClosedWhenEmptyTabList() {
+  fun sideBarNavigation_drawerOpensWhenListEmpty() {
     composeTestRule.setContent {
       SideBarNavigation(onIconSelect = {}, tabList = emptyList(), selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsDisplayed()
   }
 
   @Test
@@ -196,8 +197,9 @@ class SideBarNavigationTest {
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
 
     LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
-      composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route)
-        .assert(hasContentDescription(tab.textId))
+      composeTestRule
+          .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route)
+          .assert(hasContentDescription(tab.textId))
     }
   }
 
@@ -205,7 +207,8 @@ class SideBarNavigationTest {
   fun sideBarNavigation_multipleClicksOnSameTabKeepDrawerClosed() {
     val selectedItem = LIST_TOP_LEVEL_DESTINATIONS.first().route
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
+      SideBarNavigation(
+          onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -216,5 +219,4 @@ class SideBarNavigationTest {
 
     composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
   }
-
 }

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -108,4 +108,72 @@ class SideBarNavigationTest {
   private fun SemanticsNodeInteraction.assertIsSelected() {
     assert(SemanticsMatcher.expectValue(IsSelectedKey, true))
   }
+
+  @Test
+  fun sidebarNavigation_withSelectedItem() {
+    val selectedItem = Route.OVERVIEW
+    val onIconSelect: (TopLevelDestination) -> Unit = {}
+
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect, LIST_TOP_LEVEL_DESTINATIONS, selectedItem)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + Route.OVERVIEW).assertIsSelected()
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + Route.MAP).assertIsNotSelected()
+  }
+
+  @Test
+  fun sideBarNavigation_withEmptyTabList() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = emptyList(), selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
+      composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).assertIsNotDisplayed()
+    }
+  }
+
+  @Test
+  fun sideBarNavigation_withInvalidSelectedItem() {
+    val invalidSelectedItem = "invalid_route"
+    composeTestRule.setContent {
+      SideBarNavigation(
+          onIconSelect = {},
+          tabList = LIST_TOP_LEVEL_DESTINATIONS,
+          selectedItem = invalidSelectedItem)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+    LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
+      if (tab.route == invalidSelectedItem) {
+        // It should not be marked as selected
+        composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).assertIsNotSelected()
+      } else {
+        // Other tabs should not be affected
+        composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).assertExists()
+      }
+    }
+  }
+
+  @Test
+  fun sideBarNavigation_allTabsAreClickable() {
+    var selectedItem: String = ""
+    val onIconSelect: (TopLevelDestination) -> Unit = { selectedItem = it.route }
+    composeTestRule.setContent {
+      SideBarNavigation(
+          onIconSelect = onIconSelect,
+          tabList = LIST_TOP_LEVEL_DESTINATIONS,
+          selectedItem = selectedItem)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
+      composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).performClick()
+
+      assertEquals(tab.route, selectedItem)
+    }
+  }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -1,0 +1,111 @@
+package ch.hikemate.app.navigation
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import ch.hikemate.app.ui.navigation.*
+import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
+import ch.hikemate.app.ui.navigation.SideBarNavigation
+import ch.hikemate.app.ui.navigation.TopLevelDestination
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class SideBarNavigationTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun sideBarNavigation_displaysCorrectContent() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).assertExists()
+  }
+
+  @Test
+  fun sideBarNavigation_opensDrawerOnClick() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertExists()
+  }
+
+  @Test
+  fun sideBarNavigation_displaysAllTabs() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
+      composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).assertExists()
+    }
+  }
+
+  @Test
+  fun sideBarNavigation_selectsCorrectTab() {
+    val selectedItem = LIST_TOP_LEVEL_DESTINATIONS.first().route
+    composeTestRule.setContent {
+      SideBarNavigation(
+          onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + selectedItem).assertIsSelected()
+  }
+
+  @Test
+  fun sideBarNavigation_callsOnIconSelectWhenTabClicked() {
+    var selectedDestination: TopLevelDestination? = null
+
+    val onIconSelect: (TopLevelDestination) -> Unit = { destination ->
+      selectedDestination = destination
+    }
+
+    composeTestRule.setContent {
+      SideBarNavigation(
+          onIconSelect = onIconSelect, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + LIST_TOP_LEVEL_DESTINATIONS.first().route)
+        .performClick()
+
+    assertEquals(LIST_TOP_LEVEL_DESTINATIONS.first(), selectedDestination)
+  }
+
+  @Test
+  fun sideBarNavigation_closesDrawerWhenTabClicked() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + LIST_TOP_LEVEL_DESTINATIONS.first().route)
+        .performClick()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun sideBarNavigation_closesDrawerWhenCloseButtonClicked() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CLOSE_BUTTON).performClick()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
+  }
+
+  private fun SemanticsNodeInteraction.assertIsSelected() {
+    assert(SemanticsMatcher.expectValue(IsSelectedKey, true))
+  }
+}

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.navigation
 
-import androidx.compose.material3.DrawerValue.*
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -22,7 +21,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_displaysCorrectContent() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).assertExists()
@@ -31,7 +30,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_opensDrawerOnClick() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -41,7 +40,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_displaysAllTabs() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -56,7 +55,7 @@ class SideBarNavigationTest {
     val selectedItem = LIST_TOP_LEVEL_DESTINATIONS.first().route
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
+          onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -73,7 +72,7 @@ class SideBarNavigationTest {
 
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = onIconSelect, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+          onTabSelect = onIconSelect, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -87,7 +86,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_closesDrawerWhenTabClicked() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -101,7 +100,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_closesDrawerWhenCloseButtonClicked() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -116,21 +115,23 @@ class SideBarNavigationTest {
 
   @Test
   fun sidebarNavigation_withSelectedItem() {
-    val selectedItem = Route.OVERVIEW
+    val selectedItem = Route.PLANNED_HIKES
     val onIconSelect: (TopLevelDestination) -> Unit = {}
 
     composeTestRule.setContent {
       SideBarNavigation(onIconSelect, LIST_TOP_LEVEL_DESTINATIONS, selectedItem)
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + Route.OVERVIEW).assertIsSelected()
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + Route.PLANNED_HIKES)
+        .assertIsSelected()
     composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + Route.MAP).assertIsNotSelected()
   }
 
   @Test
   fun sideBarNavigation_withEmptyTabList() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = emptyList(), selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = emptyList(), selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -145,7 +146,7 @@ class SideBarNavigationTest {
     val invalidSelectedItem = "invalid_route"
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = {},
+          onTabSelect = {},
           tabList = LIST_TOP_LEVEL_DESTINATIONS,
           selectedItem = invalidSelectedItem)
     }
@@ -168,7 +169,7 @@ class SideBarNavigationTest {
     val onIconSelect: (TopLevelDestination) -> Unit = { selectedItem = it.route }
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = onIconSelect,
+          onTabSelect = onIconSelect,
           tabList = LIST_TOP_LEVEL_DESTINATIONS,
           selectedItem = selectedItem)
     }
@@ -185,7 +186,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_drawerOpensWhenListEmpty() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = emptyList(), selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = emptyList(), selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -196,7 +197,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_correctIconDisplayedForEachTab() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -213,7 +214,7 @@ class SideBarNavigationTest {
     val selectedItem = LIST_TOP_LEVEL_DESTINATIONS.first().route
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
+          onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -228,7 +229,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_accessibilityTest() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule
@@ -249,7 +250,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_drawerGesturesDisabled() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
@@ -262,7 +263,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_drawerWidth() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -276,7 +277,7 @@ class SideBarNavigationTest {
 
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = { selectedTab = it.route },
+          onTabSelect = { selectedTab = it.route },
           tabList = LIST_TOP_LEVEL_DESTINATIONS,
           selectedItem = selectedTab)
     }
@@ -293,7 +294,7 @@ class SideBarNavigationTest {
   @Test
   fun sideBarNavigation_emptyTabList() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = emptyList(), selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = emptyList(), selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -306,7 +307,7 @@ class SideBarNavigationTest {
     val singleItem = LIST_TOP_LEVEL_DESTINATIONS.first()
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = {}, tabList = listOf(singleItem), selectedItem = singleItem.route)
+          onTabSelect = {}, tabList = listOf(singleItem), selectedItem = singleItem.route)
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -321,7 +322,7 @@ class SideBarNavigationTest {
     val nonExistentRoute = "non_existent_route"
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = nonExistentRoute)
+          onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = nonExistentRoute)
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -336,7 +337,7 @@ class SideBarNavigationTest {
 
     composeTestRule.setContent {
       SideBarNavigation(
-          onIconSelect = { selectedDestination = it },
+          onTabSelect = { selectedDestination = it },
           tabList = LIST_TOP_LEVEL_DESTINATIONS,
           selectedItem = "")
     }
@@ -352,7 +353,7 @@ class SideBarNavigationTest {
   @Test
   fun navigationItemDrawer_displaysLabel() {
     composeTestRule.setContent {
-      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+      SideBarNavigation(onTabSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -176,4 +176,45 @@ class SideBarNavigationTest {
       assertEquals(tab.route, selectedItem)
     }
   }
+  @Test
+  fun sideBarNavigation_drawerStaysClosedWhenEmptyTabList() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = emptyList(), selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun sideBarNavigation_correctIconDisplayedForEachTab() {
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = "")
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    LIST_TOP_LEVEL_DESTINATIONS.forEach { tab ->
+      composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route)
+        .assert(hasContentDescription(tab.textId))
+    }
+  }
+
+  @Test
+  fun sideBarNavigation_multipleClicksOnSameTabKeepDrawerClosed() {
+    val selectedItem = LIST_TOP_LEVEL_DESTINATIONS.first().route
+    composeTestRule.setContent {
+      SideBarNavigation(onIconSelect = {}, tabList = LIST_TOP_LEVEL_DESTINATIONS, selectedItem = selectedItem)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
+
+    val firstTabTag = TEST_TAG_DRAWER_ITEM_PREFIX + selectedItem
+    composeTestRule.onNodeWithTag(firstTabTag).performClick()
+    composeTestRule.onNodeWithTag(firstTabTag).performClick()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_CONTENT).assertIsNotDisplayed()
+  }
+
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -9,79 +9,77 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
 object Route {
-    const val OVERVIEW = "Overview"
-    const val MAP = "Map"
-    const val AUTH = "Auth"
-    const val PROFILE = "Profile"
+  const val OVERVIEW = "Overview"
+  const val MAP = "Map"
+  const val AUTH = "Auth"
+  const val PROFILE = "Profile"
 }
 
 object Screen {
-    const val AUTH = "Auth Screen"
-    const val OVERVIEW = "Overview Screen"
-    const val MAP = "Map Screen"
-    const val PROFILE = "Profile Screen"
-    const val EDIT_PROFILE = "Edit-profile Screen"
+  const val AUTH = "Auth Screen"
+  const val OVERVIEW = "Overview Screen"
+  const val MAP = "Map Screen"
+  const val PROFILE = "Profile Screen"
+  const val EDIT_PROFILE = "Edit-profile Screen"
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
 
 object TopLevelDestinations {
-    val OVERVIEW=TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
-    val MAP=TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
-    val PROFILE=TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
+  val OVERVIEW = TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
+  val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
+  val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
 }
-val topLevelDestinations = listOf(
-    TopLevelDestinations.OVERVIEW,
-    TopLevelDestinations.MAP,
-    TopLevelDestinations.PROFILE
-)
+
+val LIST_TOP_LEVEL_DESTINATIONS =
+    listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
 
 open class NavigationActions(
     private val navController: NavHostController,
 ) {
-    /**
-     * Navigate to the specified [TopLevelDestination]
-     *
-     * @param destination The top level destination to navigate to Clear the back stack when
-     *   navigating to a new destination This is useful when navigating to a new screen from the
-     *   bottom navigation bar as we don't want to keep the previous screen in the back stack
-     */
-    open fun navigateTo(destination: TopLevelDestination) {
+  /**
+   * Navigate to the specified [TopLevelDestination]
+   *
+   * @param destination The top level destination to navigate to Clear the back stack when
+   *   navigating to a new destination This is useful when navigating to a new screen from the
+   *   bottom navigation bar as we don't want to keep the previous screen in the back stack
+   */
+  open fun navigateTo(destination: TopLevelDestination) {
 
-        navController.navigate(destination.route) {
-            popUpTo(navController.graph.findStartDestination().id) {
-                saveState = true
-                inclusive = true
-            }
+    navController.navigate(destination.route) {
+      popUpTo(navController.graph.findStartDestination().id) {
+        saveState = true
+        inclusive = true
+      }
 
-            launchSingleTop = true
+      launchSingleTop = true
 
-            if (destination.route != Route.AUTH) {
-                restoreState = true
-            }
-        }
+      if (destination.route != Route.AUTH) {
+        restoreState = true
+      }
     }
+  }
 
-    /**
-     * Navigate to the specified screen.
-     *
-     * @param screen The screen to navigate to
-     */
-    open fun navigateTo(screen: String) {
-        navController.navigate(screen)
-    }
+  /**
+   * Navigate to the specified screen.
+   *
+   * @param screen The screen to navigate to
+   */
+  open fun navigateTo(screen: String) {
+    navController.navigate(screen)
+  }
 
-    /** Navigate back to the previous screen. */
-    open fun goBack() {
-        navController.popBackStack()
-    }
+  /** Navigate back to the previous screen. */
+  open fun goBack() {
+    navController.popBackStack()
+  }
 
-    /**
-     * Get the current route of the navigation controller.
-     *
-     * @return The current route
-     */
-    open fun currentRoute(): String {
-        return navController.currentDestination?.route ?: ""
-    }
+  /**
+   * Get the current route of the navigation controller.
+   *
+   * @return The current route
+   */
+  open fun currentRoute(): String {
+    return navController.currentDestination?.route ?: ""
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -8,6 +8,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
+/**
+ * Object containing route constants.
+ */
 object Route {
   const val OVERVIEW = "Overview"
   const val MAP = "Map"
@@ -15,6 +18,9 @@ object Route {
   const val PROFILE = "Profile"
 }
 
+/**
+ * Object containing screen constants.
+ */
 object Screen {
   const val AUTH = "Auth Screen"
   const val OVERVIEW = "Overview Screen"
@@ -23,37 +29,55 @@ object Screen {
   const val EDIT_PROFILE = "Edit-profile Screen"
 }
 
+/**
+ * Data class representing a top-level destination.
+ *
+ * @property route The route of the destination.
+ * @property icon The icon associated with the destination.
+ * @property textId The text identifier for the destination.
+ */
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
 
+/**
+ * Object containing top-level destinations.
+ */
 object TopLevelDestinations {
   val OVERVIEW = TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
   val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
   val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
 }
 
+/**
+ * List of top-level destinations.
+ */
 val LIST_TOP_LEVEL_DESTINATIONS =
-    listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
+  listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
 
+/**
+ * Class containing navigation actions.
+ *
+ * @property navController The navigation controller used to manage app navigation.
+ */
 open class NavigationActions(
-    private val navController: NavHostController,
+  private val navController: NavHostController,
 ) {
   /**
-   * Navigate to the specified [TopLevelDestination]
+   * Navigate to the specified [TopLevelDestination].
    *
-   * @param destination The top level destination to navigate to Clear the back stack when
-   *   navigating to a new destination This is useful when navigating to a new screen from the
-   *   bottom navigation bar as we don't want to keep the previous screen in the back stack
+   * @param destination The top-level destination to navigate to.
+   * Clears the back stack when navigating to a new destination.
+   * This is useful when navigating to a new screen from the bottom navigation bar
+   * as we don't want to keep the previous screen in the back stack.
    */
   open fun navigateTo(destination: TopLevelDestination) {
-
     navController.navigate(destination.route) {
+      // Clear the back stack up to the start destination
       popUpTo(navController.graph.findStartDestination().id) {
         saveState = true
         inclusive = true
       }
-
       launchSingleTop = true
-
+      // Restore state if not navigating to the Auth route
       if (destination.route != Route.AUTH) {
         restoreState = true
       }
@@ -63,7 +87,7 @@ open class NavigationActions(
   /**
    * Navigate to the specified screen.
    *
-   * @param screen The screen to navigate to
+   * @param screen The screen to navigate to.
    */
   open fun navigateTo(screen: String) {
     navController.navigate(screen)
@@ -77,7 +101,7 @@ open class NavigationActions(
   /**
    * Get the current route of the navigation controller.
    *
-   * @return The current route
+   * @return The current route.
    */
   open fun currentRoute(): String {
     return navController.currentDestination?.route ?: ""

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -39,7 +39,6 @@ object TopLevelDestinations {
   val OVERVIEW = TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
   val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
   val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
-  val AUTH = TopLevelDestination(Route.AUTH, Icons.Outlined.Menu, "Auth")
 }
 
 /** List of top-level destinations. */

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -1,0 +1,87 @@
+package ch.hikemate.app.ui.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Place
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+
+object Route {
+    const val OVERVIEW = "Overview"
+    const val MAP = "Map"
+    const val AUTH = "Auth"
+    const val PROFILE = "Profile"
+}
+
+object Screen {
+    const val AUTH = "Auth Screen"
+    const val OVERVIEW = "Overview Screen"
+    const val MAP = "Map Screen"
+    const val PROFILE = "Profile Screen"
+    const val EDIT_PROFILE = "Edit-profile Screen"
+}
+
+data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
+
+object TopLevelDestinations {
+    val OVERVIEW=TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
+    val MAP=TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
+    val PROFILE=TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
+}
+val topLevelDestinations = listOf(
+    TopLevelDestinations.OVERVIEW,
+    TopLevelDestinations.MAP,
+    TopLevelDestinations.PROFILE
+)
+
+open class NavigationActions(
+    private val navController: NavHostController,
+) {
+    /**
+     * Navigate to the specified [TopLevelDestination]
+     *
+     * @param destination The top level destination to navigate to Clear the back stack when
+     *   navigating to a new destination This is useful when navigating to a new screen from the
+     *   bottom navigation bar as we don't want to keep the previous screen in the back stack
+     */
+    open fun navigateTo(destination: TopLevelDestination) {
+
+        navController.navigate(destination.route) {
+            popUpTo(navController.graph.findStartDestination().id) {
+                saveState = true
+                inclusive = true
+            }
+
+            launchSingleTop = true
+
+            if (destination.route != Route.AUTH) {
+                restoreState = true
+            }
+        }
+    }
+
+    /**
+     * Navigate to the specified screen.
+     *
+     * @param screen The screen to navigate to
+     */
+    open fun navigateTo(screen: String) {
+        navController.navigate(screen)
+    }
+
+    /** Navigate back to the previous screen. */
+    open fun goBack() {
+        navController.popBackStack()
+    }
+
+    /**
+     * Get the current route of the navigation controller.
+     *
+     * @return The current route
+     */
+    open fun currentRoute(): String {
+        return navController.currentDestination?.route ?: ""
+    }
+}

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -39,6 +39,7 @@ object TopLevelDestinations {
   val PLANNED_HIKES = TopLevelDestination(Route.PLANNED_HIKES, Icons.Outlined.Menu, "Planned Hikes")
   val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
   val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
+  val AUTH = TopLevelDestination(Route.AUTH, Icons.Outlined.Person, "Auth")
 }
 
 /** List of top-level destinations. */

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -8,9 +8,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
-/**
- * Object containing route constants.
- */
+/** Object containing route constants. */
 object Route {
   const val OVERVIEW = "Overview"
   const val MAP = "Map"
@@ -18,9 +16,7 @@ object Route {
   const val PROFILE = "Profile"
 }
 
-/**
- * Object containing screen constants.
- */
+/** Object containing screen constants. */
 object Screen {
   const val AUTH = "Auth Screen"
   const val OVERVIEW = "Overview Screen"
@@ -38,20 +34,16 @@ object Screen {
  */
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
 
-/**
- * Object containing top-level destinations.
- */
+/** Object containing top-level destinations. */
 object TopLevelDestinations {
   val OVERVIEW = TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
   val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
   val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
 }
 
-/**
- * List of top-level destinations.
- */
+/** List of top-level destinations. */
 val LIST_TOP_LEVEL_DESTINATIONS =
-  listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
+    listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
 
 /**
  * Class containing navigation actions.
@@ -59,15 +51,14 @@ val LIST_TOP_LEVEL_DESTINATIONS =
  * @property navController The navigation controller used to manage app navigation.
  */
 open class NavigationActions(
-  private val navController: NavHostController,
+    private val navController: NavHostController,
 ) {
   /**
    * Navigate to the specified [TopLevelDestination].
    *
-   * @param destination The top-level destination to navigate to.
-   * Clears the back stack when navigating to a new destination.
-   * This is useful when navigating to a new screen from the bottom navigation bar
-   * as we don't want to keep the previous screen in the back stack.
+   * @param destination The top-level destination to navigate to. Clears the back stack when
+   *   navigating to a new destination. This is useful when navigating to a new screen from the
+   *   bottom navigation bar as we don't want to keep the previous screen in the back stack.
    */
   open fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavHostController
 
 /** Object containing route constants. */
 object Route {
-  const val OVERVIEW = "Overview"
+  const val PLANNED_HIKES = "PlannedHikes"
   const val MAP = "Map"
   const val AUTH = "Auth"
   const val PROFILE = "Profile"
@@ -19,7 +19,7 @@ object Route {
 /** Object containing screen constants. */
 object Screen {
   const val AUTH = "Auth Screen"
-  const val OVERVIEW = "Overview Screen"
+  const val PLANNED_HIKES = "PlannedHikes Screen"
   const val MAP = "Map Screen"
   const val PROFILE = "Profile Screen"
   const val EDIT_PROFILE = "Edit-profile Screen"
@@ -36,14 +36,15 @@ data class TopLevelDestination(val route: String, val icon: ImageVector, val tex
 
 /** Object containing top-level destinations. */
 object TopLevelDestinations {
-  val OVERVIEW = TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
+  val PLANNED_HIKES = TopLevelDestination(Route.PLANNED_HIKES, Icons.Outlined.Menu, "Planned Hikes")
   val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
   val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
 }
 
 /** List of top-level destinations. */
 val LIST_TOP_LEVEL_DESTINATIONS =
-    listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
+    listOf(
+        TopLevelDestinations.PLANNED_HIKES, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
 
 /**
  * Class containing navigation actions.

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -39,6 +39,7 @@ object TopLevelDestinations {
   val OVERVIEW = TopLevelDestination(Route.OVERVIEW, Icons.Outlined.Menu, "Overview")
   val MAP = TopLevelDestination(Route.MAP, Icons.Outlined.Place, "Map")
   val PROFILE = TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
+  val AUTH = TopLevelDestination(Route.AUTH, Icons.Outlined.Menu, "Auth")
 }
 
 /** List of top-level destinations. */

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.ui.navigation
 
-import android.graphics.drawable.Icon
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -1,0 +1,81 @@
+package ch.hikemate.app.ui.navigation
+
+import android.graphics.drawable.Icon
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ch.hikemate.app.ui.theme.SampleAppTheme
+import kotlinx.coroutines.launch
+
+const val TAG = "HikeMate"
+
+@Composable
+fun SideBarNavigation(
+    onIconSelect: (TopLevelDestination) -> Unit,
+    tabList: List<TopLevelDestination>,
+    selectedItem: String
+) {
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    SampleAppTheme {
+        ModalNavigationDrawer(
+            gesturesEnabled = false,
+            drawerState = drawerState,
+            drawerContent = {
+                ModalDrawerSheet(modifier = Modifier.width(180.dp)) {
+                    Row {
+                        Button(onClick = { scope.launch { drawerState.close() } }) { Icons.Filled.Menu }
+                        Text(TAG, modifier = Modifier.padding(16.dp))
+                    }
+                    HorizontalDivider()
+                    tabList.forEach { tab ->
+                        NavigationDrawerItem(
+                            label = { Text(text = tab.textId) },
+                            selected = tab.route == selectedItem,
+                            onClick = { onIconSelect(tab) }
+                        )
+
+                    }
+                }
+            },
+            content = {
+                    IconButton(onClick = {
+                        scope.launch {
+                            drawerState.open()
+                        }
+                    },
+                        content = {
+                                Icon(
+                                    Icons.Filled.Menu,
+                                    contentDescription = "SideBar",
+                                )
+                        }
+                    )
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SideBarNavigationPreview() {
+    SideBarNavigation(onIconSelect = {}, tabList = topLevelDestinations, selectedItem = "")
+}

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -19,10 +19,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import ch.hikemate.app.ui.theme.SampleAppTheme
 import kotlinx.coroutines.launch
 
-const val TAG = "HikeMate"
+const val APP_NAME = "HikeMate"
 const val TEST_TAG_SIDEBAR_BUTTON = "TEST_TAG_SIDEBAR_BUTTON"
 const val TEST_TAG_DRAWER_CONTENT = "TEST_TAG_DRAWER_CONTENT"
 const val TEST_TAG_DRAWER_CLOSE_BUTTON = "TEST_TAG_DRAWER_CLOSE_BUTTON"
@@ -33,66 +32,68 @@ val IsSelectedKey = SemanticsPropertyKey<Boolean>("IsSelected")
 /**
  * Composable function for the sidebar navigation.
  *
- * @param onIconSelect Callback function when an icon is selected.
+ * @param onTabSelect Callback function when an icon is selected.
  * @param tabList List of top-level destinations.
  * @param selectedItem The currently selected item.
  */
 @Composable
 fun SideBarNavigation(
-    onIconSelect: (TopLevelDestination) -> Unit,
+    onTabSelect: (TopLevelDestination) -> Unit,
     tabList: List<TopLevelDestination>,
-    selectedItem: String
+    selectedItem: String,
 ) {
   val drawerState = rememberDrawerState(DrawerValue.Closed)
   val scope = rememberCoroutineScope()
-  SampleAppTheme {
-    ModalNavigationDrawer(
-        gesturesEnabled = false,
-        drawerState = drawerState,
-        drawerContent = {
-          ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
-            Row {
-              Button(
-                  onClick = { scope.launch { drawerState.close() } },
-                  modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
-                    Icon(Icons.Filled.Close, contentDescription = "Close")
-                  }
-              Text(TAG, modifier = Modifier.padding(16.dp))
+  ModalNavigationDrawer(
+      gesturesEnabled = false,
+      drawerState = drawerState,
+      drawerContent = {
+        ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
+          Row {
+            Button(
+                onClick = { scope.launch { drawerState.close() } },
+                modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON),
+            ) {
+              Icon(Icons.Filled.Close, contentDescription = "Close")
             }
-            HorizontalDivider()
-            tabList.forEach { tab ->
-              val isSelected = tab.route == selectedItem
-              NavigationDrawerItem(
-                  label = { Text(text = tab.textId) },
-                  selected = isSelected,
-                  onClick = {
-                    onIconSelect(tab)
-                    scope.launch { drawerState.close() }
-                  },
-                  icon = {
-                    Icon(
-                        tab.icon,
-                        contentDescription = tab.textId,
-                        modifier =
-                            Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route + "Icon"))
-                  },
-                  modifier =
-                      Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
-                        set(IsSelectedKey, isSelected)
-                      })
-            }
+            Text(APP_NAME, modifier = Modifier.padding(16.dp))
           }
-        },
-        content = {
-          Button(
-              onClick = { scope.launch { drawerState.open() } },
-              modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
-              content = {
-                Icon(
-                    Icons.Filled.Menu,
-                    contentDescription = "SideBar",
-                )
-              })
-        })
-  }
+          HorizontalDivider()
+          tabList.forEach { tab ->
+            val isSelected = tab.route == selectedItem
+            NavigationDrawerItem(
+                label = { Text(text = tab.textId) },
+                selected = isSelected,
+                onClick = {
+                  onTabSelect(tab)
+                  scope.launch { drawerState.close() }
+                },
+                icon = {
+                  Icon(
+                      tab.icon,
+                      contentDescription = tab.textId,
+                      modifier = Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route + "Icon"),
+                  )
+                },
+                modifier =
+                    Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
+                      set(IsSelectedKey, isSelected)
+                    },
+            )
+          }
+        }
+      },
+      content = {
+        Button(
+            onClick = { scope.launch { drawerState.open() } },
+            modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
+            content = {
+              Icon(
+                  Icons.Filled.Menu,
+                  contentDescription = "SideBar",
+              )
+            },
+        )
+      },
+  )
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -93,11 +93,3 @@ fun SideBarNavigation(
   }
 }
 
-@Preview
-@Composable
-fun SideBarNavigationPreview() {
-  val tabList =
-      listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
-  var selectedItem by remember { mutableStateOf(TopLevelDestinations.OVERVIEW.route) }
-  SideBarNavigation(onIconSelect = {}, tabList = tabList, selectedItem = selectedItem)
-}

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.hikemate.app.ui.theme.SampleAppTheme
 import kotlinx.coroutines.launch
@@ -92,4 +91,3 @@ fun SideBarNavigation(
         })
   }
 }
-

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -3,12 +3,12 @@ package ch.hikemate.app.ui.navigation
 import android.graphics.drawable.Icon
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Button
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.hikemate.app.ui.theme.SampleAppTheme
 import kotlinx.coroutines.launch
@@ -56,7 +57,7 @@ fun SideBarNavigation(
               Button(
                   onClick = { scope.launch { drawerState.close() } },
                   modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
-                    Icon(Icons.Filled.Menu, contentDescription = "Close")
+                    Icon(Icons.Filled.Close, contentDescription = "Close")
                   }
               Text(TAG, modifier = Modifier.padding(16.dp))
             }
@@ -79,7 +80,7 @@ fun SideBarNavigation(
           }
         },
         content = {
-          IconButton(
+          Button(
               onClick = { scope.launch { drawerState.open() } },
               modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
               content = {
@@ -90,4 +91,13 @@ fun SideBarNavigation(
               })
         })
   }
+}
+
+@Preview
+@Composable
+fun SideBarNavigationPreview() {
+  val tabList =
+      listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP, TopLevelDestinations.PROFILE)
+  var selectedItem by remember { mutableStateOf(TopLevelDestinations.OVERVIEW.route) }
+  SideBarNavigation(onIconSelect = {}, tabList = tabList, selectedItem = selectedItem)
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -50,25 +50,29 @@ fun SideBarNavigation(
                         NavigationDrawerItem(
                             label = { Text(text = tab.textId) },
                             selected = tab.route == selectedItem,
-                            onClick = { onIconSelect(tab) }
+                            onClick = {
+                                onIconSelect(tab)
+                                scope.launch { drawerState.close() }
+                            },
+                            icon = { Icon(tab.icon, contentDescription = tab.textId) }
                         )
 
                     }
                 }
             },
             content = {
-                    IconButton(onClick = {
-                        scope.launch {
-                            drawerState.open()
-                        }
-                    },
-                        content = {
-                                Icon(
-                                    Icons.Filled.Menu,
-                                    contentDescription = "SideBar",
-                                )
-                        }
-                    )
+                IconButton(onClick = {
+                    scope.launch {
+                        drawerState.open()
+                    }
+                },
+                    content = {
+                        Icon(
+                            Icons.Filled.Menu,
+                            contentDescription = "SideBar",
+                        )
+                    }
+                )
             }
         )
     }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -1,16 +1,11 @@
 package ch.hikemate.app.ui.navigation
 
 import android.graphics.drawable.Icon
-import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.rememberDrawerState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Button
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -18,14 +13,26 @@ import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.hikemate.app.ui.theme.SampleAppTheme
 import kotlinx.coroutines.launch
 
 const val TAG = "HikeMate"
+const val TEST_TAG_SIDEBAR_BUTTON = "TEST_TAG_SIDEBAR_BUTTON"
+const val TEST_TAG_DRAWER_CONTENT = "TEST_TAG_DRAWER_CONTENT"
+const val TEST_TAG_DRAWER_CLOSE_BUTTON = "TEST_TAG_DRAWER_CLOSE_BUTTON"
+const val TEST_TAG_DRAWER_ITEM_PREFIX = "TEST_TAG_DRAWER_ITEM_"
+
+val IsSelectedKey = SemanticsPropertyKey<Boolean>("IsSelected")
 
 @Composable
 fun SideBarNavigation(
@@ -33,53 +40,51 @@ fun SideBarNavigation(
     tabList: List<TopLevelDestination>,
     selectedItem: String
 ) {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val scope = rememberCoroutineScope()
-    SampleAppTheme {
-        ModalNavigationDrawer(
-            gesturesEnabled = false,
-            drawerState = drawerState,
-            drawerContent = {
-                ModalDrawerSheet(modifier = Modifier.width(180.dp)) {
-                    Row {
-                        Button(onClick = { scope.launch { drawerState.close() } }) { Icons.Filled.Menu }
-                        Text(TAG, modifier = Modifier.padding(16.dp))
-                    }
-                    HorizontalDivider()
-                    tabList.forEach { tab ->
-                        NavigationDrawerItem(
-                            label = { Text(text = tab.textId) },
-                            selected = tab.route == selectedItem,
-                            onClick = {
-                                onIconSelect(tab)
-                                scope.launch { drawerState.close() }
-                            },
-                            icon = { Icon(tab.icon, contentDescription = tab.textId) }
-                        )
-
-                    }
-                }
-            },
-            content = {
-                IconButton(onClick = {
-                    scope.launch {
-                        drawerState.open()
-                    }
-                },
-                    content = {
-                        Icon(
-                            Icons.Filled.Menu,
-                            contentDescription = "SideBar",
-                        )
-                    }
-                )
+  val drawerState = rememberDrawerState(DrawerValue.Closed)
+  val scope = rememberCoroutineScope()
+  SampleAppTheme {
+    ModalNavigationDrawer(
+        gesturesEnabled = false,
+        drawerState = drawerState,
+        drawerContent = {
+          ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
+            Row {
+              Button(
+                  onClick = { scope.launch { drawerState.close() } },
+                  modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
+                    Icon(Icons.Filled.Menu, contentDescription = "Close")
+                  }
+              Text(TAG, modifier = Modifier.padding(16.dp))
             }
-        )
-    }
+            HorizontalDivider()
+            tabList.forEach { tab ->
+              val isSelected = tab.route == selectedItem
+              NavigationDrawerItem(
+                  label = { Text(text = tab.textId) },
+                  selected = isSelected,
+                  onClick = {
+                    onIconSelect(tab)
+                    scope.launch { drawerState.close() }
+                  },
+                  icon = { Icon(tab.icon, contentDescription = tab.textId) },
+                  modifier =
+                      Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
+                        set(IsSelectedKey, isSelected)
+                      })
+            }
+          }
+        },
+        content = {
+          IconButton(
+              onClick = { scope.launch { drawerState.open() } },
+              modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
+              content = {
+                Icon(
+                    Icons.Filled.Menu,
+                    contentDescription = "SideBar",
+                )
+              })
+        })
+  }
 }
 
-@Preview
-@Composable
-fun SideBarNavigationPreview() {
-    SideBarNavigation(onIconSelect = {}, tabList = topLevelDestinations, selectedItem = "")
-}

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -15,13 +15,10 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.hikemate.app.ui.theme.SampleAppTheme
 import kotlinx.coroutines.launch
@@ -34,57 +31,63 @@ const val TEST_TAG_DRAWER_ITEM_PREFIX = "TEST_TAG_DRAWER_ITEM_"
 
 val IsSelectedKey = SemanticsPropertyKey<Boolean>("IsSelected")
 
+/**
+ * Composable function for the sidebar navigation.
+ *
+ * @param onIconSelect Callback function when an icon is selected.
+ * @param tabList List of top-level destinations.
+ * @param selectedItem The currently selected item.
+ */
 @Composable
 fun SideBarNavigation(
     onIconSelect: (TopLevelDestination) -> Unit,
     tabList: List<TopLevelDestination>,
     selectedItem: String
 ) {
-  val drawerState = rememberDrawerState(DrawerValue.Closed)
-  val scope = rememberCoroutineScope()
-  SampleAppTheme {
-    ModalNavigationDrawer(
-        gesturesEnabled = false,
-        drawerState = drawerState,
-        drawerContent = {
-          ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
-            Row {
-              Button(
-                  onClick = { scope.launch { drawerState.close() } },
-                  modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
-                    Icon(Icons.Filled.Menu, contentDescription = "Close")
-                  }
-              Text(TAG, modifier = Modifier.padding(16.dp))
-            }
-            HorizontalDivider()
-            tabList.forEach { tab ->
-              val isSelected = tab.route == selectedItem
-              NavigationDrawerItem(
-                  label = { Text(text = tab.textId) },
-                  selected = isSelected,
-                  onClick = {
-                    onIconSelect(tab)
-                    scope.launch { drawerState.close() }
-                  },
-                  icon = { Icon(tab.icon, contentDescription = tab.textId) },
-                  modifier =
-                      Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
-                        set(IsSelectedKey, isSelected)
-                      })
-            }
-          }
-        },
-        content = {
-          IconButton(
-              onClick = { scope.launch { drawerState.open() } },
-              modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
-              content = {
-                Icon(
-                    Icons.Filled.Menu,
-                    contentDescription = "SideBar",
-                )
-              })
-        })
-  }
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    SampleAppTheme {
+        ModalNavigationDrawer(
+            gesturesEnabled = false,
+            drawerState = drawerState,
+            drawerContent = {
+                ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
+                    Row {
+                        Button(
+                            onClick = { scope.launch { drawerState.close() } },
+                            modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
+                            Icon(Icons.Filled.Menu, contentDescription = "Close")
+                        }
+                        Text(TAG, modifier = Modifier.padding(16.dp))
+                    }
+                    HorizontalDivider()
+                    tabList.forEach { tab ->
+                        val isSelected = tab.route == selectedItem
+                        NavigationDrawerItem(
+                            label = { Text(text = tab.textId) },
+                            selected = isSelected,
+                            onClick = {
+                                onIconSelect(tab)
+                                scope.launch { drawerState.close() }
+                            },
+                            icon = { Icon(tab.icon, contentDescription = tab.textId) },
+                            modifier =
+                            Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
+                                set(IsSelectedKey, isSelected)
+                            })
+                    }
+                }
+            },
+            content = {
+                IconButton(
+                    onClick = { scope.launch { drawerState.open() } },
+                    modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
+                    content = {
+                        Icon(
+                            Icons.Filled.Menu,
+                            contentDescription = "SideBar",
+                        )
+                    })
+            })
+    }
 }
-

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -44,50 +44,50 @@ fun SideBarNavigation(
     tabList: List<TopLevelDestination>,
     selectedItem: String
 ) {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val scope = rememberCoroutineScope()
-    SampleAppTheme {
-        ModalNavigationDrawer(
-            gesturesEnabled = false,
-            drawerState = drawerState,
-            drawerContent = {
-                ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
-                    Row {
-                        Button(
-                            onClick = { scope.launch { drawerState.close() } },
-                            modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
-                            Icon(Icons.Filled.Menu, contentDescription = "Close")
-                        }
-                        Text(TAG, modifier = Modifier.padding(16.dp))
-                    }
-                    HorizontalDivider()
-                    tabList.forEach { tab ->
-                        val isSelected = tab.route == selectedItem
-                        NavigationDrawerItem(
-                            label = { Text(text = tab.textId) },
-                            selected = isSelected,
-                            onClick = {
-                                onIconSelect(tab)
-                                scope.launch { drawerState.close() }
-                            },
-                            icon = { Icon(tab.icon, contentDescription = tab.textId) },
-                            modifier =
-                            Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
-                                set(IsSelectedKey, isSelected)
-                            })
-                    }
-                }
-            },
-            content = {
-                IconButton(
-                    onClick = { scope.launch { drawerState.open() } },
-                    modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
-                    content = {
-                        Icon(
-                            Icons.Filled.Menu,
-                            contentDescription = "SideBar",
-                        )
-                    })
-            })
-    }
+  val drawerState = rememberDrawerState(DrawerValue.Closed)
+  val scope = rememberCoroutineScope()
+  SampleAppTheme {
+    ModalNavigationDrawer(
+        gesturesEnabled = false,
+        drawerState = drawerState,
+        drawerContent = {
+          ModalDrawerSheet(modifier = Modifier.width(180.dp).testTag(TEST_TAG_DRAWER_CONTENT)) {
+            Row {
+              Button(
+                  onClick = { scope.launch { drawerState.close() } },
+                  modifier = Modifier.testTag(TEST_TAG_DRAWER_CLOSE_BUTTON)) {
+                    Icon(Icons.Filled.Menu, contentDescription = "Close")
+                  }
+              Text(TAG, modifier = Modifier.padding(16.dp))
+            }
+            HorizontalDivider()
+            tabList.forEach { tab ->
+              val isSelected = tab.route == selectedItem
+              NavigationDrawerItem(
+                  label = { Text(text = tab.textId) },
+                  selected = isSelected,
+                  onClick = {
+                    onIconSelect(tab)
+                    scope.launch { drawerState.close() }
+                  },
+                  icon = { Icon(tab.icon, contentDescription = tab.textId) },
+                  modifier =
+                      Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
+                        set(IsSelectedKey, isSelected)
+                      })
+            }
+          }
+        },
+        content = {
+          IconButton(
+              onClick = { scope.launch { drawerState.open() } },
+              modifier = Modifier.testTag(TEST_TAG_SIDEBAR_BUTTON),
+              content = {
+                Icon(
+                    Icons.Filled.Menu,
+                    contentDescription = "SideBar",
+                )
+              })
+        })
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -70,7 +70,13 @@ fun SideBarNavigation(
                     onIconSelect(tab)
                     scope.launch { drawerState.close() }
                   },
-                  icon = { Icon(tab.icon, contentDescription = tab.textId) },
+                  icon = {
+                    Icon(
+                        tab.icon,
+                        contentDescription = tab.textId,
+                        modifier =
+                            Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route + "Icon"))
+                  },
                   modifier =
                       Modifier.testTag(TEST_TAG_DRAWER_ITEM_PREFIX + tab.route).semantics {
                         set(IsSelectedKey, isSelected)

--- a/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
@@ -1,6 +1,8 @@
 package ch.hikemate.app.navigation
 
 import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
@@ -10,6 +12,7 @@ import androidx.navigation.testing.TestNavHostController
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
+import ch.hikemate.app.ui.navigation.TopLevelDestination
 import ch.hikemate.app.ui.navigation.TopLevelDestinations
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
@@ -97,7 +100,7 @@ class NavigationActionsTest {
 
   @Test
   fun navigateToAuth_respectsProperties() {
-    navigationActions.navigateTo(TopLevelDestinations.AUTH)
+    navigationActions.navigateTo(TopLevelDestination(Route.AUTH, Icons.Default.AccountBox, "Auth"))
 
     navHostController.navigate(currentRoute_isEmptyWhenNoRoute())
     verify(navHostController).navigate(eq(Route.AUTH), navOptionsCaptor.capture())

--- a/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.navigation
 
-
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
@@ -12,44 +11,45 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 
 class NavigationActionsTest {
 
-    private lateinit var navigationDestination: NavDestination
-    private lateinit var navHostController: NavHostController
-    private lateinit var navigationActions: NavigationActions
+  private lateinit var navigationDestination: NavDestination
+  private lateinit var navHostController: NavHostController
+  private lateinit var navigationActions: NavigationActions
 
-    @Before
-    fun setUp() {
-        navigationDestination = mock(NavDestination::class.java)
-        navHostController = mock(NavHostController::class.java)
-        navigationActions = NavigationActions(navHostController)
-    }
+  @Before
+  fun setUp() {
+    navigationDestination = mock(NavDestination::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
+  }
 
-    @Test
-    fun navigateToCallsController() {
-        navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
-        verify(navHostController).navigate(eq(Route.OVERVIEW), any<NavOptionsBuilder.() -> Unit>())
-        navigationActions.navigateTo(Screen.MAP)
-        verify(navHostController).navigate(Screen.MAP)
-    }
+  @Test
+  fun navigateToCallsController() {
+    navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+    verify(navHostController)
+        .navigate(eq(Route.OVERVIEW), org.mockito.kotlin.any<NavOptionsBuilder.() -> Unit>())
+    navigationActions.navigateTo(Screen.MAP)
+    verify(navHostController).navigate(Screen.MAP)
+  }
 
-    @Test
-    fun goBackCallsController() {
-        navigationActions.goBack()
-        verify(navHostController).popBackStack()
-    }
+  @Test
+  fun goBackCallsController() {
+    navigationActions.goBack()
+    verify(navHostController).popBackStack()
+  }
 
-    @Test
-    fun currentRouteWorksWithDestination() {
-        `when`(navHostController.currentDestination).thenReturn(navigationDestination)
-        `when`(navigationDestination.route).thenReturn(Route.OVERVIEW)
+  @Test
+  fun currentRouteWorksWithDestination() {
+    `when`(navHostController.currentDestination).thenReturn(navigationDestination)
+    `when`(navigationDestination.route).thenReturn(Route.OVERVIEW)
 
-        assertThat(navigationActions.currentRoute(), `is`(Route.OVERVIEW))
-    }
+    assertThat(navigationActions.currentRoute(), `is`(Route.OVERVIEW))
+  }
 }

--- a/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
@@ -1,0 +1,55 @@
+package ch.hikemate.app.navigation
+
+
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
+import ch.hikemate.app.ui.navigation.NavigationActions
+import ch.hikemate.app.ui.navigation.Route
+import ch.hikemate.app.ui.navigation.Screen
+import ch.hikemate.app.ui.navigation.TopLevelDestinations
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class NavigationActionsTest {
+
+    private lateinit var navigationDestination: NavDestination
+    private lateinit var navHostController: NavHostController
+    private lateinit var navigationActions: NavigationActions
+
+    @Before
+    fun setUp() {
+        navigationDestination = mock(NavDestination::class.java)
+        navHostController = mock(NavHostController::class.java)
+        navigationActions = NavigationActions(navHostController)
+    }
+
+    @Test
+    fun navigateToCallsController() {
+        navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+        verify(navHostController).navigate(eq(Route.OVERVIEW), any<NavOptionsBuilder.() -> Unit>())
+        navigationActions.navigateTo(Screen.MAP)
+        verify(navHostController).navigate(Screen.MAP)
+    }
+
+    @Test
+    fun goBackCallsController() {
+        navigationActions.goBack()
+        verify(navHostController).popBackStack()
+    }
+
+    @Test
+    fun currentRouteWorksWithDestination() {
+        `when`(navHostController.currentDestination).thenReturn(navigationDestination)
+        `when`(navigationDestination.route).thenReturn(Route.OVERVIEW)
+
+        assertThat(navigationActions.currentRoute(), `is`(Route.OVERVIEW))
+    }
+}

--- a/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
@@ -1,8 +1,6 @@
 package ch.hikemate.app.navigation
 
 import android.content.Context
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountBox
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
@@ -12,7 +10,6 @@ import androidx.navigation.testing.TestNavHostController
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
-import ch.hikemate.app.ui.navigation.TopLevelDestination
 import ch.hikemate.app.ui.navigation.TopLevelDestinations
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
@@ -99,7 +96,7 @@ class NavigationActionsTest {
 
   @Test
   fun navigateToAuth_respectsProperties() {
-    navigationActions.navigateTo(TopLevelDestination(Route.AUTH, Icons.Default.AccountBox, "Auth"))
+    navigationActions.navigateTo(TopLevelDestinations.AUTH)
 
     navHostController.navigate(currentRoute_isEmptyWhenNoRoute())
     verify(navHostController).navigate(eq(Route.AUTH), navOptionsCaptor.capture())

--- a/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
@@ -52,4 +52,32 @@ class NavigationActionsTest {
 
     assertThat(navigationActions.currentRoute(), `is`(Route.OVERVIEW))
   }
+
+  @Test
+  fun currentRoute_isEmptyWhenNoDestination() {
+    `when`(navHostController.currentDestination).thenReturn(null)
+    assertThat(navigationActions.currentRoute(), `is`(""))
+  }
+
+  @Test
+  fun currentRoute_isEmptyWhenNoRoute() {
+    `when`(navHostController.currentDestination).thenReturn(navigationDestination)
+    `when`(navigationDestination.route).thenReturn(null)
+    assertThat(navigationActions.currentRoute(), `is`(""))
+  }
+
+  @Test
+  fun navigateToAuth_DoesNotRestoreState() {
+    navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+    verify(navHostController).navigate(eq(Route.OVERVIEW), any<NavOptionsBuilder.() -> Unit>())
+
+    navigationActions.navigateTo(TopLevelDestinations.PROFILE)
+    verify(navHostController).navigate(eq(Route.PROFILE), any<NavOptionsBuilder.() -> Unit>())
+
+    navigationActions.navigateTo(TopLevelDestinations.MAP)
+    verify(navHostController).navigate(eq(Route.MAP), any<NavOptionsBuilder.() -> Unit>())
+
+    navigationActions.navigateTo(TopLevelDestinations.AUTH)
+    verify(navHostController).navigate(eq(Route.AUTH), any<NavOptionsBuilder.() -> Unit>())
+  }
 }

--- a/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/navigation/NavigationActionsTest.kt
@@ -50,9 +50,8 @@ class NavigationActionsTest {
 
   @Test
   fun navigateToCallsController() {
-    navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
-    verify(navHostController)
-        .navigate(eq(Route.OVERVIEW), org.mockito.kotlin.any<NavOptionsBuilder.() -> Unit>())
+    navigationActions.navigateTo(TopLevelDestinations.PLANNED_HIKES)
+    verify(navHostController).navigate(eq(Route.PLANNED_HIKES), any<NavOptionsBuilder.() -> Unit>())
     navigationActions.navigateTo(Screen.MAP)
     verify(navHostController).navigate(Screen.MAP)
   }
@@ -66,9 +65,9 @@ class NavigationActionsTest {
   @Test
   fun currentRouteWorksWithDestination() {
     `when`(navHostController.currentDestination).thenReturn(navigationDestination)
-    `when`(navigationDestination.route).thenReturn(Route.OVERVIEW)
+    `when`(navigationDestination.route).thenReturn(Route.PLANNED_HIKES)
 
-    assertThat(navigationActions.currentRoute(), `is`(Route.OVERVIEW))
+    assertThat(navigationActions.currentRoute(), `is`(Route.PLANNED_HIKES))
   }
 
   @Test
@@ -86,10 +85,10 @@ class NavigationActionsTest {
 
   @Test
   fun navigateToNotAuth_respectsProperties() {
-    navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+    navigationActions.navigateTo(TopLevelDestinations.PLANNED_HIKES)
 
     navHostController.navigate(currentRoute_isEmptyWhenNoRoute())
-    verify(navHostController).navigate(eq(Route.OVERVIEW), navOptionsCaptor.capture())
+    verify(navHostController).navigate(eq(Route.PLANNED_HIKES), navOptionsCaptor.capture())
     val navOptions = navOptions(navOptionsCaptor.firstValue)
 
     assertThat(navOptions.shouldRestoreState(), `is`(true))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ firebaseDatabaseKtx = "21.0.0"
 firebaseFirestore = "25.1.0"
 firebaseUiAuth = "8.0.0"
 firebaseFirestoreKtx = "25.1.0"
+navigationRuntimeKtx = "2.8.2"
+navigationCommonKtx = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -61,6 +63,8 @@ firebase-database-ktx = { module = "com.google.firebase:firebase-database-ktx", 
 firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-ui-auth = { module = "com.firebaseui:firebase-ui-auth", version.ref = "firebaseUiAuth" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
+androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
+androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,11 @@ composeViewModel = "2.8.6"
 lifecycleRuntimeKtx = "2.8.6"
 kaspresso = "1.5.5"
 mockitoAndroid = "5.13.0"
+mockitoAndroidVersion = "4.0.0"
 mockitoCore = "5.13.0"
+mockitoCoreVersion = "4.0.0"
 mockitoInline = "4.0.0"
+mockitoKotlin = "5.4.0"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 gms = "4.4.2"
@@ -34,12 +37,16 @@ navigationCommonKtx = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 junit-v412 = { module = "junit:junit", version.ref = "junitJunit" }
+kotlin-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 
@@ -58,8 +65,12 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-android-v400 = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroidVersion" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-core-v400 = { module = "org.mockito:mockito-core", version.ref = "mockitoCoreVersion" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+mockito-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # Firebase Libraries
@@ -71,6 +82,8 @@ firebase-ui-auth = { module = "com.firebaseui:firebase-ui-auth", version.ref = "
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }
+ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,17 +41,12 @@ navigationTesting = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
-androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-junit-v412 = { module = "junit:junit", version.ref = "junitJunit" }
-kotlin-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" }
 kotlin-mockito-kotlin-v320 = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoMockitoKotlin" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 
@@ -71,9 +66,7 @@ kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspre
 
 mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
 mockito-android-v3124 = { module = "org.mockito:mockito-android", version.ref = "mockitoMockitoAndroid" }
-mockito-android-v400 = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroidVersion" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
-mockito-core-v400 = { module = "org.mockito:mockito-core", version.ref = "mockitoCoreVersion" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 mockito-mockito-core-v3124 = { module = "org.mockito:mockito-core", version.ref = "mockitoMockitoCoreVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,9 @@ mockitoCore = "5.13.0"
 mockitoCoreVersion = "4.0.0"
 mockitoInline = "4.0.0"
 mockitoKotlin = "5.4.0"
+mockitoMockitoAndroid = "3.12.4"
+mockitoMockitoCoreVersion = "3.12.4"
+mockitoMockitoKotlin = "3.2.0"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 gms = "4.4.2"
@@ -47,6 +50,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 junit-v412 = { module = "junit:junit", version.ref = "junitJunit" }
 kotlin-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" }
+kotlin-mockito-kotlin-v320 = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoMockitoKotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
@@ -66,11 +70,13 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-android-v3124 = { module = "org.mockito:mockito-android", version.ref = "mockitoMockitoAndroid" }
 mockito-android-v400 = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroidVersion" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-core-v400 = { module = "org.mockito:mockito-core", version.ref = "mockitoCoreVersion" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+mockito-mockito-core-v3124 = { module = "org.mockito:mockito-core", version.ref = "mockitoMockitoCoreVersion" }
 mockito-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,9 @@ composeActivity = "1.9.2"
 composeViewModel = "2.8.6"
 lifecycleRuntimeKtx = "2.8.6"
 kaspresso = "1.5.5"
+mockitoAndroid = "5.13.0"
+mockitoCore = "5.13.0"
+mockitoInline = "4.0.0"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 gms = "4.4.2"
@@ -54,6 +57,9 @@ compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifes
 kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # Firebase Libraries

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ firebaseUiAuth = "8.0.0"
 firebaseFirestoreKtx = "25.1.0"
 navigationRuntimeKtx = "2.8.2"
 navigationCommonKtx = "2.8.2"
+navigationTesting = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -84,6 +85,7 @@ androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navig
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
 
 
 [plugins]


### PR DESCRIPTION
# Summary

This pull request introduces the core navigation functionality for the **HikeMate** application, setting up the foundation for user flow across various screens.

### Key Changes
- **`NavigationActions.kt`**:  
  This file defines the primary navigation routes and screen names for the different sections of the app. It provides utility functions for navigating between `TopLevelDestination`s, allowing seamless transitions within the app's structure.
  
- **`SideBarNavigation.kt`**:  
  Introduces a sidebar component that serves as the main navigation UI element. This `ModalNavigationDrawer` is available on most key screens, enabling users to toggle a sidebar menu by clicking the icon in the upper left corner. The menu allows users to navigate through essential parts of the application.

### Additional Updates
- Modifications were made to `build.gradle` to include the necessary dependencies for testing, ensuring the navigation components are covered by relevant unit and UI tests.
