### PR TITLE
feat(nav): pass scaffold padding as content param

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/SideBarNavigation.kt
@@ -49,7 +49,7 @@ fun SideBarNavigation(
     // The reason the content of the screen has to be passed as a lambda is because the drawer has
     // to be
     // integrated with the screen.
-    content: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit
 ) {
   val drawerState = rememberDrawerState(DrawerValue.Closed)
   val scope = rememberCoroutineScope()
@@ -111,8 +111,8 @@ fun SideBarNavigation(
                     )
                   },
               )
-            }) {
-              content()
+            }) { padding: PaddingValues ->
+              content(padding)
             }
       },
   )


### PR DESCRIPTION
# Summary

The `SidebarNavigation` composable adds a burger menu button in the top left corner of the screen. For screens such as map, the fact that the button takes a bit of space hovering on the map is not a problem, the user can simply move the map (see attached image below).

However, on screens such as Saved Hikes, the burger menu button could hide the title of the screen or the top composable. This is not the desired behavior (see attached image below).

<img src="https://github.com/user-attachments/assets/471aabab-7b0c-4180-bea9-3e2d128b281b" width="300" />

<img src="https://github.com/user-attachments/assets/6887b7db-53a5-4184-80df-4576f0f3b967" width="300" />

# Details

This PR proposes a quite simple solution to this. `SidebarNavigation` takes a `content` lambda as a parameter. Initially, this `content` lambda took no parameter. I changed it to take a parameter of type `PaddingValues`.

Existing code does not have to change. If there is no parameter in the provided lambda, Kotlin will assume the lambda wants to ignore the parameter, and it still compiles and works as expected. Tests all pass as well.

However, if one *wants* to use the padding, simply add `paddingValues ->` in the callback to take the parameter. It allows the map to keep its current behavior, and the Saved Hikes screen to take the menu button into account :

<img src="https://github.com/user-attachments/assets/dbb46207-13f1-4922-acf3-dc8b71001692" width="300" />