### PR TITLE
feat(profile): change fitness level to an enum

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/profile/Profile.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/Profile.kt
@@ -2,16 +2,12 @@ package ch.hikemate.app.model.profile
 
 import com.google.firebase.Timestamp
 
-/**
- * A class representing a fitness level.
- *
- * @property level The level of the fitness level.
- * @property description The description of the fitness level.
- */
-data class FitnessLevel(
-    val level: Int,
-    val description: String,
-)
+/** An enum class representing the fitness level of a user. */
+enum class FitnessLevel {
+  BEGINNER,
+  INTERMEDIATE,
+  EXPERT
+}
 
 /**
  * A class representing a user profile.

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
@@ -6,7 +6,6 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.getField
 
 /**
  * A Firestore implementation of the profile repository.
@@ -150,10 +149,8 @@ class ProfileRepositoryFirestore(private val db: FirebaseFirestore) : ProfileRep
       val uid = document.id
       val name = document.getString("name") ?: return null
       val email = document.getString("email") ?: return null
-      val fitnessLevelData = document.getField("fitnessLevel") as? Map<*, *> ?: return null
-      val fitnessLevelLevel = fitnessLevelData["level"] as? Int ?: return null
-      val fitnessLevelDescription = fitnessLevelData["description"] as? String ?: return null
-      val fitnessLevel = FitnessLevel(fitnessLevelLevel, fitnessLevelDescription)
+      val fitnessLevelString = document.getString("fitnessLevel") ?: return null
+      val fitnessLevel = FitnessLevel.values().find { it.name == fitnessLevelString } ?: return null
       val joinedDate = document.getTimestamp("joinedDate") ?: return null
       Profile(uid, name, email, fitnessLevel, joinedDate)
     } catch (e: Exception) {

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestoreTest.kt
@@ -9,7 +9,6 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
-import com.google.firebase.firestore.getField
 import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
@@ -37,7 +36,7 @@ class ProfileRepositoryFirestoreTest {
           id = "1",
           name = "John Doe",
           email = "john.doe@gmail.com",
-          fitnessLevel = FitnessLevel(8, "Very fit"),
+          fitnessLevel = FitnessLevel.INTERMEDIATE,
           joinedDate = Timestamp(1609459200, 0))
 
   @Before
@@ -63,8 +62,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
     `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
-    `when`(mockDocumentSnapshot.getField<Map<*, *>>("fitnessLevel"))
-        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getString("fitnessLevel")).thenReturn("INTERMEDIATE")
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(testTimestamp)
 
     val profile = repository.documentToProfile(mockDocumentSnapshot)
@@ -72,8 +70,7 @@ class ProfileRepositoryFirestoreTest {
     assert(profile!!.id == "1")
     assert(profile.name == "John Doe")
     assert(profile.email == "john.doe@gmail.com")
-    assert(profile.fitnessLevel.level == 8)
-    assert(profile.fitnessLevel.description == "Very fit")
+    assert(profile.fitnessLevel == FitnessLevel.INTERMEDIATE)
     assert(profile.joinedDate == testTimestamp)
   }
 
@@ -82,8 +79,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn(null)
     `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
-    `when`(mockDocumentSnapshot.get("fitnessLevel"))
-        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getString("fitnessLevel")).thenReturn("INTERMEDIATE")
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
 
     val profile = repository.documentToProfile(mockDocumentSnapshot)
@@ -96,8 +92,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
     `when`(mockDocumentSnapshot.getString("email")).thenThrow(RuntimeException("No email field"))
-    `when`(mockDocumentSnapshot.get("fitnessLevel"))
-        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getString("fitnessLevel")).thenReturn("INTERMEDIATE")
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
 
     val profile = repository.documentToProfile(mockDocumentSnapshot)
@@ -131,9 +126,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
     `when`(mockDocumentSnapshot.getString("email")).thenReturn("john.doe@gmail.com")
-
-    `when`(mockDocumentSnapshot.getField<Map<*, *>>("fitnessLevel"))
-        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getString("fitnessLevel")).thenReturn("INTERMEDIATE")
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
 
     // Simulate the task being completed
@@ -163,8 +156,7 @@ class ProfileRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("name")).thenReturn("John Doe")
     `when`(mockDocumentSnapshot.getString("email")).thenThrow(RuntimeException("No email field"))
-    `when`(mockDocumentSnapshot.get("fitnessLevel"))
-        .thenReturn(mapOf("level" to 8, "description" to "Very fit"))
+    `when`(mockDocumentSnapshot.getString("fitnessLevel")).thenReturn("INTERMEDIATE")
     `when`(mockDocumentSnapshot.getTimestamp("joinedDate")).thenReturn(Timestamp(1609459200, 0))
 
     // Simulate the task being completed

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
@@ -26,7 +26,7 @@ class ProfileViewModelTest {
           id = "1",
           name = "John Doe",
           email = "john.doe@gmail.com",
-          fitnessLevel = FitnessLevel(8, "Very fit"),
+          fitnessLevel = FitnessLevel.INTERMEDIATE,
           joinedDate = Timestamp(1609459200, 0))
 
   @Mock private lateinit var repository: ProfileRepository


### PR DESCRIPTION
Changed the Fitness level to an enum as suggested in the meeting

# Summary
As discussed in the meeting, the `FitnessLevel` is now an enum with 3 values: beginner, intermediate and expert
