### PR TITLE
Feat/firebase authentication repository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,12 +52,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     packaging {
@@ -120,6 +120,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))
     implementation(libs.firebase.firestore.ktx)
+    implementation(libs.firebase.auth.ktx)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
@@ -160,6 +161,14 @@ dependencies {
     // Adds a remote binary dependency only for local tests.
     testImplementation(libs.junit)
 
+    // ----------        MockK          ------------
+    testImplementation(libs.mockk.v1133)
+    androidTestImplementation(libs.mockk.android.v1133)
+
+    // ----------       Mockito         ------------
+    androidTestImplementation(libs.mockito.android.v540)
+
+    // ----------        OkHttp          ------------
 
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,8 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            merges  += "META-INF/LICENSE.md"
+            merges += "META-INF/LICENSE-notice.md"
         }
     }
 
@@ -120,7 +122,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))
     implementation(libs.firebase.firestore.ktx)
-    implementation(libs.firebase.auth.ktx)
+    implementation(libs.androidx.espresso.intents)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)
@@ -154,31 +156,41 @@ dependencies {
 
     // ----------        FireBase       ------------
     implementation(platform(libs.firebase.bom))
-
-    // ---------- OpenStreetMap ------------
-    implementation(libs.osmdroid)
+    implementation(libs.google.firebase.auth)
+    implementation(libs.play.services.auth)
 
     // Adds a remote binary dependency only for local tests.
     testImplementation(libs.junit)
 
-    // ----------        MockK          ------------
-    testImplementation(libs.mockk.v1133)
-    androidTestImplementation(libs.mockk.android.v1133)
-
-    // ----------       Mockito         ------------
-    androidTestImplementation(libs.mockito.android.v540)
-
-    // ----------        OkHttp          ------------
-
     androidTestImplementation(libs.androidx.espresso.core)
+
+    // Mockito
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    androidTestImplementation(libs.mockito.android)
+    androidTestImplementation(libs.mockito.kotlin.v320)
+
+    // MockK
+    testImplementation(libs.mockk)
+    androidTestImplementation(libs.mockk.android.v11312)
+    androidTestImplementation(libs.mockk.agent)
+
+    // Google Sign in
+    implementation(libs.androidx.credentials.vlatestversion)
+    implementation(libs.androidx.credentials.play.services.auth.v10)
+    implementation(libs.googleid.vlatestversion)
+
+    // OSM
+    implementation(libs.osmdroid.android.v6110)
 
     // To fix an issue with Firebase and the Protobuf library
     configurations.configureEach {
         exclude(group = "com.google.protobuf", module = "protobuf-lite")
     }
+
+
+
 }
