### PR TITLE
feat(auth): implement the sign in screen

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.MainActivity
-import ch.hikemate.app.ui.auth.TEST_TAG_LOGIN_BUTTON
+import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.map.MapScreen.TEST_TAG_MAP
 import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import ch.hikemate.app.ui.navigation.Screen.PROFILE
@@ -30,13 +30,14 @@ class EndToEndTest : TestCase() {
   @Test
   fun test() {
     // Check that we are on the login screen
-    composeTestRule.onNodeWithTag(TEST_TAG_LOGIN_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).assertIsDisplayed()
 
     // Click on the login button
-    composeTestRule.onNodeWithTag(TEST_TAG_LOGIN_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).performClick()
 
     // Check that we are not on the login screen anymore
-    composeTestRule.onNodeWithTag(TEST_TAG_LOGIN_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).assertIsNotDisplayed()
 
     // Check that we are on the map
     composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.HikeMateApp
-import ch.hikemate.app.ui.auth.TEST_TAG_LOGIN_BUTTON
+import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.TEST_TAG_DRAWER_ITEM_PREFIX
@@ -35,7 +35,7 @@ class HikeMateAppNavigationTest {
 
     composeTestRule.onNodeWithTag(Screen.AUTH).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_LOGIN_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).performClick()
     composeTestRule.onNodeWithTag(Screen.MAP).assertIsDisplayed()
   }
 
@@ -44,7 +44,7 @@ class HikeMateAppNavigationTest {
     composeTestRule.setContent { HikeMateApp() }
     composeTestRule.onNodeWithTag(Screen.AUTH).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_LOGIN_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).performClick()
     composeTestRule.onNodeWithTag(Screen.MAP).assertIsDisplayed()
 
     // Open the sidebar
@@ -60,7 +60,7 @@ class HikeMateAppNavigationTest {
     composeTestRule.setContent { HikeMateApp() }
     composeTestRule.onNodeWithTag(Screen.AUTH).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_LOGIN_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).performClick()
     composeTestRule.onNodeWithTag(Screen.MAP).assertIsDisplayed()
 
     // Open the sidebar

--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.espresso.intent.Intents
 import ch.hikemate.app.MainActivity
+import ch.hikemate.app.ui.components.AppIcon
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.After
 import org.junit.Before
@@ -29,12 +30,15 @@ class SignInScreenTest : TestCase() {
 
   @Test
   fun everythingIsOnScreen() {
-    composeTestRule.onNodeWithTag("appIcon").assertIsDisplayed()
+    composeTestRule.onNodeWithTag(AppIcon.TEST_TAG).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("appNameText").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("appNameText").assertTextEquals("HikeMate")
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_TITLE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_TITLE).assertTextEquals("HikeMate")
 
-    composeTestRule.onNodeWithTag("loginButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("loginButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL).assertHasClickAction()
+
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE).assertHasClickAction()
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInWithEmailScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInWithEmailScreenTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 class SignInWithEmailScreenTest : TestCase() {
@@ -24,6 +25,9 @@ class SignInWithEmailScreenTest : TestCase() {
   private lateinit var navigationActions: NavigationActions
   private lateinit var authRepository: AuthRepository
   private lateinit var authViewModel: AuthViewModel
+
+  private val TEST_EMAIL = "test@example.com"
+  private val TEST_PASSWORD = "password"
 
   @Before
   fun setUp() {
@@ -52,22 +56,23 @@ class SignInWithEmailScreenTest : TestCase() {
   fun canWriteToEmailAndPasswordFields() {
     composeTestRule
         .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT)
-        .performTextInput("test@gmail.com")
+        .performTextInput(TEST_EMAIL)
     composeTestRule
         .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT)
-        .performTextInput("password")
+        .performTextInput(TEST_PASSWORD)
   }
 
   @Test
   fun clickOnSignInButton() {
     composeTestRule
         .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT)
-        .performTextInput("test@gmail.com")
+        .performTextInput(TEST_EMAIL)
     composeTestRule
         .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT)
-        .performTextInput("password")
+        .performTextInput(TEST_PASSWORD)
     composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON).performClick()
 
-    verify(authRepository, times(1)).signInWithEmailAndPassword(any(), any(), any(), any())
+    verify(authRepository, times(1))
+        .signInWithEmailAndPassword(any(), any(), eq(TEST_EMAIL), eq(TEST_PASSWORD))
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInWithEmailScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInWithEmailScreenTest.kt
@@ -1,0 +1,73 @@
+package ch.hikemate.app.ui.auth
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import ch.hikemate.app.model.authentication.AuthRepository
+import ch.hikemate.app.model.authentication.AuthViewModel
+import ch.hikemate.app.ui.components.BackButton
+import ch.hikemate.app.ui.navigation.NavigationActions
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+
+class SignInWithEmailScreenTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var authRepository: AuthRepository
+  private lateinit var authViewModel: AuthViewModel
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    authRepository = mock(AuthRepository::class.java)
+    authViewModel = AuthViewModel(authRepository)
+
+    composeTestRule.setContent {
+      SignInWithEmailScreen(navigationActions = navigationActions, authViewModel = authViewModel)
+    }
+  }
+
+  @Test
+  fun everythingIsOnScreen() {
+    composeTestRule.onNodeWithTag(BackButton.BACK_BUTTON_TEST_TAG).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_TITLE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON)
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun canWriteToEmailAndPasswordFields() {
+    composeTestRule
+        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT)
+        .performTextInput("test@gmail.com")
+    composeTestRule
+        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT)
+        .performTextInput("password")
+  }
+
+  @Test
+  fun clickOnSignInButton() {
+    composeTestRule
+        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT)
+        .performTextInput("test@gmail.com")
+    composeTestRule
+        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT)
+        .performTextInput("password")
+    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON).performClick()
+
+    verify(authRepository, times(1)).signInWithEmailAndPassword(any(), any(), any(), any())
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/MainActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/MainActivity.kt
@@ -18,6 +18,7 @@ import ch.hikemate.app.model.authentication.FirebaseAuthRepository
 import ch.hikemate.app.model.profile.ProfileRepositoryDummy
 import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.auth.SignInScreen
