### PR TITLE
feat: fetch name and description from overpass API

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
@@ -83,5 +83,13 @@ data class LatLong(val lat: Double, val lon: Double)
  * @param id The id of the route, depending of the client
  * @param bounds The bounding box of the route
  * @param ways The points of the route
+ * @param name The name of the route
+ * @param description The description of the route
  */
-data class HikeRoute(val id: String, val bounds: Bounds, val ways: List<LatLong>)
+data class HikeRoute(
+    val id: String,
+    val bounds: Bounds,
+    val ways: List<LatLong>,
+    val name: String? = null,
+    val description: String? = null
+)

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
@@ -2,6 +2,7 @@ package ch.hikemate.app.model.route
 
 import android.util.JsonReader
 import android.util.Log
+import ch.hikemate.app.R
 import java.io.Reader
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -229,8 +230,8 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
             nameEn != null -> nameEn
             otherName != null -> otherName
             from != null && to != null -> "$from - $to"
-            from != null -> from
-            to != null -> to
+            from != null -> "${R.string.hike_name_from_prefix} $from"
+            to != null -> "${R.string.hike_name_to_prefix} $to"
             else -> null
           }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
@@ -201,7 +201,7 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
       // most relevant one
       var name: String? = null
       var description: String? = null
-      var nameFr: String? = null
+      var nameEn: String? = null
       var otherName: String? = null
       var from: String? = null
       var to: String? = null
@@ -211,7 +211,7 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
           "int_name" -> name = tagsReader.nextString()
           // int_name has priority over name
           "name" -> if (name == null) name = tagsReader.nextString() else tagsReader.skipValue()
-          "name:fr" -> nameFr = tagsReader.nextString()
+          "name:en" -> nameEn = tagsReader.nextString()
           "osmc:name",
           "operator",
           "symbol" ->
@@ -226,7 +226,7 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
       val finalName =
           when {
             name != null -> name
-            nameFr != null -> nameFr
+            nameEn != null -> nameEn
             otherName != null -> otherName
             from != null && to != null -> "$from - $to"
             from != null -> from

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.model.route
 
 import android.util.JsonReader
+import android.util.Log
 import java.io.Reader
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -142,6 +143,8 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
       var id = ""
       val boundsBuilder = Bounds.Builder()
       val points = mutableListOf<LatLong>()
+      var elementName: String? = null
+      var description: String? = null
       while (elementReader.hasNext()) {
         val name = elementReader.nextName()
         when (name) {
@@ -168,10 +171,79 @@ class HikeRoutesRepositoryOverpass(val client: OkHttpClient) : HikeRoutesReposit
             }
             elementReader.endArray()
           }
+          "tags" -> {
+            elementReader.beginObject() // We're in the tags object of the element
+            parseTags(elementReader).let { pair ->
+              elementName = pair.first
+              description = pair.second
+            }
+            elementReader.endObject()
+          }
           else -> elementReader.skipValue()
         }
       }
-      return HikeRoute(id, boundsBuilder.build(), points)
+      return HikeRoute(id, boundsBuilder.build(), points, elementName, description)
+    }
+
+    /**
+     * Parses the tags from the Overpass API response. The reader is supposed to already be in the
+     * tags object.
+     *
+     * @param tagsReader The reader for the tags object.
+     * @return The name and description of the route, in a Pair, the name first, the description
+     *   after.
+     */
+    private fun parseTags(tagsReader: JsonReader): Pair<String?, String?> {
+      // The name of the route can be in multiple tags, we'll try to get the most relevant one
+      // The usual tag is the name tag, but if it's not present, we'll try the name:fr tag, then
+      // alternative tags...
+      // Since OSM is a public database, we can't be sure of the tags used, so we'll try to get the
+      // most relevant one
+      var name: String? = null
+      var description: String? = null
+      var nameFr: String? = null
+      var otherName: String? = null
+      var from: String? = null
+      var to: String? = null
+      while (tagsReader.hasNext()) {
+        when (tagsReader.nextName()) {
+          // int_name is used for international names
+          "int_name" -> name = tagsReader.nextString()
+          // int_name has priority over name
+          "name" -> if (name == null) name = tagsReader.nextString() else tagsReader.skipValue()
+          "name:fr" -> nameFr = tagsReader.nextString()
+          "osmc:name",
+          "operator",
+          "symbol" ->
+              if (otherName == null) otherName = tagsReader.nextString() else tagsReader.skipValue()
+          "from" -> from = tagsReader.nextString()
+          "to" -> to = tagsReader.nextString()
+          "description" -> description = tagsReader.nextString()
+          else -> tagsReader.skipValue()
+        }
+      }
+
+      val finalName =
+          when {
+            name != null -> name
+            nameFr != null -> nameFr
+            otherName != null -> otherName
+            from != null && to != null -> "$from - $to"
+            from != null -> from
+            to != null -> to
+            else -> null
+          }
+
+      // If the description is not set, we'll set it to the from - to, if available
+      // We also assert that the name is not the same as the description
+      if (description == null && from != null && to != null && finalName != "$from - $to") {
+        description = "$from - $to"
+      }
+
+      if (finalName == null) {
+        Log.w(this.javaClass::class.simpleName, "No name found for route")
+      }
+      return Pair(finalName, description)
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,8 @@
         An error occurred while loading saved hikes.
         Please check your Internet connection and try again.
     </string>
+
+    <!-- Hike names prefixes -->
+    <string name="hike_name_from_prefix">Starting from</string>
+    <string name="hike_name_to_prefix">Going to</string>
 </resources>

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
@@ -451,21 +451,6 @@ class HikeRoutesRepositoryOverpassTest {
               "Camino de Santiago",
               "Lausanne - Roll"))
 
