### PR TITLE
fix: lock orientation to remove landscape mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,9 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/title_activity_main"
-            android:theme="@style/Theme.HikeMate">
+            android:theme="@style/Theme.HikeMate"
+            android:screenOrientation="portrait"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
# Summary

The app is not adapted to landscape mode, at least yet, and we do not plan to support it as of now. This is a simple lock in the AndroidManifest.xml file and should prevent the app from going into landscape mode.

# Testing

Unfortunately I couldn't implement any meaningful, working test for this. I attached the test I tried to create below.

The problem with the following test is that `requestedOrientation` can bypass the lock of `AndroidManifest.xml`, meaning the app will pass in landscape mode even though the user, when using the app, can't.

```kotlin
package ch.hikemate.app.ui

import android.content.pm.ActivityInfo
import android.content.res.Configuration
import androidx.compose.ui.test.junit4.createAndroidComposeRule
import ch.hikemate.app.MainActivity
import ch.hikemate.app.ui.navigation.NavigationActions
import org.junit.Assert.assertEquals
import org.junit.Before
import org.junit.Rule
import org.junit.Test
import org.mockito.Mockito.mock

class AppOrientationTest {
  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()

  private lateinit var navigationActions: NavigationActions

  @Before
  fun setUp() {
    navigationActions = mock(NavigationActions::class.java)
  }

  @Test
  fun lockedToPortraitInLoginScreen() {
    // Set initial orientation to portrait
    composeTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT

    // Attempt to request landscape mode
    composeTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE

    // Allow some time for the orientation change to be processed
    composeTestRule.waitForIdle()

    // Verify that the orientation remains in portrait
    val currentOrientation = composeTestRule.activity.resources.configuration.orientation
    assertEquals(Configuration.ORIENTATION_PORTRAIT, currentOrientation)
  }
}
```
