### PR TITLE
fix(auth): fix go to map directly when signed in

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/auth/SignInScreenTest.kt
@@ -77,8 +77,7 @@ class SignInScreenTest : TestCase() {
 
   @Test
   fun whenUserIsSignedIn_navigatesToMap() {
-    val mockUser = mockk<FirebaseUser>(relaxed = true)
-    mockUserStateFlow.value = mockUser
+    every { mockAuthViewModel.isUserLoggedIn() } returns true
 
     setupSignInScreen()
 

--- a/app/src/main/java/ch/hikemate/app/MainActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/MainActivity.kt
@@ -54,45 +54,52 @@ fun HikeMateApp() {
 
   val authViewModel = AuthViewModel(FirebaseAuthRepository())
 
-  NavHost(navController = navController, startDestination = TopLevelDestinations.AUTH.route) {
-    navigation(
-        startDestination = Screen.AUTH,
-        route = Route.AUTH,
-    ) {
-      composable(Screen.AUTH) { SignInScreen(navigationActions, authViewModel) }
-      composable(Screen.SIGN_IN_WITH_EMAIL) {
-        SignInWithEmailScreen(navigationActions, authViewModel)
-      }
-      composable(Screen.CREATE_ACCOUNT) { CreateAccountScreen(navigationActions, authViewModel) }
-    }
+  val isUserLoggedIn = authViewModel.isUserLoggedIn()
 
-    navigation(
-        startDestination = Screen.SAVED_HIKES,
-        route = Route.SAVED_HIKES,
-    ) {
-      composable(Screen.SAVED_HIKES) { SavedHikesScreen(navigationActions = navigationActions) }
-    }
+  NavHost(
+      navController = navController,
+      startDestination =
+          if (isUserLoggedIn) TopLevelDestinations.MAP.route else TopLevelDestinations.AUTH.route) {
+        navigation(
+            startDestination = Screen.AUTH,
+            route = Route.AUTH,
+        ) {
+          composable(Screen.AUTH) { SignInScreen(navigationActions, authViewModel) }
+          composable(Screen.SIGN_IN_WITH_EMAIL) {
+            SignInWithEmailScreen(navigationActions, authViewModel)
+          }
+          composable(Screen.CREATE_ACCOUNT) {
+            CreateAccountScreen(navigationActions, authViewModel)
+          }
+        }
 
-    navigation(
-        startDestination = Screen.MAP,
-        route = Route.MAP,
-    ) {
-      composable(Screen.MAP) { MapScreen(navigationActions = navigationActions) }
-    }
-    navigation(
-        startDestination = Screen.PROFILE,
-        route = Route.PROFILE,
-    ) {
-      composable(Screen.PROFILE) {
-        ProfileScreen(
-            navigationActions = navigationActions,
-            profileViewModel = profileViewModel,
-            authViewModel = authViewModel)
+        navigation(
+            startDestination = Screen.SAVED_HIKES,
+            route = Route.SAVED_HIKES,
+        ) {
+          composable(Screen.SAVED_HIKES) { SavedHikesScreen(navigationActions = navigationActions) }
+        }
+
+        navigation(
+            startDestination = Screen.MAP,
+            route = Route.MAP,
+        ) {
+          composable(Screen.MAP) { MapScreen(navigationActions = navigationActions) }
+        }
+        navigation(
+            startDestination = Screen.PROFILE,
+            route = Route.PROFILE,
+        ) {
+          composable(Screen.PROFILE) {
+            ProfileScreen(
+                navigationActions = navigationActions,
+                profileViewModel = profileViewModel,
+                authViewModel = authViewModel)
+          }
+          composable(Screen.EDIT_PROFILE) {
+            EditProfileScreen(
+                navigationActions = navigationActions, profileViewModel = profileViewModel)
+          }
+        }
       }
-      composable(Screen.EDIT_PROFILE) {
-        EditProfileScreen(
-            navigationActions = navigationActions, profileViewModel = profileViewModel)
-      }
-    }
-  }
 }

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -22,6 +22,11 @@ class AuthViewModel(private val repository: AuthRepository) : ViewModel() {
   val currentUser: StateFlow<FirebaseUser?>
     get() = _currentUser
 
+  /** Checks if the user is currently logged in. */
+  fun isUserLoggedIn(): Boolean {
+    return _currentUser.value != null
+  }
+
   /**
    * Initiates the sign-in process using Google Sign-In.* Note: This function only changes the state
    * of currentUser, it has no return or onSuccess invocation.

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,8 +49,6 @@ import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.TopLevelDestinations
 import ch.hikemate.app.ui.theme.kaushanTitleFontFamily
 import ch.hikemate.app.ui.theme.primaryColor
-import com.google.firebase.auth.FirebaseUser
-import kotlinx.coroutines.flow.StateFlow
 
 object SignInScreen {
   const val TEST_TAG_TITLE = "sign_in_title"
@@ -67,12 +64,10 @@ private const val CONNECTED_ACCOUNT_MESSAGE =
 fun SignInScreen(
     navigationActions: NavigationActions,
     authViewModel: AuthViewModel,
-    currUserStateFlow: StateFlow<FirebaseUser?> = authViewModel.currentUser
 ) {
 
   val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
-  val currUser = currUserStateFlow.collectAsState().value
 
   // Create the launcher for adding a Google account in case there is no Google account connected
   // to the device. Necessary since the Google sign-in process requires a Google account to be
@@ -88,8 +83,8 @@ fun SignInScreen(
           }
 
   // If the user is already signed in, navigate to the map screen
-  LaunchedEffect(currUser) {
-    if (currUser != null) {
+  LaunchedEffect(authViewModel.isUserLoggedIn()) {
+    if (authViewModel.isUserLoggedIn()) {
       navigationActions.navigateTo(TopLevelDestinations.MAP)
     }
   }


### PR DESCRIPTION
# Summary
Fixed a bug where when a user was logged in, the sign in screen would appear before directing him to the map screen.

# Details
I also cleaned up a little bit the `SignInScreen` as it was receiving a useless parameter that was never used.
Also, a lot of changes in `MainActivity` are due to formatting because I made a line longer.