-
-
 
 tasks.withType<Test> {
     // Configure Jacoco for each tests

--- a/app/src/androidTest/java/ch/hikemate/app/authentication/FirebaseAuthRepositoryTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/authentication/FirebaseAuthRepositoryTest.kt
@@ -1,0 +1,187 @@
+import android.content.Context
+import androidx.credentials.Credential
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.hikemate.app.model.authentication.FirebaseAuthRepository
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class FirebaseAuthRepositoryInstrumentedTest {
+
+  private lateinit var context: Context
+
+  // Repository under Test
+  private lateinit var repository: FirebaseAuthRepository
+
+  // Mock objects
+  private lateinit var mockCredentialManager: CredentialManager
+  private lateinit var mockFirebaseAuth: FirebaseAuth
+  private lateinit var mockFirebaseUser: FirebaseUser
+  private lateinit var mockFirebaseApp: FirebaseApp
+  private lateinit var mockAuthCredential: AuthCredential
+  private lateinit var mockCredential: Credential
+  private lateinit var mockCredentialResponse: GetCredentialResponse
+  private lateinit var mockTask: Task<AuthResult>
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+
+    // Initialize mocks
+    mockCredentialManager = mockk(relaxed = true)
+    mockFirebaseAuth = mockk(relaxed = true)
+    mockFirebaseUser = mockk(relaxed = true)
+    mockFirebaseApp = mockk(relaxed = true)
+    mockAuthCredential = mockk(relaxed = true)
+    mockCredential = mockk(relaxed = true)
+    mockCredentialResponse = mockk(relaxed = true)
+    mockTask = mockk(relaxed = true)
+
+    // Mock FirebaseApp initialization
+    mockkStatic(FirebaseApp::class)
+    every { FirebaseApp.initializeApp(any()) } returns mockFirebaseApp
+
+    // Mock Firebase object
+    mockkObject(Firebase)
+    every { FirebaseAuth.getInstance() } returns mockFirebaseAuth
+    every { Firebase.auth } returns mockFirebaseAuth
+
+    // Mock GoogleAuthProvider
+    mockkStatic(GoogleAuthProvider::class)
+    every { GoogleAuthProvider.getCredential(any(), null) } returns mockAuthCredential
+
+    // Mock behavior for the CredentialManager
+    every { mockCredentialResponse.credential } returns mockCredential
+    coEvery { mockCredentialManager.getCredential(any(), any<GetCredentialRequest>()) } returns
+        mockCredentialResponse
+
+    // Mock behavior authentication with Firebase
+    every { mockFirebaseAuth.signInWithCredential(any()) } returns mockTask
+    every { mockTask.addOnCompleteListener(any()) } answers
+        {
+          val listener = firstArg<OnCompleteListener<AuthResult>>()
+          listener.onComplete(mockTask)
+          mockTask
+        }
+
+    // Initialize the Firebase and the repository
+    FirebaseApp.initializeApp(context)
+    repository = FirebaseAuthRepository()
+  }
+
+  @After
+  fun tearDown() {
+    clearAllMocks()
+  }
+
+  @Test
+  fun testSignInWithGoogle_successful() = runTest {
+    // Mocks a successful call to FirebaseAuth.signInWithCredential
+    every { mockTask.isSuccessful } returns true
+
+    /* We hardcode that FirebaseAuth.currentUser is a valid user even before the login process is successful, since we are mocking Firebase's
+    functionality almost completely, so we don't have access Firebase's backend, and can therefore not
+    organically sign in a "real" (or fake ;) ) user. This however does not compromise the tests,
+    since we assume for this test that FirebaseAuth.signInWithCredential works and will successfully sign in our user once it is called with the correct parameters. This method is provided by
+    Firebase and therefore outside of the scope of the tests.*/
+    every { mockFirebaseAuth.currentUser } returns mockFirebaseUser
+
+    val onSuccess: (FirebaseUser?) -> Unit = mockk(relaxed = true)
+    val onError: (Throwable) -> Unit = mockk(relaxed = true)
+
+    repository.signInWithGoogle(
+        onSuccess = onSuccess,
+        onErrorAction = onError,
+        context = context,
+        credentialManager = mockCredentialManager,
+        coroutineScope = this)
+
+    advanceUntilIdle()
+
+    coVerify { mockCredentialManager.getCredential(any(), any<GetCredentialRequest>()) }
+    verify { mockFirebaseAuth.signInWithCredential(mockAuthCredential) }
+    verify { onSuccess(mockFirebaseUser) }
+    verify(exactly = 0) { onError(any()) }
+  }
+
+  @Test
+  fun testSignInWithGoogle_unsuccessful() = runTest {
+    every { mockTask.isSuccessful } returns false
+    every { mockTask.exception } returns Exception("Test Error")
+
+    val onSuccess: (FirebaseUser?) -> Unit = mockk(relaxed = true)
+    val onError: (Throwable) -> Unit = mockk(relaxed = true)
+
+    repository.signInWithGoogle(
+        onSuccess = onSuccess,
+        onErrorAction = onError,
+        context = context,
+        credentialManager = mockCredentialManager,
+        coroutineScope = this)
+
+    advanceUntilIdle()
+
+    coVerify { mockCredentialManager.getCredential(any(), any<GetCredentialRequest>()) }
+    verify { mockFirebaseAuth.signInWithCredential(mockAuthCredential) }
+    verify(exactly = 0) { onSuccess(any()) }
+    verify { onError(any<Throwable>()) }
+  }
+
+  @Test
+  fun testSignInWithGoogle_Error() = runTest {
+    val testException = GetCredentialUnknownException("Test Error")
+    coEvery { mockCredentialManager.getCredential(any(), any<GetCredentialRequest>()) } throws
+        testException
+
+    val onSuccess: (FirebaseUser?) -> Unit = mockk(relaxed = true)
+    val onError: (Throwable) -> Unit = mockk(relaxed = true)
+
+    repository.signInWithGoogle(
+        onSuccess = onSuccess,
+        onErrorAction = onError,
+        context = context,
+        credentialManager = mockCredentialManager,
+        coroutineScope = this)
+
+    advanceUntilIdle()
+
+    coVerify { mockCredentialManager.getCredential(any(), any<GetCredentialRequest>()) }
+    verify(exactly = 0) { mockFirebaseAuth.signInWithCredential(mockAuthCredential) }
+    verify(exactly = 0) { onSuccess(any()) }
+    verify { onError(any<GetCredentialUnknownException>()) }
+  }
+
+  @Test
+  fun testSignOut_successful() = runTest {
+    every { mockFirebaseAuth.currentUser } returns mockFirebaseUser
+
+    val onSuccess: () -> Unit = mockk(relaxed = true)
+
+    repository.signOut(onSuccess)
+
+    verify { mockFirebaseAuth.signOut() }
+    verify { onSuccess() }
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -1,0 +1,35 @@
+package ch.hikemate.app.model.authentication
+
+import android.content.Context
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class AuthViewModel(private val repository: FirebaseAuthRepository) {
+
+  private val _currentUser = MutableStateFlow(FirebaseAuth.getInstance().currentUser)
+  val currentUser: StateFlow<FirebaseUser?> get() = _currentUser
+
+  /**
+   *
+   */
+  fun signInWithGoogle(
+    coroutineScope: CoroutineScope,
+    context: Context
+  ) {
+    repository.signInWithGoogle(
+      onSuccess = { user: FirebaseUser? -> _currentUser.value = user },
+      onErrorAction = { },
+      context = context,
+      coroutineScope = coroutineScope
+    )
+  }
+
+  fun signOut() {
+    repository.signOut(
+      onSuccess = { _currentUser.value = null },
+    )
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -1,0 +1,100 @@
+package ch.hikemate.app.model.authentication
+
+import android.content.Context
+import android.util.Log
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import ch.hikemate.app.R
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class FirebaseAuthRepository {
+
+  /**
+   * Sign in with Google using Firebase Authentication.
+   *
+   * @param onSuccess Callback to invoke when login is successful. Passes the FirebaseUser if
+   *   successful.
+   * @param onErrorAction Callback to invoke when an error occurs during login. Passes the Throwable
+   *   error.
+   * @param context The Android Context, used for accessing resources and system services.
+   * @param coroutineScope The CoroutineScope to launch the login task in a non-blocking way.
+   * @param credentialManager (Optional) CredentialManager for handling credential requests. Pass
+   *   explicitly when testing with mocks.
+   */
+  fun signInWithGoogle(
+      onSuccess: (FirebaseUser?) -> Unit,
+      onErrorAction: (Exception) -> Unit,
+      context: Context,
+      coroutineScope: CoroutineScope,
+      credentialManager: CredentialManager = CredentialManager.create(context),
+  ) {
+
+    // Initialize Firebase authentication and retrieve the web client ID from resources
+    val auth = Firebase.auth
+    val token = context.getString(R.string.default_web_client_id)
+
+    // Configure Google ID options to request credentials from authorized accounts and the server
+    // client ID
+    val googleIdOption: GetGoogleIdOption =
+        GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(
+                true) // Only allow accounts already signed in on the device
+            .setServerClientId(token) // Server client ID for OAuth
+            .setAutoSelectEnabled(true) // Auto-select if only one account is available
+            .build()
+
+    // Build the credential request with the Google ID option
+    val request: GetCredentialRequest =
+        GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+
+    // Launch a coroutine for the login process to avoid blocking the main thread
+    coroutineScope.launch {
+      try {
+        // Request credentials from the credential manager
+        val result =
+            credentialManager.getCredential(
+                request = request, // Send the request we built
+                context = context // Provide the context for the request
+                )
+
+        // Extract the ID token from the result and create a Firebase credential
+        val firebaseCredential =
+            GoogleAuthProvider.getCredential(
+                result.credential.data.getString(
+                    "com.google.android.libraries.identity.googleid.BUNDLE_KEY_ID_TOKEN")!!, // Non-null assertion because the token must exist if login is successful
+                null // No access token needed
+                )
+
+        // Sign in with the Firebase credential (async task)
+        auth.signInWithCredential(firebaseCredential).addOnCompleteListener { task ->
+          if (task.isSuccessful) {
+            Log.d("SignInButton", "signInWithCredential:success")
+            onSuccess(auth.currentUser)
+          } else {
+            Log.d("SignInButton", "signInWithCredential:failure")
+            onErrorAction(task.exception ?: Exception("Unknown error"))
+          }
+        }
+      } catch (e: Exception) {
+        Log.d("SignInButton", "Login error: ${e.message}")
+        onErrorAction(e)
+      }
+    }
+  }
+
+  /**
+   * Signs out the current user from Firebase and invokes the success callback.
+   *
+   * @param onSuccess Callback to invoke after the user has successfully signed out.
+   */
+  fun signOut(onSuccess: () -> Unit) {
+    Firebase.auth.signOut()
+    onSuccess()
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">SampleApp</string>
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_second">SecondActivity</string>
+    <string name="default_web_client_id">154591189513-eilbr2jtms0av2ses4tsvo62009q5t7n.apps.googleusercontent.com</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,13 @@
 [versions]
 agp = "8.6.1"
+androidxCredentials = "<latest version>"
+credentials = "1.3.0"
+credentialsPlayServicesAuth = "1.5.0-alpha05"
+credentialsPlayServicesAuthVersion = "1.0"
+credentialsVersion = "1.5.0-alpha05"
 firebaseBom = "33.4.0"
+googleid = "1.3.0"
+googleidVersion = "<latest version>"
 junitJunit = "4.12"
 kotlin =  "1.8.10"
 coreKtx = "1.13.1"
@@ -15,6 +22,20 @@ composeActivity = "1.9.2"
 composeViewModel = "2.8.6"
 lifecycleRuntimeKtx = "2.8.6"
 kaspresso = "1.5.5"
+mockitoAndroid = "5.13.0"
+mockitoCore = "5.13.0"
+mockitoInline = "3.12.4"
+mockitoKotlin = "5.4.0"
+mockitoKotlinVersion = "3.2.0"
+mockk = "1.13.7"
+mockkAgent = "1.13.12"
+mockkAndroid = "1.13.7"
+mockkAndroidVersion = "1.13.12"
+mockkMockk = "1.13.2"
+mockkMockkAndroid = "1.13.2"
+mockkVersion = "1.13.0"
+osmdroidAndroid = "6.1.10"
+playServicesAuth = "21.2.0"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 gms = "4.4.2"
@@ -26,10 +47,24 @@ firebaseDatabaseKtx = "21.0.0"
 firebaseFirestore = "25.1.0"
 firebaseUiAuth = "8.0.0"
 firebaseFirestoreKtx = "25.1.0"
+espressoIntents = "3.6.1"
+
+# OSM Librairies
+osmdroid = "6.1.20"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
+androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
+androidx-credentials-play-services-auth-v10 = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentialsPlayServicesAuthVersion" }
+androidx-credentials-play-services-auth-v150alpha05 = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentialsPlayServicesAuth" }
+androidx-credentials-v150alpha05 = { module = "androidx.credentials:credentials", version.ref = "credentialsVersion" }
+androidx-credentials-vlatestversion = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+google-firebase-auth = { module = "com.google.firebase:firebase-auth" }
+googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
+googleid-vlatestversion = { module = "com.google.android.libraries.identity.googleid:googleid", version = "1.1.1" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -52,8 +87,23 @@ compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifes
 kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+mockito-kotlin-v320 = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlinVersion" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockkAgent" }
+mockk-android = { module = "io.mockk:mockk-android" }
+mockk-android-v11312 = { module = "io.mockk:mockk-android", version.ref = "mockkAndroidVersion" }
+mockk-android-v1132 = { module = "io.mockk:mockk-android", version.ref = "mockkMockkAndroid" }
+mockk-mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
+mockk-v1130 = { module = "io.mockk:mockk", version.ref = "mockkVersion" }
+mockk-v1132 = { module = "io.mockk:mockk", version.ref = "mockkMockk" }
+osmdroid-android-v6110 = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroidAndroid" }
+play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-osmdroid = { module = "org.osmdroid:osmdroid-android", version = "6.1.14" }
+osmdroid = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid" }
 
 # Firebase Libraries
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
@@ -62,6 +112,7 @@ firebase-database-ktx = { module = "com.google.firebase:firebase-database-ktx", 
 firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-ui-auth = { module = "com.firebaseui:firebase-ui-auth", version.ref = "firebaseUiAuth" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
+androidx-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "espressoIntents" }
 
 
 [plugins]


### PR DESCRIPTION
# Summary

Add a repository that can authenticate users using firebase. Currently, users can only sign in using their Google account. This repository will be followed by a viewModel, so the UI can easily access the functionality in this repository.

# Details

This pull request introduces a new method signInWithGoogle() within the FirebaseAuthRepository class to handle authentication with Firebase using Google Sign-In. The method integrates the Android CredentialManager to request user credentials and uses the Firebase SDK to authenticate via Google credentials.

**Functionality:**
signInWithGoogle():

Authenticates users via Google accounts already signed in on the device using Firebase Authentication.
Utilizes Android's CredentialManager to request credentials, streamlining the sign-in process.
Incorporates coroutines to handle asynchronous tasks, avoiding UI thread blocking.
Handles success and error callbacks via parameters (onSuccess, onErrorAction).

signOut():

Signs out the current user

