### PR TITLE
fix(auth): add sign in with password in backend

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthRepository.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 interface AuthRepository {
 
   /**
-   * Sign in with Google using Firebase Authentication.
+   * This function should be called to initiate the sign-in process using Google Sign-In.
    *
    * @param onSuccess Callback to invoke when login is successful. Passes the FirebaseUser if
    *   successful.
@@ -32,7 +32,24 @@ interface AuthRepository {
   )
 
   /**
-   * Signs out the current user from Firebase and invokes the success callback.
+   * This function should be called to initiate the sign-in process using email and password.
+   *
+   * @param onSuccess Callback to invoke when login is successful. Passes the FirebaseUser if
+   *   successful.
+   * @param onErrorAction Callback to invoke when an error occurs during login. Passes the Throwable
+   *   error.
+   * @param email The email address of the user.
+   * @param password The password of the user.
+   */
+  fun signInWithEmailAndPassword(
+      onSuccess: (FirebaseUser?) -> Unit,
+      onErrorAction: (Exception) -> Unit,
+      email: String,
+      password: String,
+  )
+
+  /**
+   * Signs out the current user  and invokes the success callback.
    *
    * @param onSuccess Callback to invoke after the user has successfully signed out.
    */

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -44,6 +44,21 @@ class AuthViewModel(private val repository: AuthRepository) : ViewModel() {
     )
   }
 
+  /**
+   * Initiates the sign-in process using email and password.
+   *
+   * @param email The email address of the user.
+   * @param password The password of the user.
+   */
+  fun signInWithEmailAndPassword(email: String, password: String) {
+    repository.signInWithEmailAndPassword(
+        onSuccess = { user: FirebaseUser? -> _currentUser.value = user },
+        onErrorAction = {},
+        email = email,
+        password = password,
+    )
+  }
+
   /** Signs out the current user. On successful sign-out, the _currentUser is set to null. */
   fun signOut() {
     repository.signOut(

--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -21,21 +21,6 @@ import kotlinx.coroutines.launch
 
 class FirebaseAuthRepository : AuthRepository {
 
-  /**
-   * Sign in with Google using Firebase Authentication.
-   *
-   * @param onSuccess Callback to invoke when login is successful. Passes the FirebaseUser if
-   *   successful.
-   * @param onErrorAction Callback to invoke when an error occurs during login. Passes the Throwable
-   *   error.
-   * @param context The Android Context, used for accessing resources and system services.
-   * @param coroutineScope The CoroutineScope to launch the login task in a non-blocking way.
-   * @param credentialManager (Optional) CredentialManager for handling credential requests. Pass
-   *   explicitly when testing with mocks.
-   * @param startAddAccountIntentLauncher (Optional) to handle the scenario where no Google
-   *   credentials are found on the device. When `NoCredentialException` is thrown, this launcher
-   *   prompts the user to add a Google account.
-   */
   override fun signInWithGoogle(
       onSuccess: (FirebaseUser?) -> Unit,
       onErrorAction: (Exception) -> Unit,
@@ -107,11 +92,22 @@ class FirebaseAuthRepository : AuthRepository {
     return intent
   }
 
-  /**
-   * Signs out the current user from Firebase and invokes the success callback.
-   *
-   * @param onSuccess Callback to invoke after the user has successfully signed out.
-   */
+  override fun signInWithEmailAndPassword(
+      onSuccess: (FirebaseUser?) -> Unit,
+      onErrorAction: (Exception) -> Unit,
+      email: String,
+      password: String
+  ) {
+    val auth = FirebaseAuth.getInstance()
+    auth.signInWithEmailAndPassword(email, password).addOnCompleteListener { task ->
+      if (task.isSuccessful) {
+        onSuccess(auth.currentUser)
+      } else {
+        onErrorAction(task.exception ?: Exception("Unknown error"))
+      }
+    }
+  }
+
   override fun signOut(onSuccess: () -> Unit) {
     Firebase.auth.signOut()
     onSuccess()

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -128,6 +128,60 @@ class AuthViewModelTest {
   }
 
   @Test
+  fun signInWithEmailAndPassword_calls_repository_and_updates_currentUser_on_success() = runTest {
+    setupSignedOutUser()
+
+    // Simulate a successful email and password sign-in by invoking the onSuccess callback
+    doAnswer { invocation ->
+          val onSuccess = invocation.getArgument<(FirebaseUser?) -> Unit>(0)
+          onSuccess(mockFirebaseUser) // Call the success callback with a mock user
+          null
+        }
+        .`when`(mockRepository)
+        .signInWithEmailAndPassword(any(), any(), any(), any())
+
+    // Verify that currentUser is initially null
+    assertNull(viewModel.currentUser.first())
+
+    viewModel.signInWithEmailAndPassword("mock@example.com", "password")
+
+    val currentUser = viewModel.currentUser.first() // Get the first (current) value of the flow
+
+    // Verify call to the repository
+    verify(mockRepository).signInWithEmailAndPassword(any(), any(), any(), any())
+
+    assertEquals(mockFirebaseUser, currentUser)
+  }
+
+  @Test
+  fun signInWithEmailAndPassword_calls_repository_and_does_not_update_currentUser_on_error() =
+      runTest {
+        setupSignedOutUser()
+
+        // Simulate an unsuccessful email and password sign-in by invoking the onError callback
+        doAnswer { invocation ->
+              val onErrorAction = invocation.getArgument<(Exception) -> Unit>(1)
+              onErrorAction(Exception("Error"))
+              null
+            }
+            .`when`(mockRepository)
+            .signInWithEmailAndPassword(any(), any(), any(), any())
+
+        // Verify that currentUser is initially null
+        assertNull(viewModel.currentUser.first())
+
+        viewModel.signInWithEmailAndPassword("mock@example.com", "password")
+
+        val currentUser = viewModel.currentUser.first()
+
+        // Verify call to the repository
+        verify(mockRepository).signInWithEmailAndPassword(any(), any(), any(), any())
+
+        // Confirm that currentUser is still null
+        assertNull(currentUser)
+      }
+
+  @Test
   fun signOut_calls_repository_signOut_and_updates_currentUser_to_null() = runTest {
     setupSignedInUser()
 


### PR DESCRIPTION
# Summary
Added functions into the `FirebaseAuthRepository` and `AuthViewModel` in order to sign in with email and password to firebase.

# Details
I also removed some comments from `FirebaseAuthRepository` as they were in `AuthRepository`