-  private val alternativeRoutes: List<HikeRoute> =
-      listOf(
-          HikeRoute(
-              "124582",
-              Bounds(45.8689061, 6.4395807, 46.8283926, 7.2109599),
-              listOf(
-                  LatLong(46.8240018, 6.4395807),
-                  LatLong(46.8239650, 6.4396698),
-                  LatLong(46.8236197, 6.4400574),
-                  LatLong(46.8235322, 6.4401168),
-                  LatLong(46.8234367, 6.4401715),
-                  LatLong(46.8232651, 6.4402355)),
-              "Camino de Santiago",
-              "Lausanne - Roll"))
-
   private val combinedRoutes: List<HikeRoute> =
       listOf(
           HikeRoute(
@@ -589,7 +574,7 @@ class HikeRoutesRepositoryOverpassTest {
     }
 
     hikingRouteProviderRepositoryOverpass.getRoutes(
-        bounds, { routes -> assertEquals(alternativeRoutes, routes) }) {
+        bounds, { routes -> assertEquals(simpleRoutes, routes) }) {
           fail("Failed to fetch routes from Overpass API")
         }
   }

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
@@ -356,6 +356,86 @@ class HikeRoutesRepositoryOverpassTest {
           .request(mock())
           .build()
 
+  private val responseWithFromAndToButNoName =
+      Response.Builder()
+          .code(200)
+          .message("OK")
+          .body(
+              """
+{
+    "version": 0.6,
+    "generator": "Overpass API 0.7.62.1 084b4234",
+    "osm3s": {
+        "timestamp_osm_base": "2024-10-10T19:14:42Z",
+        "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+    },
+    "elements": [
+        {
+            "type": "relation",
+            "id": 124582,
+            "bounds": {
+                "minlat": 45.8689061,
+                "minlon": 6.4395807,
+                "maxlat": 46.8283926,
+                "maxlon": 7.2109599
+            },
+            "members": [
+            ],
+            "tags": {
+                "from": "Lausanne",
+                "to": "Roll"
+            }
+        }
+    ]
+}
+"""
+                  .trimIndent()
+                  .replace("\n", "")
+                  .toResponseBody())
+          .protocol(Protocol.HTTP_1_1)
+          .header("Content-Type", "application/json")
+          .request(mock())
+          .build()
+
+  private val responseWithNoName =
+      Response.Builder()
+          .code(200)
+          .message("OK")
+          .body(
+              """
+{
+    "version": 0.6,
+    "generator": "Overpass API 0.7.62.1 084b4234",
+    "osm3s": {
+        "timestamp_osm_base": "2024-10-10T19:14:42Z",
+        "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+    },
+    "elements": [
+        {
+            "type": "relation",
+            "id": 124582,
+            "bounds": {
+                "minlat": 45.8689061,
+                "minlon": 6.4395807,
+                "maxlat": 46.8283926,
+                "maxlon": 7.2109599
+            },
+            "members": [
+            ],
+            "tags": {
+            }
+        }
+    ]
+}
+"""
+                  .trimIndent()
+                  .replace("\n", "")
+                  .toResponseBody())
+          .protocol(Protocol.HTTP_1_1)
+          .header("Content-Type", "application/json")
+          .request(mock())
+          .build()
+
   private val simpleRoutes: List<HikeRoute> =
       listOf(
           HikeRoute(
@@ -367,7 +447,42 @@ class HikeRoutesRepositoryOverpassTest {
                   LatLong(46.8236197, 6.4400574),
                   LatLong(46.8235322, 6.4401168),
                   LatLong(46.8234367, 6.4401715),
-                  LatLong(46.8232651, 6.4402355))))
+                  LatLong(46.8232651, 6.4402355)),
+              "Camino de Santiago",
+              "Lausanne - Roll"))
+
+  private val alternativeRoutes: List<HikeRoute> =
+      listOf(
+          HikeRoute(
+              "124582",
+              Bounds(45.8689061, 6.4395807, 46.8283926, 7.2109599),
+              listOf(
+                  LatLong(46.8240018, 6.4395807),
+                  LatLong(46.8239650, 6.4396698),
+                  LatLong(46.8236197, 6.4400574),
+                  LatLong(46.8235322, 6.4401168),
+                  LatLong(46.8234367, 6.4401715),
+                  LatLong(46.8232651, 6.4402355)),
+              "Camino de Santiago",
+              "Lausanne - Roll"))
+
+  private val combinedRoutes: List<HikeRoute> =
+      listOf(
+          HikeRoute(
+              "124582",
+              Bounds(45.8689061, 6.4395807, 46.8283926, 7.2109599),
+              emptyList(),
+              "Lausanne - Roll",
+              null))
+
+  private val noNameRoutes: List<HikeRoute> =
+      listOf(
+          HikeRoute(
+              "124582",
+              Bounds(45.8689061, 6.4395807, 46.8283926, 7.2109599),
+              emptyList(),
+              null,
+              null))
 
   @Before
   fun setUp() {
@@ -474,7 +589,7 @@ class HikeRoutesRepositoryOverpassTest {
     }
 
     hikingRouteProviderRepositoryOverpass.getRoutes(
-        bounds, { routes -> assertEquals(simpleRoutes, routes) }) {
+        bounds, { routes -> assertEquals(alternativeRoutes, routes) }) {
           fail("Failed to fetch routes from Overpass API")
         }
   }