+import ch.hikemate.app.ui.auth.SignInWithEmailScreen
 import ch.hikemate.app.ui.map.MapScreen
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
@@ -58,6 +59,9 @@ fun HikeMateApp() {
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(navigationActions) }
+      composable(Screen.SIGN_IN_WITH_EMAIL) {
+        SignInWithEmailScreen(navigationActions, authViewModel)
+      }
     }
 
     navigation(

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -65,10 +65,23 @@ class AuthViewModel(private val repository: AuthRepository) : ViewModel() {
    * @param email The email address of the user.
    * @param password The password of the user.
    */
-  fun signInWithEmailAndPassword(email: String, password: String) {
+  fun signInWithEmailAndPassword(
+      email: String,
+      password: String,
+      onSuccess: () -> Unit,
+      onErrorAction: (Exception) -> Unit
+  ) {
+    if (email.isEmpty() || password.isEmpty()) {
+      onErrorAction(Exception("Email and password must not be empty"))
+      return
+    }
+
     repository.signInWithEmailAndPassword(
-        onSuccess = { user: FirebaseUser? -> _currentUser.value = user },
-        onErrorAction = {},
+        onSuccess = { user: FirebaseUser? ->
+          _currentUser.value = user
+          onSuccess()
+        },
+        onErrorAction = onErrorAction,
         email = email,
         password = password,
     )

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -39,11 +40,16 @@ import ch.hikemate.app.ui.navigation.TopLevelDestinations
 import ch.hikemate.app.ui.theme.kaushanTitleFontFamily
 import ch.hikemate.app.ui.theme.primaryColor
 
-const val TEST_TAG_LOGIN_BUTTON = "loginButton"
+object SignInScreen {
+  const val TEST_TAG_TITLE = "sign_in_title"
+  const val TEST_TAG_SIGN_IN_WITH_EMAIL = "sign_in_with_email_button"
+  const val TEST_TAG_SIGN_IN_WITH_GOOGLE = "sign_in_with_google_button"
+}
 
 /** A composable function to display the sign in screen */
 @Composable
-fun SignInScreen(navigaionActions: NavigationActions) {
+fun SignInScreen(navigationActions: NavigationActions) {
+  val context = LocalContext.current
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(Screen.AUTH),
       content = { padding ->
@@ -76,7 +82,7 @@ fun SignInScreen(navigaionActions: NavigationActions) {
 
               // App name Text
               Text(
-                  modifier = Modifier.testTag("appNameText"),
+                  modifier = Modifier.testTag(SignInScreen.TEST_TAG_TITLE),
                   text = "HikeMate",
                   style =
                       TextStyle(
@@ -88,10 +94,26 @@ fun SignInScreen(navigaionActions: NavigationActions) {
               )
             }
 
-            SignInWithGoogleButton {
-              // TODO: Implement the sign in with Google functionality
-              // This bypasses all security and should not be used in production
-              navigaionActions.navigateTo(TopLevelDestinations.MAP)
+            // Sign in with email button
+            Column {
+              SignInButton(
+                  text = context.getString(R.string.SIGN_IN_WITH_EMAIL),
+                  icon = R.drawable.app_icon,
+                  modifier = Modifier.testTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL),
+              ) {
+                navigationActions.navigateTo(Screen.SIGN_IN_WITH_EMAIL)
+              }
+
+              // Sign in with Google button
+              SignInButton(
+                  text = context.getString(R.string.SIGN_IN_WITH_GOOGLE),
+                  icon = R.drawable.google_logo,
+                  modifier = Modifier.testTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE),
+              ) {
+                // TODO: Implement the sign in with Google functionality
+                // This bypasses all security and should not be used in production
+                navigationActions.navigateTo(TopLevelDestinations.MAP)
+              }
             }
           }
         }
@@ -100,34 +122,41 @@ fun SignInScreen(navigaionActions: NavigationActions) {
 }
 
 /**
- * A composable function to display the sign in with Google button
+ * A composable function to display the sign in with an icon
  *
  * @param onSignInClick A lambda function to handle the sign in click event
+ * @param icon The icon to display on the button
  */
 @Composable
-fun SignInWithGoogleButton(onSignInClick: () -> Unit) {
+fun SignInButton(
+    icon: Int,
+    text: String,
+    modifier: Modifier = Modifier,
+    onSignInClick: () -> Unit
+) {
   Button(
       onClick = onSignInClick,
       colors = ButtonDefaults.buttonColors(containerColor = Color.White),
       shape = RoundedCornerShape(50),
       modifier =
-          Modifier.padding(8.dp)
+          modifier
+              .padding(8.dp)
               .height(48.dp)
-              .border(width = 3.dp, color = primaryColor, shape = RoundedCornerShape(size = 32.dp))
-              .testTag(TEST_TAG_LOGIN_BUTTON)) {
+              .border(
+                  width = 3.dp, color = primaryColor, shape = RoundedCornerShape(size = 32.dp))) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth()) {
               // Load the Google logo from resources
               Image(
-                  painter = painterResource(id = R.drawable.google_logo),
-                  contentDescription = "Google Logo",
+                  painter = painterResource(id = icon),
+                  contentDescription = text,
                   modifier = Modifier.size(30.dp).padding(end = 8.dp))
 
               // Text for the button
               Text(
-                  text = "Sign In with Google",
+                  text = text,
                   color = Color.Black, // Text color
                   fontSize = 18.sp, // Font size
                   fontWeight = FontWeight.Bold,

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,9 +26,9 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,7 +50,6 @@ object SignInScreen {
 /** A composable function to display the sign in screen */
 @Composable
 fun SignInScreen(navigationActions: NavigationActions) {
-  val context = LocalContext.current
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(Screen.AUTH),
       content = { padding ->
@@ -97,7 +97,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
             // Sign in with email button
             Column {
               SignInButton(
-                  text = context.getString(R.string.SIGN_IN_WITH_EMAIL),
+                  text = stringResource(R.string.sign_in_with_email),
                   icon = R.drawable.app_icon,
                   modifier = Modifier.testTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL),
               ) {
@@ -106,7 +106,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
 
               // Sign in with Google button
               SignInButton(
-                  text = context.getString(R.string.SIGN_IN_WITH_GOOGLE),
+                  text = stringResource(R.string.sign_in_with_google),
                   icon = R.drawable.google_logo,
                   modifier = Modifier.testTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_GOOGLE),
               ) {
@@ -125,7 +125,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
  * A composable function to display the sign in with an icon
  *
  * @param onSignInClick A lambda function to handle the sign in click event
- * @param icon The icon to display on the button
+ * @param icon The resource ID of the icon to display on the button
  */
 @Composable
 fun SignInButton(
@@ -136,7 +136,7 @@ fun SignInButton(
 ) {
   Button(
       onClick = onSignInClick,
-      colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+      colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surface),
       shape = RoundedCornerShape(50),
       modifier =
           modifier
@@ -151,13 +151,13 @@ fun SignInButton(
               // Load the Google logo from resources
               Image(
                   painter = painterResource(id = icon),
-                  contentDescription = text,
+                  contentDescription = null,
                   modifier = Modifier.size(30.dp).padding(end = 8.dp))
 
               // Text for the button
               Text(
                   text = text,
-                  color = Color.Black, // Text color
+                  color = MaterialTheme.colorScheme.onSurface, // Text color
                   fontSize = 18.sp, // Font size
                   fontWeight = FontWeight.Bold,
               )

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -1,0 +1,148 @@
+package ch.hikemate.app.ui.auth
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ch.hikemate.app.R
+import ch.hikemate.app.model.authentication.AuthViewModel
+import ch.hikemate.app.ui.components.BackButton
+import ch.hikemate.app.ui.components.BigButton
+import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.navigation.NavigationActions
+import ch.hikemate.app.ui.navigation.Route
+import ch.hikemate.app.ui.navigation.Screen
+import ch.hikemate.app.ui.theme.primaryColor
+
+object SignInWithEmailScreen {
+  const val TEST_TAG_TITLE = "sign_in_with_email_title"
+  const val TEST_TAG_EMAIL_INPUT = "sign_in_with_email_name_input"
+  const val TEST_TAG_PASSWORD_INPUT = "sign_in_with_email_password_input"
+  const val TEST_TAG_SIGN_IN_BUTTON = "sign_in_with_email_sign_in_button"
+  const val TEST_TAG_GO_TO_SIGN_UP_BUTTON = "sign_in_with_email_go_to_sign_up_button"
+}
+
+/**
+ * A composable that displays the sign in with email screen.
+ *
+ * @param navigationActions The navigation actions.
+ * @param authViewModel The authentication view model.
+ */
+@Composable
+fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: AuthViewModel) {
+  val context = LocalContext.current
+
+  // Define the colors for the input fields
+  val inputColors =
+      OutlinedTextFieldDefaults.colors()
+          .copy(
+              focusedLabelColor = primaryColor,
+              focusedIndicatorColor = primaryColor,
+              cursorColor = primaryColor,
+              textSelectionColors =
+                  TextSelectionColors(
+                      handleColor = primaryColor,
+                      backgroundColor = primaryColor,
+                  ))
+
+  // Define the email and password state
+  var email by remember { mutableStateOf("") }
+  var password by remember { mutableStateOf("") }
+
+  Column(
+      modifier =
+          Modifier.testTag(Screen.SIGN_IN_WITH_EMAIL)
+              .padding(
+                  // Add padding to the sidebar padding
+                  start = 16.dp,
+                  end = 16.dp,
+                  top = 16.dp,
+              ),
+      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        BackButton(navigationActions)
+        Text(
+            context.getString(R.string.SIGN_IN_WITH_EMAIL_TITLE),
+            style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 32.sp),
+            modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_TITLE))
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+            colors = inputColors,
+            value = email,
+            onValueChange = { email = it },
+            label = { Text(context.getString(R.string.SIGN_IN_WITH_EMAIL_EMAIL_LABEL)) })
+
+        OutlinedTextField(
+            modifier =
+                Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT),
+            visualTransformation = PasswordVisualTransformation(),
+            colors = inputColors,
+            value = password,
+            onValueChange = { password = it },
+            label = { Text(context.getString(R.string.SIGN_IN_WITH_EMAIL_PASSWORD_LABEL)) })
+
+        BigButton(
+            modifier =
+                Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON),
+            buttonType = ButtonType.PRIMARY,
+            label = context.getString(R.string.SIGN_IN_WITH_EMAIL_SIGN_IN_BUTTON),
+            onClick = {
+              authViewModel.signInWithEmailAndPassword(
+                  email,
+                  password,
+                  onSuccess = {
+                    // Navigate to the map screen
+                    navigationActions.navigateTo(Route.MAP)
+                  },
+                  onErrorAction = {
+                    // Show an error message in a toast
+                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+                  })
+            })
+
+        // Push the sign up button to the bottom of the screen by adding a spacer
+        Spacer(modifier = Modifier.weight(1f))
+
+        Box(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+            contentAlignment = Alignment.Center) {
+              TextButton(
+                  onClick = {
+                    // Navigate to the sign up screen
+                    // navigationActions.navigateTo(Screen.SIGN_UP_WITH_EMAIl)
+                  },
+                  modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON),
+              ) {
+                Text(
+                    context.getString(R.string.SIGN_IN_WITH_EMAIL_GO_TO_SIGN_UP),
+                    style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 16.sp),
+                )
+              }
+            }
+      }
+}

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -85,7 +86,7 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(
-            context.getString(R.string.SIGN_IN_WITH_EMAIL_TITLE),
+            stringResource(R.string.sign_in_with_email_title),
             style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 32.sp),
             modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_TITLE))
 
@@ -95,7 +96,7 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
             colors = inputColors,
             value = email,
             onValueChange = { email = it },
-            label = { Text(context.getString(R.string.SIGN_IN_WITH_EMAIL_EMAIL_LABEL)) })
+            label = { Text(stringResource(R.string.sign_in_with_email_email_label)) })
 
         OutlinedTextField(
             modifier =
@@ -104,13 +105,13 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
             colors = inputColors,
             value = password,
             onValueChange = { password = it },
-            label = { Text(context.getString(R.string.SIGN_IN_WITH_EMAIL_PASSWORD_LABEL)) })
+            label = { Text(stringResource(R.string.sign_in_with_email_password_label)) })
 
         BigButton(
             modifier =
                 Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON),
             buttonType = ButtonType.PRIMARY,
-            label = context.getString(R.string.SIGN_IN_WITH_EMAIL_SIGN_IN_BUTTON),
+            label = stringResource(R.string.sign_in_with_email_sign_in_button),
             onClick = {
               authViewModel.signInWithEmailAndPassword(
                   email,
@@ -139,7 +140,7 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
                   modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON),
               ) {
                 Text(
-                    context.getString(R.string.SIGN_IN_WITH_EMAIL_GO_TO_SIGN_UP),
+                    stringResource(R.string.sign_in_with_email_go_to_sign_up),
                     style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 16.sp),
                 )
               }

--- a/app/src/main/java/ch/hikemate/app/ui/components/AppIcon.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/AppIcon.kt
@@ -9,6 +9,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import ch.hikemate.app.R
 
+object AppIcon {
+  const val TEST_TAG = "appIcon"
+}
+
 /**
  * A composable that displays the app icon.
  *
@@ -19,5 +23,6 @@ fun AppIcon(size: Dp) {
   Image(
       painter = painterResource(id = R.drawable.app_icon),
       contentDescription = "App Logo",
-      modifier = Modifier.size(size).testTag("appIcon"))
+      modifier = Modifier.size(size).testTag(AppIcon.TEST_TAG),
+  )
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -23,6 +23,7 @@ object Screen {
   const val MAP = "Map Screen"
   const val PROFILE = "Profile Screen"
   const val EDIT_PROFILE = "Edit-profile Screen"
+  const val SIGN_IN_WITH_EMAIL = "Sign-in-with-email Screen"
 }
 
 /**

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -19,11 +19,11 @@ object Route {
 /** Object containing screen constants. */
 object Screen {
   const val AUTH = "Auth Screen"
+  const val SIGN_IN_WITH_EMAIL = "Sign-in-with-email Screen"
   const val SAVED_HIKES = "SavedHikes Screen"
   const val MAP = "Map Screen"
   const val PROFILE = "Profile Screen"
   const val EDIT_PROFILE = "Edit-profile Screen"
-  const val SIGN_IN_WITH_EMAIL = "Sign-in-with-email Screen"
 }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,4 +77,14 @@
     <string name="profile_screen_hiking_level_choice_intermediate">Intermediate</string>
     <string name="profile_screen_hiking_level_choice_expert">Expert</string>
     <string name="edit_profile_screen_save_button_text">Save profile</string>
+
+    <!-- Authentication -->
+    <string name="SIGN_IN_WITH_EMAIL">Sign in with Email</string>
+    <string name="SIGN_IN_WITH_GOOGLE">Sign in with Google</string>
+
+    <string name="SIGN_IN_WITH_EMAIL_TITLE">Sign in</string>
+    <string name="SIGN_IN_WITH_EMAIL_EMAIL_LABEL">Email</string>
+    <string name="SIGN_IN_WITH_EMAIL_PASSWORD_LABEL">Password</string>
+    <string name="SIGN_IN_WITH_EMAIL_SIGN_IN_BUTTON">Sign in</string>
+    <string name="SIGN_IN_WITH_EMAIL_GO_TO_SIGN_UP">I want to sign up</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,12 +79,12 @@
     <string name="edit_profile_screen_save_button_text">Save profile</string>
 
     <!-- Authentication -->
-    <string name="SIGN_IN_WITH_EMAIL">Sign in with Email</string>
-    <string name="SIGN_IN_WITH_GOOGLE">Sign in with Google</string>
+    <string name="sign_in_with_email">Sign in with Email</string>
+    <string name="sign_in_with_google">Sign in with Google</string>
 
-    <string name="SIGN_IN_WITH_EMAIL_TITLE">Sign in</string>
-    <string name="SIGN_IN_WITH_EMAIL_EMAIL_LABEL">Email</string>
-    <string name="SIGN_IN_WITH_EMAIL_PASSWORD_LABEL">Password</string>
-    <string name="SIGN_IN_WITH_EMAIL_SIGN_IN_BUTTON">Sign in</string>
-    <string name="SIGN_IN_WITH_EMAIL_GO_TO_SIGN_UP">I want to sign up</string>
+    <string name="sign_in_with_email_title">Sign in</string>
+    <string name="sign_in_with_email_email_label">Email</string>
+    <string name="sign_in_with_email_password_label">Password</string>
+    <string name="sign_in_with_email_sign_in_button">Sign in</string>
+    <string name="sign_in_with_email_go_to_sign_up">I want to sign up</string>
 </resources>

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -143,7 +144,8 @@ class AuthViewModelTest {
     // Verify that currentUser is initially null
     assertNull(viewModel.currentUser.first())
 
-    viewModel.signInWithEmailAndPassword("mock@example.com", "password", {}, {})
+    viewModel.signInWithEmailAndPassword(
+        "mock@example.com", "password", {}, { fail("Error callback should not be called") })
 
     val currentUser = viewModel.currentUser.first() // Get the first (current) value of the flow
 
@@ -170,7 +172,8 @@ class AuthViewModelTest {
         // Verify that currentUser is initially null
         assertNull(viewModel.currentUser.first())
 
-        viewModel.signInWithEmailAndPassword("mock@example.com", "password", {}, {})
+        viewModel.signInWithEmailAndPassword(
+            "mock@example.com", "password", { fail("Success callback should not be called") }, {})
 
         val currentUser = viewModel.currentUser.first()
 

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -143,7 +143,7 @@ class AuthViewModelTest {
     // Verify that currentUser is initially null
     assertNull(viewModel.currentUser.first())
 
-    viewModel.signInWithEmailAndPassword("mock@example.com", "password")
+    viewModel.signInWithEmailAndPassword("mock@example.com", "password", {}, {})
 
     val currentUser = viewModel.currentUser.first() // Get the first (current) value of the flow
 
@@ -170,7 +170,7 @@ class AuthViewModelTest {
         // Verify that currentUser is initially null
         assertNull(viewModel.currentUser.first())
 
-        viewModel.signInWithEmailAndPassword("mock@example.com", "password")
+        viewModel.signInWithEmailAndPassword("mock@example.com", "password", {}, {})
 
         val currentUser = viewModel.currentUser.first()
 


### PR DESCRIPTION
# Summary
Implemented the sign in with password screen so that a user can sign in without Google.
In this PR I also fixed some typos which were in the same code base as I was working on. I also fixed some old bad practices.

# Details
The create account is not implemented yet. You can try to sign in with a fake account which email is
"testing@gmail.com" and password "123123"

I will delete this user as soon as this PR is done. It is not a bad thing for it to exist for now as the user can not create or modify any data.