### PR TITLE
feat(auth): implement the create account screen

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/CreateAccountScreenTest.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.ui.auth
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -28,6 +29,7 @@ class CreateAccountScreenTest : TestCase() {
 
   private val TEST_NAME = "Test Name"
   private val TEST_EMAIL = "test@example.com"
+  private val TEST_WRONG_EMAIL = "test"
   private val TEST_PASSWORD = "password"
   private val TEST_DIFFERENT_PASSWORD = "different_password"
 
@@ -68,7 +70,14 @@ class CreateAccountScreenTest : TestCase() {
         .performTextInput(TEST_PASSWORD)
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
-        .performTextInput(TEST_PASSWORD)
+        .performTextInput(TEST_DIFFERENT_PASSWORD)
+
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .assertTextContains(TEST_NAME)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT)
+        .assertTextContains(TEST_EMAIL)
   }
 
   @Test
@@ -89,6 +98,32 @@ class CreateAccountScreenTest : TestCase() {
 
     verify(authRepository, times(1))
         .createAccountWithEmailAndPassword(any(), any(), eq(TEST_EMAIL), eq(TEST_PASSWORD))
+  }
+
+  @Test
+  fun clickOnCreateAccountButtonWithEmptyFields() {
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
+
+    verify(authRepository, times(0)).createAccountWithEmailAndPassword(any(), any(), any(), any())
+  }
+
+  @Test
+  fun clickOnCreateAccountWithDummyEmail() {
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .performTextInput(TEST_NAME)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT)
+        .performTextInput(TEST_WRONG_EMAIL)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
+
+    verify(authRepository, times(0)).createAccountWithEmailAndPassword(any(), any(), any(), any())
   }
 
   @Test

--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/CreateAccountScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/CreateAccountScreenTest.kt
@@ -1,0 +1,113 @@
+package ch.hikemate.app.ui.auth
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import ch.hikemate.app.model.authentication.AuthRepository
+import ch.hikemate.app.model.authentication.AuthViewModel
+import ch.hikemate.app.ui.components.BackButton
+import ch.hikemate.app.ui.navigation.NavigationActions
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+class CreateAccountScreenTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var authRepository: AuthRepository
+  private lateinit var authViewModel: AuthViewModel
+
+  private val TEST_NAME = "Test Name"
+  private val TEST_EMAIL = "test@example.com"
+  private val TEST_PASSWORD = "password"
+  private val TEST_DIFFERENT_PASSWORD = "different_password"
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    authRepository = mock(AuthRepository::class.java)
+    authViewModel = AuthViewModel(authRepository)
+
+    composeTestRule.setContent {
+      CreateAccountScreen(navigationActions = navigationActions, authViewModel = authViewModel)
+    }
+  }
+
+  @Test
+  fun everythingIsOnScreen() {
+    composeTestRule.onNodeWithTag(BackButton.BACK_BUTTON_TEST_TAG).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_TITLE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).assertIsDisplayed()
+  }
+
+  @Test
+  fun canWriteToAllFields() {
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .performTextInput(TEST_NAME)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT)
+        .performTextInput(TEST_EMAIL)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+  }
+
+  @Test
+  fun clickOnCreateAccountButton() {
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .performTextInput(TEST_NAME)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT)
+        .performTextInput(TEST_EMAIL)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
+
+    verify(authRepository, times(1))
+        .createAccountWithEmailAndPassword(any(), any(), eq(TEST_EMAIL), eq(TEST_PASSWORD))
+  }
+
+  @Test
+  fun clickOnCreateAccountButtonWithDifferentPasswords() {
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .performTextInput(TEST_NAME)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT)
+        .performTextInput(TEST_EMAIL)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT)
+        .performTextInput(TEST_PASSWORD)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .performTextInput(TEST_DIFFERENT_PASSWORD)
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
+
+    verify(authRepository, times(0))
+        .createAccountWithEmailAndPassword(any(), any(), eq(TEST_EMAIL), eq(TEST_PASSWORD))
+  }
+}

--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInWithEmailScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInWithEmailScreenTest.kt
@@ -73,6 +73,6 @@ class SignInWithEmailScreenTest : TestCase() {
     composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON).performClick()
 
     verify(authRepository, times(1))
-        .signInWithEmailAndPassword(any(), any(), eq(TEST_EMAIL), eq(TEST_PASSWORD))
+        .signInWithEmailAndPassword(eq(TEST_EMAIL), eq(TEST_PASSWORD), any(), any())
   }
 }

