### PR TITLE
fix(map): set user agent before OSMDroid map init

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -193,10 +193,6 @@ fun MapScreen(
     mapInitialCenter: GeoPoint = MapScreen.MAP_INITIAL_CENTER,
 ) {
   val context = LocalContext.current
-  // Avoid re-creating the MapView on every recomposition
-  val mapView = remember { MapView(context) }
-  // Keep track of whether a search for hikes is ongoing
-  var isSearching by remember { mutableStateOf(false) }
 
   // Only do the configuration on the first composition, not on every recomposition
   LaunchedEffect(Unit) {
@@ -213,23 +209,26 @@ fun MapScreen(
       // Maximum number of bytes that can be used by the tile file system cache. Default is 600MB.
       tileFileSystemCacheMaxBytes = 600L * 1024L * 1024L
     }
-
-    mapView.apply {
-      // Set map's initial state
-      controller.setZoom(mapInitialZoomLevel)
-      controller.setCenter(mapInitialCenter)
-      // Limit the zoom to avoid the user zooming out or out too much
-      minZoomLevel = mapMinZoomLevel
-      maxZoomLevel = mapMaxZoomLevel
-      // Avoid repeating the map when the user reaches the edge or zooms out
-      isHorizontalMapRepetitionEnabled = false
-      isVerticalMapRepetitionEnabled = false
-      // Disable built-in zoom controls since we have our own
-      zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
-      // Enable touch-controls such as pinch to zoom
-      setMultiTouchControls(true)
-    }
   }
+
+  // Avoid re-creating the MapView on every recomposition
+  val mapView = remember { MapView(context).apply {
+    // Set map's initial state
+    controller.setZoom(mapInitialZoomLevel)
+    controller.setCenter(mapInitialCenter)
+    // Limit the zoom to avoid the user zooming out or out too much
+    minZoomLevel = mapMinZoomLevel
+    maxZoomLevel = mapMaxZoomLevel
+    // Avoid repeating the map when the user reaches the edge or zooms out
+    isHorizontalMapRepetitionEnabled = false
+    isVerticalMapRepetitionEnabled = false
+    // Disable built-in zoom controls since we have our own
+    zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
+    // Enable touch-controls such as pinch to zoom
+    setMultiTouchControls(true)
+  } }
+  // Keep track of whether a search for hikes is ongoing
+  var isSearching by remember { mutableStateOf(false) }
 
   // Show hikes on the map
   val routes by hikingRoutesViewModel.hikeRoutes.collectAsState()

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -212,21 +212,23 @@ fun MapScreen(
   }
 
   // Avoid re-creating the MapView on every recomposition
-  val mapView = remember { MapView(context).apply {
-    // Set map's initial state
-    controller.setZoom(mapInitialZoomLevel)
-    controller.setCenter(mapInitialCenter)
-    // Limit the zoom to avoid the user zooming out or out too much
-    minZoomLevel = mapMinZoomLevel
-    maxZoomLevel = mapMaxZoomLevel
-    // Avoid repeating the map when the user reaches the edge or zooms out
-    isHorizontalMapRepetitionEnabled = false
-    isVerticalMapRepetitionEnabled = false
-    // Disable built-in zoom controls since we have our own
-    zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
-    // Enable touch-controls such as pinch to zoom
-    setMultiTouchControls(true)
-  } }
+  val mapView = remember {
+    MapView(context).apply {
+      // Set map's initial state
+      controller.setZoom(mapInitialZoomLevel)
+      controller.setCenter(mapInitialCenter)
+      // Limit the zoom to avoid the user zooming out or out too much
+      minZoomLevel = mapMinZoomLevel
+      maxZoomLevel = mapMaxZoomLevel
+      // Avoid repeating the map when the user reaches the edge or zooms out
+      isHorizontalMapRepetitionEnabled = false
+      isVerticalMapRepetitionEnabled = false
+      // Disable built-in zoom controls since we have our own
+      zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
+      // Enable touch-controls such as pinch to zoom
+      setMultiTouchControls(true)
+    }
+  }
   // Keep track of whether a search for hikes is ongoing
   var isSearching by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
This PR introduces a quick fix for a minor bug that was causing Logcat errors when loading the map screen.

We use OSMDroid to display map tiles from OSM as a map view. OSMDroid requires to set an actual user agent for the tiles requests.

The configured user agent was indeed set to a valid value in our code, but it was set **after** the map view was created, meaning the first requests were being sent before the configuration was set, and an error could be seen in Logcat. It did not impact the functionality of the app too much, but is better fixed anyway.