### PR TITLE
fix: allow new google accounts to sign up

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -37,6 +37,7 @@ class FirebaseAuthRepository : AuthRepository {
     // client ID
     val googleIdOption: GetGoogleIdOption =
         GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false) // Allow all kinds of Google accounts
             .setServerClientId(token) // Server client ID for OAuth
             .setAutoSelectEnabled(true) // Auto-select if only one account is available
             .build()


### PR DESCRIPTION
# Summary
By default, Google Sign in limits the sign in to accounts already registered once. This PR fix it
