### PR TITLE
feat(map): display hike names instead of ids

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/components/HikeCard.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/HikeCard.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.unit.dp
 import ch.hikemate.app.R
 import ch.hikemate.app.ui.map.MapScreen
 
+const val TEST_TAG_HIKE_CARD_TITLE = "HikeCardTitle"
+
 @Composable
 fun HikeCard(
     title: String,
@@ -57,7 +59,8 @@ fun HikeCard(
           Text(
               text = title,
               style = MaterialTheme.typography.titleLarge,
-              fontWeight = FontWeight.Bold)
+              fontWeight = FontWeight.Bold,
+              modifier = Modifier.testTag(TEST_TAG_HIKE_CARD_TITLE))
           Spacer(modifier = Modifier.height(8.dp))
 
           Row(

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -378,7 +379,7 @@ fun HikeCardFor(route: HikeRoute, isSuitable: Boolean, viewModel: ListOfHikeRout
   val suitableLabelIcon = if (isSuitable) R.drawable.check_circle else R.drawable.warning
 
   HikeCard(
-      title = route.id,
+      title = route.name ?: stringResource(R.string.map_screen_hike_title_default),
       altitudeDifference = 1000,
       onClick = {
         // The user clicked on the route to select it

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="map_screen_too_many_hikes_message">
         Too many hikes to display on the map. Only %d hikes are shown.
     </string>
+    <string name="map_screen_hike_title_default">Unnamed Hike</string>
     <string name="zoom_in">Zoom in</string>
     <string name="zoom_out">Zoom out</string>
 


### PR DESCRIPTION
# Summary

On the map screen, in the list of hikes below the map, instead of displaying each hike's ID, display their name instead. That is what this PR does.

Also added two tests to check that the name is displayed, or a default name if the name itself is not available.