--- a/app/src/main/java/ch/hikemate/app/MainActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/MainActivity.kt
@@ -17,6 +17,7 @@ import ch.hikemate.app.model.authentication.AuthViewModel
 import ch.hikemate.app.model.authentication.FirebaseAuthRepository
 import ch.hikemate.app.model.profile.ProfileRepositoryDummy
 import ch.hikemate.app.model.profile.ProfileViewModel
+import ch.hikemate.app.ui.auth.CreateAccountScreen
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
 import ch.hikemate.app.ui.map.MapScreen
@@ -62,6 +63,7 @@ fun HikeMateApp() {
       composable(Screen.SIGN_IN_WITH_EMAIL) {
         SignInWithEmailScreen(navigationActions, authViewModel)
       }
+      composable(Screen.CREATE_ACCOUNT) { CreateAccountScreen(navigationActions, authViewModel) }
     }
 
     navigation(

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthRepository.kt
@@ -59,10 +59,10 @@ interface AuthRepository {
    * @param password The password of the user.
    */
   fun signInWithEmailAndPassword(
-      onSuccess: (FirebaseUser?) -> Unit,
-      onErrorAction: (Exception) -> Unit,
       email: String,
       password: String,
+      onSuccess: (FirebaseUser?) -> Unit,
+      onErrorAction: (Exception) -> Unit,
   )
 
   /**

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -50,10 +50,22 @@ class AuthViewModel(private val repository: AuthRepository) : ViewModel() {
    * @param email The email address of the user.
    * @param password The password of the user.
    */
-  fun createAccountWithEmailAndPassword(email: String, password: String) {
+  fun createAccountWithEmailAndPassword(
+      email: String,
+      password: String,
+      onSuccess: () -> Unit,
+      onErrorAction: (Exception) -> Unit
+  ) {
+    if (email.isEmpty() || password.isEmpty()) {
+      onErrorAction(Exception("Email and password must not be empty"))
+      return
+    }
     repository.createAccountWithEmailAndPassword(
-        onSuccess = { user: FirebaseUser? -> _currentUser.value = user },
-        onErrorAction = {},
+        onSuccess = { user: FirebaseUser? ->
+          _currentUser.value = user
+          onSuccess()
+        },
+        onErrorAction = onErrorAction,
         email = email,
         password = password,
     )

--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -107,10 +107,10 @@ class FirebaseAuthRepository : AuthRepository {
   }
 
   override fun signInWithEmailAndPassword(
+      email: String,
+      password: String,
       onSuccess: (FirebaseUser?) -> Unit,
       onErrorAction: (Exception) -> Unit,
-      email: String,
-      password: String
   ) {
     val auth = FirebaseAuth.getInstance()
     auth.signInWithEmailAndPassword(email, password).addOnCompleteListener { task ->

--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -2,9 +2,7 @@ package ch.hikemate.app.ui.auth
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
@@ -12,13 +10,11 @@ import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -39,23 +35,27 @@ import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.theme.primaryColor
 
-object SignInWithEmailScreen {
-  const val TEST_TAG_TITLE = "sign_in_with_email_title"
-  const val TEST_TAG_EMAIL_INPUT = "sign_in_with_email_name_input"
-  const val TEST_TAG_PASSWORD_INPUT = "sign_in_with_email_password_input"
-  const val TEST_TAG_SIGN_IN_BUTTON = "sign_in_with_email_sign_in_button"
-  const val TEST_TAG_GO_TO_SIGN_UP_BUTTON = "sign_in_with_email_go_to_sign_up_button"
+object CreateAccountScreen {
+  const val TEST_TAG_TITLE = "create_account_title"
+  const val TEST_TAG_NAME_INPUT = "create_account_name_input"
+  const val TEST_TAG_EMAIL_INPUT = "create_account_email_input"
+  const val TEST_TAG_PASSWORD_INPUT = "create_account_password_input"
+  const val TEST_TAG_CONFIRM_PASSWORD_INPUT = "create_account_confirm_password_input"
+  const val TEST_TAG_SIGN_UP_BUTTON = "create_account_sign_up_button"
 }
 
 /**
- * A composable that displays the sign in with email screen.
+ * A composable that displays the create account.
  *
  * @param navigationActions The navigation actions.
  * @param authViewModel The authentication view model.
  */
 @Composable
-fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: AuthViewModel) {
+fun CreateAccountScreen(navigationActions: NavigationActions, authViewModel: AuthViewModel) {
   val context = LocalContext.current
+
+  // Define it here because it's used in the onClick lambda which is not a composable
+  val mismatchErrorMessage = stringResource(R.string.create_account_password_mismatch_error)
 
   // Define the colors for the input fields
   val inputColors =
@@ -70,13 +70,14 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
                       backgroundColor = primaryColor,
                   ))
 
-  // Define the email and password state
+  var name by remember { mutableStateOf("") }
   var email by remember { mutableStateOf("") }
   var password by remember { mutableStateOf("") }
+  var confirmPassword by remember { mutableStateOf("") }
 
   Column(
       modifier =
-          Modifier.testTag(Screen.SIGN_IN_WITH_EMAIL)
+          Modifier.testTag(Screen.CREATE_ACCOUNT)
               .padding(
                   // Add padding to the sidebar padding
                   start = 16.dp,
@@ -86,64 +87,64 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(
-            stringResource(R.string.sign_in_with_email_title),
+            stringResource(R.string.create_account_title),
             style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 32.sp),
-            modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_TITLE))
+            modifier = Modifier.testTag(CreateAccountScreen.TEST_TAG_TITLE))
 
         OutlinedTextField(
-            modifier = Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT),
+            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_NAME_INPUT),
+            colors = inputColors,
+            value = name,
+            onValueChange = { name = it },
+            label = { Text(stringResource(R.string.create_account_name_label)) })
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
             colors = inputColors,
             value = email,
             onValueChange = { email = it },
-            label = { Text(stringResource(R.string.sign_in_with_email_email_label)) })
+            label = { Text(stringResource(R.string.create_account_email_label)) })
 
         OutlinedTextField(
-            modifier =
-                Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT),
+            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT),
             visualTransformation = PasswordVisualTransformation(),
             colors = inputColors,
             value = password,
             onValueChange = { password = it },