@@ -543,5 +658,39 @@ class HikeRoutesRepositoryOverpassTest {
         }
 
     assertEquals(2, hikingRouteProviderRepositoryOverpass.getCacheSize())
+  }
+
+  @Test
+  fun getRoutes_combinesFromAndToTags() {
+    val mockCall = mock(Call::class.java)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+
+    val callbackCapture = argumentCaptor<okhttp3.Callback>()
+
+    `when`(mockCall.enqueue(callbackCapture.capture())).then {
+      callbackCapture.firstValue.onResponse(mockCall, responseWithFromAndToButNoName)
+    }
+
+    hikingRouteProviderRepositoryOverpass.getRoutes(
+        bounds, { routes -> assertEquals(combinedRoutes, routes) }) {
+          fail("Failed to fetch routes from Overpass API")
+        }
+  }
+
+  @Test
+  fun getRoutes_worksOnNoName() {
+    val mockCall = mock(Call::class.java)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+
+    val callbackCapture = argumentCaptor<okhttp3.Callback>()
+
+    `when`(mockCall.enqueue(callbackCapture.capture())).then {
+      callbackCapture.firstValue.onResponse(mockCall, responseWithNoName)
+    }
+
+    hikingRouteProviderRepositoryOverpass.getRoutes(
+        bounds, { routes -> assertEquals(noNameRoutes, routes) }) {
+          fail("Failed to fetch routes from Overpass API")
+        }
   }
 }


### PR DESCRIPTION
# Summary

- The objective was to have a name and a description from the OSM API to show to the user, fetched from the API

# Details

- Names are not always available. I've tried to implement ways to get a name, using alternative OSM tags and/or combination of tags to create decent name and/or tags, but this doesn't guarantee that a name can be shown AT ALL. 
- Some tags are more relevant than other, thus, there are priorities attributed to tags (For example, the `name` tag weights more than the `operator` tag when looking for a name.
