### PR TITLE
fix(map): fix searching crashing when zoomed out

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
@@ -31,7 +31,9 @@ data class Bounds(val minLat: Double, val minLon: Double, val maxLat: Double, va
   }
 
   init {
-    require(!(minLat > maxLat || minLon > maxLon)) { "Invalid bounds" }
+    require(!(minLat > maxLat || minLon > maxLon)) {
+      "Invalid bounds: minLat=$minLat, maxLat=$maxLat, minLon=$minLon, maxLong=$maxLon"
+    }
   }
 
   class Builder {

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -183,9 +183,13 @@ fun clearHikesFromMap(mapView: MapView) {
 
 @Composable
 fun MapScreen(
+    navigationActions: NavigationActions,
     hikingRoutesViewModel: ListOfHikeRoutesViewModel =
         viewModel(factory = ListOfHikeRoutesViewModel.Factory),
-    navigationActions: NavigationActions
+    mapInitialZoomLevel: Double = MapScreen.MAP_INITIAL_ZOOM,
+    mapMaxZoomLevel: Double = MapScreen.MAP_MAX_ZOOM,
+    mapMinZoomLevel: Double = MapScreen.MAP_MIN_ZOOM,
+    mapInitialCenter: GeoPoint = MapScreen.MAP_INITIAL_CENTER,
 ) {
   val context = LocalContext.current
   // Avoid re-creating the MapView on every recomposition
@@ -210,11 +214,11 @@ fun MapScreen(
     }
 
     mapView.apply {
-      controller.setZoom(MapScreen.MAP_INITIAL_ZOOM)
-      controller.setCenter(MapScreen.MAP_INITIAL_CENTER)
+      controller.setZoom(mapInitialZoomLevel)
+      controller.setCenter(mapInitialCenter)
       // Limit the zoom to avoid the user zooming out or out too much
-      minZoomLevel = MapScreen.MAP_MIN_ZOOM
-      maxZoomLevel = MapScreen.MAP_MAX_ZOOM
+      minZoomLevel = mapMinZoomLevel
+      maxZoomLevel = mapMaxZoomLevel
       // Avoid repeating the map when the user reaches the edge or zooms out
       isHorizontalMapRepetitionEnabled = false
       isVerticalMapRepetitionEnabled = false

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -87,6 +87,19 @@ object MapScreen {
    */
   const val MAP_INITIAL_ZOOM = 12.0
 
+  /**
+   * (Config) Maximum zoom level of the map. The zoom level is defined empirically to avoid the user
+   * zooming in too much and seeing the map tiles pixelated.
+   */
+  const val MAP_MAX_ZOOM = 18.0
+
+  /**
+   * (Config) Minimum zoom level of the map. The zoom level is defined empirically to avoid the user
+   * zooming out too much and seeing too much of the blank background behind the map tiles while
+   * still being able to see a reasonable area of the world map.
+   */
+  const val MAP_MIN_ZOOM = 2.5
+
   /** (Config) Initial position of the center of the map. */
   val MAP_INITIAL_CENTER = GeoPoint(46.5, 6.6)
 
@@ -199,6 +212,12 @@ fun MapScreen(
     mapView.apply {
       controller.setZoom(MapScreen.MAP_INITIAL_ZOOM)
       controller.setCenter(MapScreen.MAP_INITIAL_CENTER)
+      // Limit the zoom to avoid the user zooming out or out too much
+      minZoomLevel = MapScreen.MAP_MIN_ZOOM
+      maxZoomLevel = MapScreen.MAP_MAX_ZOOM
+      // Avoid repeating the map when the user reaches the edge or zooms out
+      isHorizontalMapRepetitionEnabled = false
+      isVerticalMapRepetitionEnabled = false
       // Enable touch-controls such as pinch to zoom
       setMultiTouchControls(true)
     }


### PR DESCRIPTION
# Bug report

While testing our app manually, the coaches noticed that when one clicks `Search hikes here` when the map was zoomed out very far, the app crashed without any message.

# Bug investigation

When clicking `Search hikes here`, the app takes the bounding box of the OSMDroid map view (of type `BoundingBox`) and converts it to a `Bounds` instance (our own class). However, `Bounds` only accepts valid boundaries. The minimum latitude must be less than or equal to the maximum latitude. Same for longitude.

When the map was zoomed out very far, OSMDroid automatically repeated the world map on the left, right, top and bottom of the screen :

<img src="https://github.com/user-attachments/assets/adb9e8ca-90cf-45b2-9d88-99fa549eea3b" width="300" />

This lead the `BoundingBox` of the map view to be invalid in regards of the `Bounds` criteria, leading to an exception. This is because the map started at some minLatitude/minLongitude and ended at maxLatitude/maxLongitude, while minLatitude was possibly bigger than maxLatitude because it was on another map.

# Bug fix

I fixed the bug by disabling the repetition of the map when the user zoomed out a lot. I also adjusted the maximum zoom level so that the user does not see the blank background too much.

I also added a regression test to avoid re-introducing the bug in a future update. For this, I added optional parameters to the map screen, so that the tests can set the zoom levels from outside.