-            label = { Text(stringResource(R.string.sign_in_with_email_password_label)) })
+            label = { Text(stringResource(R.string.create_account_password_label)) })
+
+        OutlinedTextField(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .testTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT),
+            visualTransformation = PasswordVisualTransformation(),
+            colors = inputColors,
+            value = confirmPassword,
+            onValueChange = { confirmPassword = it },
+            label = { Text(stringResource(R.string.create_account_repeat_password_label)) })
 
         BigButton(
-            modifier =
-                Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON),
+            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON),
             buttonType = ButtonType.PRIMARY,
-            label = stringResource(R.string.sign_in_with_email_sign_in_button),
+            label = stringResource(R.string.create_account_create_account_button),
             onClick = {
-              authViewModel.signInWithEmailAndPassword(
-                  email,
-                  password,
-                  onSuccess = {
-                    // Navigate to the map screen
-                    navigationActions.navigateTo(Route.MAP)
-                  },
-                  onErrorAction = {
-                    // Show an error message in a toast
-                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
-                  })
-            })
-
-        // Push the sign up button to the bottom of the screen by adding a spacer
-        Spacer(modifier = Modifier.weight(1f))
-
-        Box(
-            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
-            contentAlignment = Alignment.Center) {
-              TextButton(
-                  onClick = {
-                    // Navigate to the sign up screen
-                    navigationActions.navigateTo(Screen.CREATE_ACCOUNT)
-                  },
-                  modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON),
-              ) {
-                Text(
-                    stringResource(R.string.sign_in_with_email_go_to_sign_up),
-                    style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 16.sp),
-                )
+              if (password != confirmPassword) {
+                // Show an error message in a toast
+                Toast.makeText(context, mismatchErrorMessage, Toast.LENGTH_SHORT).show()
+              } else {
+                authViewModel.createAccountWithEmailAndPassword(
+                    email,
+                    password,
+                    onSuccess = {
+                      // Navigate to the map screen
+                      navigationActions.navigateTo(Route.MAP)
+                    },
+                    onErrorAction = {
+                      // Show an error message in a toast
+                      Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+                    })
               }
-            }
+            })
       }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -56,6 +56,9 @@ fun CreateAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
 
   // Define it here because it's used in the onClick lambda which is not a composable
   val mismatchErrorMessage = stringResource(R.string.create_account_password_mismatch_error)
+  val emailWrongFormatErrorMessage = stringResource(R.string.create_account_email_format_error)
+  val fieldMustBeFilledErrorMessage =
+      stringResource(R.string.create_account_fields_must_be_filled_error)
 
   // Define the colors for the input fields
   val inputColors =
@@ -74,6 +77,33 @@ fun CreateAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
   var email by remember { mutableStateOf("") }
   var password by remember { mutableStateOf("") }
   var confirmPassword by remember { mutableStateOf("") }
