### PR TITLE
fix: fix handling of alternative routes in overpass API

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
@@ -168,7 +168,6 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
             // Lat and Long are in the object, no need to change the reader
             "node" -> points.add(parseLatLong(memberReader))
             "way" -> points.addAll(parseWay(memberReader))
-            else -> memberReader.skipValue()
           }
         } else {
           memberReader.skipValue()


### PR DESCRIPTION
# Summary 
- The Overpass API can return alternative routes, which are currently not supported, but were incorrectly handled

# Details
- The parser was skipping the name because the value was already read, thus leading to an error on next iteration