### PR TITLE
fix(map): fix map going out of world

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -47,7 +47,6 @@ import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.SideBarNavigation
 import org.osmdroid.config.Configuration
-import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
@@ -95,15 +94,12 @@ object MapScreen {
   /** (Config) Width of the stroke of the lines that represent the hikes on the map. */
   const val STROKE_WIDTH = 10f
 
-  // These are the limits of the map. They are defined by the latitude and longitude values that
-  // the map can display.
-  // The latitude goes from -85 to 85, because going beyond that would (weirdly) let the user see
-  // the blank
-  // The longitude goes from -180 to 180 as it is the standard for the world map.
+  // These are the limits of the map. They are defined by the
+  // latitude values that the map can display.
+  // The latitude goes from -85 to 85, because going beyond
+  // that would (weirdly) let the user see the blank
   const val MAP_MAX_LATITUDE = 85.0
-  const val MAP_MAX_LONGITUDE = 180.0
   const val MAP_MIN_LATITUDE = -85.0
-  const val MAP_MIN_LONGITUDE = -180.0
 
   const val MIN_HUE = 0
   const val MAX_HUE = 360
@@ -220,19 +216,16 @@ fun MapScreen(
       minZoomLevel = mapMinZoomLevel
       maxZoomLevel = mapMaxZoomLevel
       // Avoid repeating the map when the user reaches the edge or zooms out
-      isHorizontalMapRepetitionEnabled = false
+      // We keep the horizontal repetition enabled to allow the user to scroll the map
+      // horizontally without limits (from Asia to America, for example)
+      isHorizontalMapRepetitionEnabled = true
       isVerticalMapRepetitionEnabled = false
       // Disable built-in zoom controls since we have our own
       zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
       // Enable touch-controls such as pinch to zoom
       setMultiTouchControls(true)
-      // Limit the scrollable area to avoid the user scrolling too far
-      setScrollableAreaLimitDouble(
-          BoundingBox(
-              MapScreen.MAP_MIN_LATITUDE,
-              MapScreen.MAP_MAX_LONGITUDE,
-              MapScreen.MAP_MAX_LATITUDE,
-              MapScreen.MAP_MIN_LONGITUDE))
+      // Limit the vertical scrollable area to avoid the user scrolling too far
+      setScrollableAreaLimitLatitude(MapScreen.MAP_MAX_LATITUDE, MapScreen.MAP_MIN_LATITUDE, 0)
     }
   }
   // Keep track of whether a search for hikes is ongoing

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -47,6 +47,7 @@ import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.SideBarNavigation
 import org.osmdroid.config.Configuration
+import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
@@ -86,13 +87,23 @@ object MapScreen {
    * zooming out too much and seeing too much of the blank background behind the map tiles while
    * still being able to see a reasonable area of the world map.
    */
-  const val MAP_MIN_ZOOM = 2.5
+  const val MAP_MIN_ZOOM = 3.0
 
   /** (Config) Initial position of the center of the map. */
   val MAP_INITIAL_CENTER = GeoPoint(46.5, 6.6)
 
   /** (Config) Width of the stroke of the lines that represent the hikes on the map. */
   const val STROKE_WIDTH = 10f
+
+  // These are the limits of the map. They are defined by the latitude and longitude values that
+  // the map can display.
+  // The latitude goes from -85 to 85, because going beyond that would (weirdly) let the user see
+  // the blank
+  // The longitude goes from -180 to 180 as it is the standard for the world map.
+  const val MAP_MAX_LATITUDE = 85.0
+  const val MAP_MAX_LONGITUDE = 180.0
+  const val MAP_MIN_LATITUDE = -85.0
+  const val MAP_MIN_LONGITUDE = -180.0
 
   const val MIN_HUE = 0
   const val MAX_HUE = 360
@@ -215,6 +226,13 @@ fun MapScreen(
       zoomController.setVisibility(CustomZoomButtonsController.Visibility.NEVER)
       // Enable touch-controls such as pinch to zoom
       setMultiTouchControls(true)
+      // Limit the scrollable area to avoid the user scrolling too far
+      setScrollableAreaLimitDouble(
+          BoundingBox(
+              MapScreen.MAP_MIN_LATITUDE,
+              MapScreen.MAP_MAX_LONGITUDE,
+              MapScreen.MAP_MAX_LATITUDE,
+              MapScreen.MAP_MIN_LONGITUDE))
     }
   }
   // Keep track of whether a search for hikes is ongoing


### PR DESCRIPTION
Fixed that the user could scroll out of the world by setting bounds

# Summary
The user could scroll out of the world and the the map. In this PR I fixed that by setting bounds at the edge of the world.

# Details
Note that I also changed the `MAP_MIN_ZOOM` as the previous one did let the user go out of the world by full zooming out