+
+  val onSignUpButtonClick = {
+    when {
+      password != confirmPassword -> {
+        Toast.makeText(context, mismatchErrorMessage, Toast.LENGTH_SHORT).show()
+      }
+      email.isEmpty() || password.isEmpty() || name.isEmpty() -> {
+        Toast.makeText(context, fieldMustBeFilledErrorMessage, Toast.LENGTH_SHORT).show()
+      }
+      !email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$".toRegex()) -> {
+        Toast.makeText(context, emailWrongFormatErrorMessage, Toast.LENGTH_SHORT).show()
+      }
+      else -> {
+        authViewModel.createAccountWithEmailAndPassword(
+            email,
+            password,
+            onSuccess = {
+              // Navigate to the map screen
+              navigationActions.navigateTo(Route.MAP)
+            },
+            onErrorAction = {
+              // Show an error message in a toast
+              Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+            })
+      }
+    }
+  }
 
   Column(
       modifier =
@@ -128,23 +158,7 @@ fun CreateAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
             modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON),
             buttonType = ButtonType.PRIMARY,
             label = stringResource(R.string.create_account_create_account_button),
-            onClick = {
-              if (password != confirmPassword) {
-                // Show an error message in a toast
-                Toast.makeText(context, mismatchErrorMessage, Toast.LENGTH_SHORT).show()
-              } else {
-                authViewModel.createAccountWithEmailAndPassword(
-                    email,
-                    password,
-                    onSuccess = {
-                      // Navigate to the map screen
-                      navigationActions.navigateTo(Route.MAP)
-                    },
-                    onErrorAction = {
-                      // Show an error message in a toast
-                      Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
-                    })
-              }
-            })
+            onClick = onSignUpButtonClick,
+        )
       }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/NavigationActions.kt
@@ -20,6 +20,7 @@ object Route {
 object Screen {
   const val AUTH = "Auth Screen"
   const val SIGN_IN_WITH_EMAIL = "Sign-in-with-email Screen"
+  const val CREATE_ACCOUNT = "Create-account Screen"
   const val SAVED_HIKES = "SavedHikes Screen"
   const val MAP = "Map Screen"
   const val PROFILE = "Profile Screen"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,4 +87,12 @@
     <string name="sign_in_with_email_password_label">Password</string>
     <string name="sign_in_with_email_sign_in_button">Sign in</string>
     <string name="sign_in_with_email_go_to_sign_up">I want to sign up</string>
+
+    <string name="create_account_title">Create an account</string>
+    <string name="create_account_name_label">Name</string>
+    <string name="create_account_email_label">Email</string>
+    <string name="create_account_password_label">Password</string>
+    <string name="create_account_repeat_password_label">Repeat password</string>
+    <string name="create_account_create_account_button">Create account</string>
+    <string name="create_account_password_mismatch_error">Passwords do not match</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,6 @@
     <string name="create_account_repeat_password_label">Repeat password</string>
     <string name="create_account_create_account_button">Create account</string>
     <string name="create_account_password_mismatch_error">Passwords do not match</string>
+    <string name="create_account_email_format_error">Invalid email format</string>
+    <string name="create_account_fields_must_be_filled_error">All fields must be filled</string>
 </resources>

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -134,7 +134,7 @@ class AuthViewModelTest {
 
     // Simulate a successful email and password sign-in by invoking the onSuccess callback
     doAnswer { invocation ->
-          val onSuccess = invocation.getArgument<(FirebaseUser?) -> Unit>(0)
+          val onSuccess = invocation.getArgument<(FirebaseUser?) -> Unit>(2)
           onSuccess(mockFirebaseUser) // Call the success callback with a mock user
           null
         }
@@ -162,7 +162,7 @@ class AuthViewModelTest {
 
         // Simulate an unsuccessful email and password sign-in by invoking the onError callback
         doAnswer { invocation ->
-              val onErrorAction = invocation.getArgument<(Exception) -> Unit>(1)
+              val onErrorAction = invocation.getArgument<(Exception) -> Unit>(3)
               onErrorAction(Exception("Error"))
               null
             }

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -202,7 +202,8 @@ class AuthViewModelTest {
         // Verify that currentUser is initially null
         assertNull(viewModel.currentUser.first())
 
-        viewModel.createAccountWithEmailAndPassword("mock@example.com", "password")
+        viewModel.createAccountWithEmailAndPassword(
+            "mock@example.com", "password", {}, { fail("Error callback should not be called") })
 
         val currentUser = viewModel.currentUser.first() // Get the first (current) value of the flow
 
@@ -230,7 +231,8 @@ class AuthViewModelTest {
         // Verify that currentUser is initially null
         assertNull(viewModel.currentUser.first())
 
-        viewModel.createAccountWithEmailAndPassword("mock@example.com", "password")
+        viewModel.createAccountWithEmailAndPassword(
+            "mock@example.com", "password", { fail("Success callback should not be called") }, {})
 
         val currentUser = viewModel.currentUser.first()
 


### PR DESCRIPTION


# Summary
Implemented the create account screen so that a user can create an account without Google.

Nothing more to say. The code is quite straightforward.
