### PR TITLE
ci: disable animations to improve running speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
+      - name: Disable animations in emulator to improve speed
+        run: | 
+          adb shell settings put global window_animation_scale 0
+          adb shell settings put global transition_animation_scale 0
+          adb shell settings put global animator_duration_scale 0
+
       - name: Grant execute permission for gradlew
         run: |
           chmod +x ./gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: create AVD and generate snapshot for caching
+      - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -86,12 +86,6 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
-
-      - name: Disable animations in emulator to improve speed
-        run: | 
-          adb shell settings put global window_animation_scale 0
-          adb shell settings put global transition_animation_scale 0
-          adb shell settings put global animator_duration_scale 0
 
       - name: Grant execute permission for gradlew
         run: |
@@ -107,6 +101,12 @@ jobs:
         run: |
           # To run the CI with debug information, add --info
           ./gradlew assemble lint --parallel --build-cache
+
+      - name: Disable animations in emulator to improve speed
+        run: | 
+          /usr/local/lib/android/sdk/platform-tools/adb shell settings put global window_animation_scale 0
+          /usr/local/lib/android/sdk/platform-tools/adb shell settings put global transition_animation_scale 0
+          /usr/local/lib/android/sdk/platform-tools/adb shell settings put global animator_duration_scale 0
 
       # Run Unit tests
       - name: Run tests


### PR DESCRIPTION
# Summary
This PR improves the running speed of the CI by disabling animations for tests