### PR TITLE
fix(nav): localize button content description

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/SideBarNavigationTest.kt
@@ -3,6 +3,7 @@ package ch.hikemate.app.navigation
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
@@ -242,7 +243,7 @@ class SideBarNavigationTest {
     composeTestRule
         .onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON)
         .assertHasClickAction()
-        .assertContentDescriptionEquals("SideBar")
+        .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.ContentDescription))
 
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
 

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -19,10 +19,12 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import ch.hikemate.app.R
 import ch.hikemate.app.ui.components.AppIcon
 import kotlinx.coroutines.launch
 
@@ -107,7 +109,9 @@ fun SideBarNavigation(
                   content = {
                     Icon(
                         Icons.Filled.Menu,
-                        contentDescription = "SideBar",
+                        contentDescription =
+                            LocalContext.current.getString(
+                                R.string.sidebar_button_content_description),
                     )
                   },
               )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
     <!--Google APi-->
     <string name="default_web_client_id">154591189513-eilbr2jtms0av2ses4tsvo62009q5t7n.apps.googleusercontent.com</string>
 
+    <!-- Sidebar -->
+    <string name="sidebar_button_content_description">Open sidebar menu</string>
+
     <!-- Map Screen -->
     <string name="map_screen_menu_button_content_description">Menu</string>
     <string name="map_screen_search_button_text">Search hikes here</string>


### PR DESCRIPTION
# Summary

The content description of the button that opens the sidebar (main menu of the app) was hardcoded in the sidebar composable. A content description should

1. Be localized (translatable, i.e. defined in `strings.xml`
2. Describe an action (i.e. "Open sidebar menu" rather than "Sidebar")

I'm not 100% certain for 2., but 1. is certain. Hence this PR simply moves the definition of the sidebar button to `strings.xml`, where it can easily be translated.

It's a very simple PR, but I did not want to include it in the one I'm working on right now (Saved Hikes screen) as I felt it should be a PR of its own given its different nature.