### PR TITLE
feat(profile): add profile class, vm and repo.

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/profile/Profile.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/Profile.kt
@@ -14,7 +14,7 @@ data class FitnessLevel(
 )
 
 /**
- * A class representing a profile.
+ * A class representing a user profile.
  *
  * @property id The ID of the profile.
  * @property name The name of the profile.

--- a/app/src/main/java/ch/hikemate/app/model/profile/Profile.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/Profile.kt
@@ -1,0 +1,30 @@
+package ch.hikemate.app.model.profile
+
+import com.google.firebase.Timestamp
+
+/**
+ * A class representing a fitness level.
+ *
+ * @property level The level of the fitness level.
+ * @property description The description of the fitness level.
+ */
+data class FitnessLevel(
+    val level: Int,
+    val description: String,
+)
+
+/**
+ * A class representing a profile.
+ *
+ * @property id The ID of the profile.
+ * @property name The name of the profile.
+ * @property email The email of the profile.
+ * @property fitnessLevel The fitness level of the profile.
+ */
+data class Profile(
+    val id: String,
+    val name: String,
+    val email: String,
+    val fitnessLevel: FitnessLevel,
+    val joinedDate: Timestamp,
+)

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepository.kt
@@ -1,0 +1,51 @@
+package ch.hikemate.app.model.profile
+
+/** Interface for the profile repository. */
+interface ProfileRepository {
+
+  /** Generates a new unique ID. */
+  fun getNewUid(): String
+
+  /**
+   * Initializes the profile repository.
+   *
+   * @param onSuccess The callback to be called when the repository is successfully initialized.
+   */
+  fun init(onSuccess: () -> Unit)
+
+  /**
+   * Returns the profile with the given ID.
+   *
+   * @param id The ID of the profile to fetch.
+   * @param onSuccess The callback to be called when the profile is successfully fetched.
+   * @param onFailure The callback to be called when the profile could not be fetched.
+   */
+  fun getProfileById(id: String, onSuccess: (Profile) -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
+   * Adds a profile.
+   *
+   * @param profile The profile to be added.
+   * @param onSuccess The callback to be called when the profile is successfully added.
+   * @param onFailure The callback to be called when the profile could not be added.
+   */
+  fun addProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
+   * Updates a profile.
+   *
+   * @param profile The profile to be updated.
+   * @param onSuccess The callback to be called when the profile is successfully updated.
+   * @param onFailure The callback to be called when the profile could not be updated.
+   */
+  fun updateProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
+   * Deletes a profile with the given ID.
+   *
+   * @param id The ID of the profile to delete.
+   * @param onSuccess The callback to be called when the profile is successfully deleted.
+   * @param onFailure The callback to be called when the profile could not be deleted.
+   */
+  fun deleteProfileById(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+}

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
@@ -1,0 +1,129 @@
+package ch.hikemate.app.model.profile
+
+import android.util.Log
+import com.google.android.gms.tasks.Task
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+
+/**
+ * A Firestore implementation of the profile repository.
+ *
+ * @property db The Firestore database.
+ */
+class ProfileRepositoryFirestore(val db: FirebaseFirestore) : ProfileRepository {
+
+  private val collectionPath = "profiles"
+
+  override fun getNewUid(): String {
+    return db.collection(collectionPath).document().id
+  }
+
+  override fun init(onSuccess: () -> Unit) {
+    // Check if the user is logged in
+    // If the user is logged in, call onSuccess
+    Firebase.auth.addAuthStateListener {
+      if (it.currentUser != null) {
+        onSuccess()
+      }
+    }
+  }
+
+  override fun getProfileById(
+      id: String,
+      onSuccess: (Profile) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Check that the profile exists
+
+    db.collection(collectionPath).document(id).get().addOnCompleteListener { task ->
+      if (task.isSuccessful) {
+        val profile = task.result?.let { documentToProfile(it) }
+        if (profile != null) {
+          onSuccess(profile)
+        } else {
+          onFailure(Exception("Profile not found"))
+        }
+      } else {
+        task.exception?.let { e ->
+          Log.e("ProfileRepositoryFirestore", "Error getting document", e)
+          onFailure(e)
+        }
+      }
+    }
+  }
+
+  override fun addProfile(profile: Profile, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    performFirestoreOperation(
+        db.collection(collectionPath).document(profile.id).set(profile), onSuccess, onFailure)
+  }
+
+  override fun updateProfile(
+      profile: Profile,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    performFirestoreOperation(
+        db.collection(collectionPath).document(profile.id).set(profile), onSuccess, onFailure)
+  }
+
+  override fun deleteProfileById(
+      id: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    performFirestoreOperation(
+        db.collection(collectionPath).document(id).delete(), onSuccess, onFailure)
+  }
+
+  /**
+   * Performs a Firestore operation and calls the appropriate callback based on the result. Function
+   * taken from the solution of the bootcamp.
+   *
+   * @param task The Firestore task to perform.
+   * @param onSuccess The callback to call if the operation is successful.
+   * @param onFailure The callback to call if the operation fails.
+   */
+  private fun performFirestoreOperation(
+      task: Task<Void>,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    task.addOnCompleteListener { result ->
+      if (result.isSuccessful) {
+        onSuccess()
+      } else {
+        result.exception?.let { e ->
+          Log.e("ProfileRepositoryFirestore", "Error performing Firestore operation", e)
+          onFailure(e)
+        }
+      }
+    }
+  }
+
+  /**
+   * Converts a Firestore document to a Profile object. Function inspired from the solution of the
+   * bootcamp.
+   *
+   * @param document The Firestore document to convert.
+   */
+  fun documentToProfile(document: DocumentSnapshot): Profile? {
+    return try {
+      val uid = document.id
+      val name = document.getString("name") ?: return null
+      val email = document.getString("email") ?: return null
+      val fitnessLevelData = document.get("fitnessLevel") as? Map<*, *>?
+      val fitnessLevel =
+          fitnessLevelData?.let {
+            FitnessLevel(
+                level = it["level"] as? Int ?: 0, description = it["description"] as? String ?: "")
+          }
+      val joinedDate = document.getTimestamp("joinedDate") ?: return null
+      Profile(uid, name, email, fitnessLevel ?: FitnessLevel(0, ""), joinedDate)
+    } catch (e: Exception) {
+      Log.e("ProfileRepositoryFirestore", "Error converting document to Profile", e)
+      null
+    }
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileViewModel.kt
@@ -1,0 +1,78 @@
+package ch.hikemate.app.model.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The view model for the profile.
+ *
+ * @param repository The profile repository.
+ */
+open class ProfileViewModel(private val repository: ProfileRepository) : ViewModel() {
+  // The profile, i.e the profile for the detail view
+  // This will probably always be the current user profile
+  private val profile_ = MutableStateFlow<Profile?>(null)
+  val profile: StateFlow<Profile?> = profile_.asStateFlow()
+
+  init {
+    repository.init {
+      // Get the profile of the current user
+      FirebaseAuth.getInstance().currentUser?.uid?.let { getProfileById(it) }
+    }
+  }
+
+  // create factory
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ProfileViewModel(ProfileRepositoryFirestore(Firebase.firestore)) as T
+          }
+        }
+  }
+
+  /**
+   * Get a profile by its ID.
+   *
+   * @param id The ID of the profile to fetch.
+   */
+  fun getProfileById(id: String) {
+    repository.getProfileById(id, onSuccess = { profile_.value = it }, onFailure = {})
+  }
+
+  /**
+   * Adds a profile.
+   *
+   * @param profile The profile to be added.
+   */
+  fun addProfile(profile: Profile) {
+    repository.addProfile(
+        profile = profile, onSuccess = { getProfileById(profile.id) }, onFailure = {})
+  }
+
+  /**
+   * Updates a profile.
+   *
+   * @param profile The profile to be updated.
+   */
+  fun updateProfile(profile: Profile) {
+    repository.updateProfile(
+        profile = profile, onSuccess = { profile_.value = profile }, onFailure = {})
+  }
+
+  /**
+   * Deletes a profile by its ID.
+   *
+   * @param id The ID of the profile to delete.
+   */
+  fun deleteProfileById(id: String) {
+    repository.deleteProfileById(id = id, onSuccess = { profile_.value = null }, onFailure = {})
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestoreTest.kt
@@ -9,6 +9,7 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.getField
 import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
@@ -21,6 +22,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 
+@Suppress("UNCHECKED_CAST")
 class ProfileRepositoryFirestoreTest {
   @Mock private lateinit var mockFirestore: FirebaseFirestore
   @Mock private lateinit var mockDocumentReference: DocumentReference
@@ -61,7 +63,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
     `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
-    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+    `when`(mockDocumentSnapshot.getField<Map<*, *>>("fitnessLevel"))
         .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(testTimestamp)
 
@@ -129,7 +131,8 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
     `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
-    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+
+    `when`(mockDocumentSnapshot.getField<Map<*, *>>("fitnessLevel"))
         .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
 
@@ -146,6 +149,8 @@ class ProfileRepositoryFirestoreTest {
         "1",
         onSuccess = { p -> assert(p == profile) },
         onFailure = { fail("Failure callback should not be called") })
+
+    verify(mockDocumentReference).get()
   }
 
   @Test
@@ -177,6 +182,8 @@ class ProfileRepositoryFirestoreTest {
         onFailure = {
           // Do nothing; we just want to verify that this is called
         })
+
+    verify(mockDocumentReference).get()
   }
 
   @Test

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestoreTest.kt
@@ -1,0 +1,390 @@
+package ch.hikemate.app.model.profile
+
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
+import junit.framework.TestCase.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.timeout
+import org.mockito.kotlin.verify
+
+class ProfileRepositoryFirestoreTest {
+  @Mock private lateinit var mockFirestore: FirebaseFirestore
+  @Mock private lateinit var mockDocumentReference: DocumentReference
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+  @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
+  @Mock private lateinit var mockProfileQuery: QuerySnapshot
+
+  private lateinit var repository: ProfileRepositoryFirestore
+
+  private val profile =
+      Profile(
+          id = "1",
+          name = "John Doe",
+          email = "john.doe@gmail.com",
+          fitnessLevel = FitnessLevel(8, "Very fit"),
+          joinedDate = Timestamp(1609459200, 0))
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    repository = ProfileRepositoryFirestore(mockFirestore)
+
+    `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+  }
+
+  @Test
+  fun getNewUid() {
+    `when`(mockDocumentReference.id).thenReturn("1")
+    val uid = repository.getNewUid()
+    assert(uid == "1")
+  }
+
+  @Test
+  fun documentToProfile() {
+    val testTimestamp = Timestamp(1609459200, 0)
+    `when`(mockDocumentSnapshot.id).thenReturn("1")
+    `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
+    `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
+    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(testTimestamp)
+
+    val profile = repository.documentToProfile(mockDocumentSnapshot)
+    assert(profile != null)
+    assert(profile!!.id == "1")
+    assert(profile.name == "John Doe")
+    assert(profile.email == "john.doe@gmail.com")
+    assert(profile.fitnessLevel.level == 8)
+    assert(profile.fitnessLevel.description == "Very fit")
+    assert(profile.joinedDate == testTimestamp)
+  }
+
+  @Test
+  fun documentToProfile_returnsNullIfDocumentIsMissingFields() {
+    `when`(mockDocumentSnapshot.id).thenReturn("1")
+    `when`(mockDocumentSnapshot.getString("name")).thenReturn(null)
+    `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
+    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
+
+    val profile = repository.documentToProfile(mockDocumentSnapshot)
+
+    assert(profile == null)
+  }
+
+  @Test
+  fun documentToProfile_returnsNullIfDataIsMissing() {
+    `when`(mockDocumentSnapshot.id).thenReturn("1")
+    `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
+    `when`(mockDocumentSnapshot.getString("email")).thenThrow(RuntimeException("No email field"))
+    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
+
+    val profile = repository.documentToProfile(mockDocumentSnapshot)
+
+    assert(profile == null)
+  }
+
+  @Test
+  fun getProfile_callsDocuments() {
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+
+    // Call the method under test
+    repository.getProfileById(
+        "whatever",
+        onSuccess = {
+          // Do nothing; we just want to verify that the 'documents' field was accessed
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    // Verify that the 'documents' field was accessed
+    verify(timeout(100)) { (mockProfileQuery).documents }
+  }
+
+  @Test
+  fun getProfileById_onSuccess() {
+    val task = mock(Task::class.java) as Task<DocumentSnapshot>
+    `when`(task.isSuccessful).thenReturn(true)
+    `when`(task.result).thenReturn(mockDocumentSnapshot)
+    `when`(mockDocumentReference.get()).thenReturn(task)
+    `when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    `when`(mockDocumentSnapshot.id).thenReturn("1")
+    `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
+    `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
+    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<DocumentSnapshot>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.getProfileById(
+        "1",
+        onSuccess = { p -> assert(p == profile) },
+        onFailure = { fail("Failure callback should not be called") })
+  }
+
+  @Test
+  fun getProfileById_onFailure() {
+    val task = mock(Task::class.java) as Task<DocumentSnapshot>
+    `when`(task.isSuccessful).thenReturn(true)
+    `when`(task.result).thenReturn(mockDocumentSnapshot)
+    `when`(mockDocumentReference.get()).thenReturn(task)
+    `when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    `when`(mockDocumentSnapshot.id).thenReturn("1")
+    `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
+    `when`(mockDocumentSnapshot.getString("email")).thenThrow(RuntimeException("No email field"))
+    `when`(mockDocumentSnapshot.get("fitnessLevel"))
+        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<DocumentSnapshot>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.getProfileById(
+        "1",
+        onSuccess = { p -> fail("Success callback should not be called") },
+        onFailure = {
+          // Do nothing; we just want to verify that this is called
+        })
+  }
+
+  @Test
+  fun getProfileById_onTaskFailed() {
+    val task = mock(Task::class.java) as Task<DocumentSnapshot>
+    `when`(task.isSuccessful).thenReturn(false)
+    `when`(task.exception).thenReturn(RuntimeException("Failed to get profile"))
+    `when`(mockDocumentReference.get()).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<DocumentSnapshot>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.getProfileById(
+        "1",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          // Do nothing; we just want to verify that this is called
+        })
+
+    verify(timeout(100)) { mockDocumentReference.get() }
+  }
+
+  @Test
+  fun addProfile_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
+
+    repository.addProfile(profile, onSuccess = {}, onFailure = {})
+
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun addProfile_onSuccess() {
+    val task = mock(Task::class.java) as Task<Void>
+    `when`(task.isSuccessful).thenReturn(true)
+    `when`(task.result).thenReturn(null)
+    `when`(mockDocumentReference.set(any())).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<Void>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.addProfile(
+        profile,
+        onSuccess = {
+          // Do nothing; we just want to verify that the 'set' method was called
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    verify(timeout(100)) { mockDocumentReference.set(any()) }
+  }
+
+  @Test
+  fun addProfile_onFailure() {
+    val task = mock(Task::class.java) as Task<Void>
+    `when`(task.isSuccessful).thenReturn(false)
+    `when`(task.exception).thenReturn(RuntimeException("Failed to add profile"))
+    `when`(mockDocumentReference.set(any())).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<Void>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.addProfile(
+        profile,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          // Do nothing; we just want to verify that the 'set' method was called
+        })
+
+    verify(timeout(100)) { mockDocumentReference.set(any()) }
+  }
+
+  @Test
+  fun updateProfile_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
+
+    repository.updateProfile(profile, onSuccess = {}, onFailure = {})
+
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun updateProfile_onSuccess() {
+    val task = mock(Task::class.java) as Task<Void>
+    `when`(task.isSuccessful).thenReturn(true)
+    `when`(task.result).thenReturn(null)
+    `when`(mockDocumentReference.set(any())).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<Void>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.updateProfile(
+        profile,
+        onSuccess = {
+          // Do nothing; we just want to verify that the 'set' method was called
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    verify(timeout(100)) { mockDocumentReference.set(any()) }
+  }
+
+  @Test
+  fun updateProfile_onFailure() {
+    val task = mock(Task::class.java) as Task<Void>
+    `when`(task.isSuccessful).thenReturn(false)
+    `when`(task.exception).thenReturn(RuntimeException("Failed to update profile"))
+    `when`(mockDocumentReference.set(any())).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<Void>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.updateProfile(
+        profile,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          // Do nothing; we just want to verify that the 'set' method was called
+        })
+
+    verify(timeout(100)) { mockDocumentReference.set(any()) }
+  }
+
+  @Test
+  fun deleteProfileById_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null)) // Simulate success
+
+    repository.deleteProfileById("1", onSuccess = {}, onFailure = {})
+
+    verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun deleteProfileById_onSuccess() {
+    val task = mock(Task::class.java) as Task<Void>
+    `when`(task.isSuccessful).thenReturn(true)
+    `when`(task.result).thenReturn(null)
+    `when`(mockDocumentReference.delete()).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<Void>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.deleteProfileById(
+        "1",
+        onSuccess = {
+          // Do nothing; we just want to verify that the 'delete' method was called
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    verify(timeout(100)) { mockDocumentReference.delete() }
+  }
+
+  @Test
+  fun deleteProfileById_onFailure() {
+    val task = mock(Task::class.java) as Task<Void>
+    `when`(task.isSuccessful).thenReturn(false)
+    `when`(task.exception).thenReturn(RuntimeException("Failed to delete profile"))
+    `when`(mockDocumentReference.delete()).thenReturn(task)
+
+    // Simulate the task being completed
+    doAnswer { invocation ->
+          val listener = invocation.arguments[0] as OnCompleteListener<Void>
+          listener.onComplete(task)
+          null
+        }
+        .`when`(task)
+        .addOnCompleteListener(any())
+
+    repository.deleteProfileById(
+        "1",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          // Do nothing; we just want to verify that the 'delete' method was called
+        })
+
+    verify(timeout(100)) { mockDocumentReference.delete() }
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
@@ -9,6 +9,8 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 
 class ProfileViewModelTest {
 
@@ -33,7 +35,6 @@ class ProfileViewModelTest {
       val init = it.getArgument<() -> Unit>(0)
       init()
     }
-
     `when`(mockFactory.create(ProfileViewModel::class.java)).thenReturn(profileViewModel)
   }
 
@@ -45,7 +46,7 @@ class ProfileViewModelTest {
   }
 
   @Test
-  fun getProfileById() {
+  fun getProfileByIdCallsRepository() {
     `when`(repository.getProfileById(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile)
@@ -53,11 +54,13 @@ class ProfileViewModelTest {
 
     profileViewModel.getProfileById("1")
 
+    verify(repository).getProfileById(eq("1"), any(), any())
+
     assert(profileViewModel.profile.value == profile)
   }
 
   @Test
-  fun addProfile() {
+  fun addProfileCallsRepository() {
     `when`(repository.addProfile(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<() -> Unit>(1)
       onSuccess()
@@ -69,11 +72,13 @@ class ProfileViewModelTest {
 
     profileViewModel.addProfile(profile)
 
+    verify(repository).addProfile(eq(profile), any(), any())
+
     assert(profileViewModel.profile.value == profile)
   }
 
   @Test
-  fun updateProfile() {
+  fun updateProfileCallsRepository() {
     `when`(repository.updateProfile(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<() -> Unit>(1)
       onSuccess()
@@ -81,17 +86,21 @@ class ProfileViewModelTest {
 
     profileViewModel.updateProfile(profile)
 
+    verify(repository).updateProfile(eq(profile), any(), any())
+
     assert(profileViewModel.profile.value == profile)
   }
 
   @Test
-  fun deleteProfileById() {
+  fun deleteProfileByIdCallsRepository() {
     `when`(repository.deleteProfileById(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<() -> Unit>(1)
       onSuccess()
     }
 
     profileViewModel.deleteProfileById("1")
+
+    verify(repository).deleteProfileById(eq("1"), any(), any())
 
     assert(profileViewModel.profile.value == null)
   }

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
@@ -1,10 +1,14 @@
 package ch.hikemate.app.model.profile
 
-import androidx.lifecycle.ViewModelProvider
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.FirebaseApp
 import com.google.firebase.Timestamp
 import junit.framework.TestCase.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -12,7 +16,10 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
+@RunWith(AndroidJUnit4::class)
 class ProfileViewModelTest {
+
+  private lateinit var context: Context
 
   private val profile =
       Profile(
@@ -23,11 +30,12 @@ class ProfileViewModelTest {
           joinedDate = Timestamp(1609459200, 0))
 
   @Mock private lateinit var repository: ProfileRepository
-  @Mock private lateinit var mockFactory: ViewModelProvider.Factory
   private lateinit var profileViewModel: ProfileViewModel
 
   @Before
   fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+
     MockitoAnnotations.openMocks(this)
     profileViewModel = ProfileViewModel(repository)
 
@@ -35,12 +43,13 @@ class ProfileViewModelTest {
       val init = it.getArgument<() -> Unit>(0)
       init()
     }
-    `when`(mockFactory.create(ProfileViewModel::class.java)).thenReturn(profileViewModel)
+
+    FirebaseApp.initializeApp(context)
   }
 
   @Test
   fun canBeCreatedAsFactory() {
-    val factory = mockFactory
+    val factory = ProfileViewModel.Factory
     val viewModel = factory.create(ProfileViewModel::class.java)
     assertNotNull(viewModel)
   }

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
@@ -1,0 +1,98 @@
+package ch.hikemate.app.model.profile
+
+import androidx.lifecycle.ViewModelProvider
+import com.google.firebase.Timestamp
+import junit.framework.TestCase.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+
+class ProfileViewModelTest {
+
+  private val profile =
+      Profile(
+          id = "1",
+          name = "John Doe",
+          email = "john.doe@gmail.com",
+          fitnessLevel = FitnessLevel(8, "Very fit"),
+          joinedDate = Timestamp(1609459200, 0))
+
+  @Mock private lateinit var repository: ProfileRepository
+  @Mock private lateinit var mockFactory: ViewModelProvider.Factory
+  private lateinit var profileViewModel: ProfileViewModel
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    profileViewModel = ProfileViewModel(repository)
+
+    `when`(repository.init(any())).thenAnswer {
+      val init = it.getArgument<() -> Unit>(0)
+      init()
+    }
+
+    `when`(mockFactory.create(ProfileViewModel::class.java)).thenReturn(profileViewModel)
+  }
+
+  @Test
+  fun canBeCreatedAsFactory() {
+    val factory = mockFactory
+    val viewModel = factory.create(ProfileViewModel::class.java)
+    assertNotNull(viewModel)
+  }
+
+  @Test
+  fun getProfileById() {
+    `when`(repository.getProfileById(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile)
+    }
+
+    profileViewModel.getProfileById("1")
+
+    assert(profileViewModel.profile.value == profile)
+  }
+
+  @Test
+  fun addProfile() {
+    `when`(repository.addProfile(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<() -> Unit>(1)
+      onSuccess()
+    }
+    `when`(repository.getProfileById(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Profile) -> Unit>(1)
+      onSuccess(profile)
+    }
+
+    profileViewModel.addProfile(profile)
+
+    assert(profileViewModel.profile.value == profile)
+  }
+
+  @Test
+  fun updateProfile() {
+    `when`(repository.updateProfile(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<() -> Unit>(1)
+      onSuccess()
+    }
+
+    profileViewModel.updateProfile(profile)
+
+    assert(profileViewModel.profile.value == profile)
+  }
+
+  @Test
+  fun deleteProfileById() {
+    `when`(repository.deleteProfileById(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<() -> Unit>(1)
+      onSuccess()
+    }
+
+    profileViewModel.deleteProfileById("1")
+
+    assert(profileViewModel.profile.value == null)
+  }
+}


### PR DESCRIPTION
Added the profile class, view model and repository using Firestore. Also added their tests

# Summary
The objective was to have a view model and a repository for the user profiles.
For this I also added the `Profile` data class.
The repository is based on its own interface and its implementation relies on Firestore.

# Notes
Most of the added lines are for tests. Don't be afraid of reviewing this PR :)
