### PR TITLE
feat(map): add user location features

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,6 +172,7 @@ dependencies {
     implementation(libs.osmdroid)
     implementation(libs.okhttp)
     implementation(libs.googleid)
+    implementation(libs.accompanist.permissions)
 
 
     // Global test dependencies

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,6 +173,7 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.googleid)
     implementation(libs.accompanist.permissions)
+    implementation(libs.play.services.location)
 
 
     // Global test dependencies

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
@@ -18,7 +18,13 @@ import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
 import ch.hikemate.app.ui.components.HikeCard
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.TEST_TAG_SIDEBAR_BUTTON
+import ch.hikemate.app.utils.LocationUtils
+import ch.hikemate.app.utils.MapUtils
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -259,5 +265,45 @@ class MapScreenTest : TestCase() {
     // Check that the search took at most twice the minimal time (only because we mocked it, so it
     // should return quickly)
     assert(endTime - startTime < 2 * MapScreen.MINIMAL_SEARCH_TIME_IN_MS)
+  }
+
+  @OptIn(ExperimentalPermissionsApi::class)
+  @Test
+  fun clickingOnCenterButtonWithPermissionCentersMapOnLocation() {
+    // Given
+    setUpMap()
+    mockkObject(LocationUtils)
+    every { LocationUtils.hasLocationPermission(any()) } returns true
+    mockkObject(MapUtils)
+    every { MapUtils.centerMapOnUserLocation(any(), any(), any()) } returns Unit
+
+    // When
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_CENTER_MAP_BUTTON).performClick()
+
+    // Then
+    io.mockk.verify { MapUtils.centerMapOnUserLocation(any(), any(), any()) }
+  }
+
+  @OptIn(ExperimentalPermissionsApi::class)
+  @Test
+  fun clickingOnCenterButtonWithoutPermissionsAsksForThem() {
+    // Given the user did not grant location permission to the app
+    setUpMap()
+    mockkObject(LocationUtils)
+    every { LocationUtils.hasLocationPermission(any()) } returns false
+
+    // When the user clicks on the "Center map on me" button
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_CENTER_MAP_BUTTON).performClick()
+
+    // Then an alert will be shown to ask for the permission
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_LOCATION_PERMISSION_ALERT).assertIsDisplayed()
+
+    // When the user clicks on the "No thanks" button
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_NO_THANKS_ALERT_BUTTON).performClick()
+
+    // Then the alert disappears
+    composeTestRule
+        .onNodeWithTag(MapScreen.TEST_TAG_LOCATION_PERMISSION_ALERT)
+        .assertIsNotDisplayed()
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
@@ -237,7 +237,6 @@ class MapScreenTest : TestCase() {
     verify(hikesRepository, times(1)).getRoutes(any(), any(), any())
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun searchingHikesTakesAMinimalTime() = runTest {
     setUpMap()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -612,6 +613,15 @@ fun MapScreen(
             Toast.makeText(context, "Error while searching for hikes", Toast.LENGTH_SHORT).show()
           }
         })
+  }
+
+  DisposableEffect(Unit) {
+    onDispose {
+      MapScreen.stopUserLocationUpdates(context, locationUpdatedCallback)
+      mapView.overlays.clear()
+      mapView.onPause()
+      mapView.onDetach()
+    }
   }
 
   SideBarNavigation(

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -388,9 +388,12 @@ fun showHikeOnMap(mapView: MapView, hike: HikeRoute, color: Int) {
  * Clears all hikes that are displayed on the map. Intended to be used when the list of hikes
  * changes and new hikes need to be drawn.
  */
-fun clearHikesFromMap(mapView: MapView) {
-  // TODO : Clear only the hikes, not the user's position
+fun clearHikesFromMap(mapView: MapView, userLocationMarker: Marker?) {
   mapView.overlays.clear()
+
+  // If there was a user location marker, do not clear this
+  userLocationMarker?.let { mapView.overlays.add(it) }
+
   mapView.invalidate()
 }
 
@@ -492,7 +495,7 @@ fun MapScreen(
   // Show hikes on the map
   val routes by hikingRoutesViewModel.hikeRoutes.collectAsState()
   LaunchedEffect(routes) {
-    clearHikesFromMap(mapView)
+    clearHikesFromMap(mapView, userLocationMarker)
     if (routes.size <= MapScreen.MAX_HIKES_DRAWN_ON_MAP) {
       routes.forEach { showHikeOnMap(mapView, it, getRandomColor()) }
       Log.d(MapScreen.LOG_TAG, "Displayed ${routes.size} hikes on the map")

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -552,6 +552,13 @@ fun MapSearchButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
       }
 }
 
+/**
+ * Composable for the "Center on my location" button.
+ *
+ * Represents an icon button with a "My Location" icon. The onclick callback is provided as a
+ * parameter, but the button is meant to be used with the location permission to center the map on
+ * the user's location.
+ */
 @Composable
 fun MapMyLocationButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
   IconButton(

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -477,8 +477,11 @@ fun MapScreen(
           MapScreen.startUserLocationUpdates(context, locationUpdatedCallback)
       if (!featuresEnabledSuccessfully) {
         Log.e(MapScreen.LOG_TAG, "Failed to enable location features")
-        // TODO : Localize the toast's text
-        Toast.makeText(context, "Failed to enable location features", Toast.LENGTH_LONG).show()
+        Toast.makeText(
+                context,
+                context.getString(R.string.map_screen_location_features_failed),
+                Toast.LENGTH_LONG)
+            .show()
       }
     }
 
@@ -605,7 +608,7 @@ fun MapMyLocationButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
   IconButton(onClick = onClick, modifier = modifier) {
     Icon(
         painter = painterResource(id = R.drawable.my_location),
-        contentDescription = "Center map on my position") // TODO : Localize this text
+        contentDescription = stringResource(R.string.map_screen_center_on_pos_content_description))
   }
 }
 

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -187,6 +187,9 @@ object MapScreen {
     clearUserPosition(previous, mapView)
 
     // Create a new marker with the new position
+    // TODO : Make the user location marker centered on the pin's bottom, not the image center
+    // TODO : Make the user location marker look nicer
+    // TODO : Remove the title popup that appears when the marker is clicked
     val newMarker =
         Marker(mapView).apply {
           position = GeoPoint(location.latitude, location.longitude)
@@ -413,6 +416,7 @@ fun clearHikesFromMap(mapView: MapView, userLocationMarker: Marker?) {
   mapView.invalidate()
 }
 
+// TODO : Move as much as possible of the location logic into a view model or a utils object
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun MapScreen(

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -604,12 +605,17 @@ fun MapSearchButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
 
 @Composable
 fun MapMyLocationButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
-  // TODO : Improve the button's appearance
-  IconButton(onClick = onClick, modifier = modifier) {
-    Icon(
-        painter = painterResource(id = R.drawable.my_location),
-        contentDescription = stringResource(R.string.map_screen_center_on_pos_content_description))
-  }
+  IconButton(
+      onClick = onClick,
+      modifier = modifier,
+      colors =
+          IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Icon(
+            painter = painterResource(id = R.drawable.my_location),
+            tint = MaterialTheme.colorScheme.onSurface,
+            contentDescription =
+                stringResource(R.string.map_screen_center_on_pos_content_description))
+      }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -555,7 +555,8 @@ fun MapScreen(
                     Uri.fromParts("package", context.packageName, null)))
           }
         },
-        onDismiss = { showLocationPermissionDialog = false })
+        onDismiss = { showLocationPermissionDialog = false },
+        simpleMessage = !locationPermissionState.shouldShowRationale)
   }
 
   SideBarNavigation(
@@ -630,16 +631,34 @@ fun MapScreen(
 }
 
 @Composable
-fun LocationPermissionAlertDialog(onDismiss: () -> Unit, onConfirm: () -> Unit) {
+fun LocationPermissionAlertDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    simpleMessage: Boolean
+) {
   AlertDialog(
       icon = {
         Icon(painter = painterResource(id = R.drawable.my_location), contentDescription = null)
       },
-      title = { Text(text = "Location Permission Required") },
-      text = { Text(text = "Test") },
+      title = { Text(text = stringResource(R.string.map_screen_location_rationale_title)) },
+      text = {
+        Text(
+            text =
+                stringResource(
+                    if (simpleMessage) R.string.map_screen_location_rationale_simple
+                    else R.string.map_screen_location_rationale))
+      },
       onDismissRequest = onDismiss,
-      confirmButton = { Button(onClick = onConfirm) { Text(text = "Go go go") } },
-      dismissButton = { Button(onClick = onDismiss) { Text(text = "Nope") } })
+      confirmButton = {
+        Button(onClick = onConfirm) {
+          Text(text = stringResource(R.string.map_screen_location_rationale_grant_button))
+        }
+      },
+      dismissButton = {
+        Button(onClick = onDismiss) {
+          Text(text = stringResource(R.string.map_screen_location_rationale_cancel_button))
+        }
+      })
 }
 
 @Composable

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -139,6 +139,20 @@ object MapScreen {
   const val TEST_TAG_SEARCH_LOADING_ANIMATION = "searchLoadingAnimation"
 
   /**
+   * Clears the marker representing the user's position from the map.
+   *
+   * The map is NOT invalidated. If needed, use [org.osmdroid.views.MapView.invalidate].
+   *
+   * To update the user's position to a new location, use [updateUserPosition].
+   *
+   * @param previous The previous marker representing the user's position
+   * @param mapView The map view where the marker is displayed
+   */
+  fun clearUserPosition(previous: Marker?, mapView: MapView) {
+    previous?.let { mapView.overlays.remove(it) }
+  }
+
+  /**
    * Draws a new marker on the map representing the user's position. The previous marker is cleared
    * to avoid duplicates. The map is invalidated to redraw the map with the new marker.
    *
@@ -149,7 +163,7 @@ object MapScreen {
    */
   fun updateUserPosition(previous: Marker?, mapView: MapView, location: Location): Marker {
     // Clear the previous marker to avoid duplicates
-    previous?.let { mapView.overlays.remove(it) }
+    clearUserPosition(previous, mapView)
 
     // Create a new marker with the new position
     val newMarker =
@@ -337,6 +351,10 @@ fun MapScreen(
             .show()
       }
     }
+    // If the user has revoked the permission, clear the user location from the map
+    else {
+      MapScreen.clearUserPosition(userLocationMarker, mapView)
+    }
   }
 
   // Keep track of whether a search for hikes is ongoing
@@ -446,7 +464,8 @@ fun MapScreen(
                 }
                 // If the user yet needs to grant the permission, show a custom educational alert
                 else {
-                  // TODO : Show a custom alert that then requests the permission instead of directly requesting it
+                  // TODO : Show a custom alert that then requests the permission instead of
+                  // directly requesting it
                   locationPermissionState.launchMultiplePermissionRequest()
                 }
               },

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -163,6 +163,10 @@ object MapScreen {
   const val TEST_TAG_EMPTY_HIKES_LIST_MESSAGE = "emptyHikesListMessage"
   const val TEST_TAG_SEARCHING_MESSAGE = "searchingMessage"
   const val TEST_TAG_SEARCH_LOADING_ANIMATION = "searchLoadingAnimation"
+  const val TEST_TAG_CENTER_MAP_BUTTON = "centerMapButton"
+  const val TEST_TAG_LOCATION_PERMISSION_ALERT = "locationPermissionAlert"
+  const val TEST_TAG_NO_THANKS_ALERT_BUTTON = "noThanksAlertButton"
+  const val TEST_TAG_GRANT_ALERT_BUTTON = "grantAlertButton"
 
   const val MINIMAL_SEARCH_TIME_IN_MS = 500 // ms
 
@@ -439,7 +443,8 @@ fun MapScreen(
               },
               modifier =
                   Modifier.align(Alignment.BottomStart)
-                      .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp))
+                      .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp)
+                      .testTag(MapScreen.TEST_TAG_CENTER_MAP_BUTTON))
           // Search button to request OSM for hikes in the displayed area
           if (!isSearching) {
             MapSearchButton(
@@ -482,6 +487,7 @@ fun LocationPermissionAlertDialog(
   if (!show) return
 
   AlertDialog(
+      modifier = Modifier.testTag(MapScreen.TEST_TAG_LOCATION_PERMISSION_ALERT),
       icon = {
         Icon(painter = painterResource(id = R.drawable.my_location), contentDescription = null)
       },
@@ -496,6 +502,7 @@ fun LocationPermissionAlertDialog(
       onDismissRequest = onDismiss,
       confirmButton = {
         Button(
+            modifier = Modifier.testTag(MapScreen.TEST_TAG_GRANT_ALERT_BUTTON),
             onClick = {
               onConfirm()
               // If should show rationale is true, it is safe to launch permission requests
@@ -525,9 +532,11 @@ fun LocationPermissionAlertDialog(
             }
       },
       dismissButton = {
-        Button(onClick = onDismiss) {
-          Text(text = stringResource(R.string.map_screen_location_rationale_cancel_button))
-        }
+        Button(
+            modifier = Modifier.testTag(MapScreen.TEST_TAG_NO_THANKS_ALERT_BUTTON),
+            onClick = onDismiss) {
+              Text(text = stringResource(R.string.map_screen_location_rationale_cancel_button))
+            }
       })
 }
 

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -130,6 +130,13 @@ object MapScreen {
    */
   private const val CENTER_MAP_ANIMATION_TIME = 500L
 
+  /**
+   * (Config) Duration in milliseconds of the animation when centering the map on a marker that was
+   * clicked. This duration is shorter than the center animation, because if the marker was clicked,
+   * it means it is already on the screen, hence the distance is minimal.
+   */
+  private const val CENTER_MAP_ON_MARKER_ANIMATION_TIME = 200L
+
   // These are the limits of the map. They are defined by the
   // latitude values that the map can display.
   // The latitude goes from -85 to 85, because going beyond
@@ -189,11 +196,15 @@ object MapScreen {
     // Create a new marker with the new position
     // TODO : Make the user location marker centered on the pin's bottom, not the image center
     // TODO : Make the user location marker look nicer
-    // TODO : Remove the title popup that appears when the marker is clicked
     val newMarker =
         Marker(mapView).apply {
           position = GeoPoint(location.latitude, location.longitude)
           setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
+          setOnMarkerClickListener { marker, mapView ->
+            mapView.controller.animateTo(
+                marker.position, mapView.zoomLevelDouble, CENTER_MAP_ON_MARKER_ANIMATION_TIME)
+            true
+          }
         }
 
     // Add the new marker to the map

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -448,6 +448,7 @@ fun MapScreen(
                   android.Manifest.permission.ACCESS_FINE_LOCATION,
                   android.Manifest.permission.ACCESS_COARSE_LOCATION))
   var showLocationPermissionDialog by remember { mutableStateOf(false) }
+  var centerMapOnUserPosition by remember { mutableStateOf(false) }
 
   // Only do the configuration on the first composition, not on every recomposition
   LaunchedEffect(Unit) {
@@ -524,10 +525,15 @@ fun MapScreen(
                 Toast.LENGTH_LONG)
             .show()
       }
+      if (centerMapOnUserPosition) {
+        centerMapOnUserPosition = false
+        MapScreen.centerMapOnUserLocation(context, mapView)
+      }
     }
 
     // The user just revoked location permission for the app, stop location features
     else {
+      centerMapOnUserPosition = false
       MapScreen.stopUserLocationUpdates(context, locationUpdatedCallback)
       MapScreen.clearUserPosition(userLocationMarker, mapView, invalidate = true)
     }
@@ -562,6 +568,7 @@ fun MapScreen(
     LocationPermissionAlertDialog(
         onConfirm = {
           showLocationPermissionDialog = false
+          centerMapOnUserPosition = true
 
           // If should show rationale is true, it is safe to launch permission requests
           if (locationPermissionState.shouldShowRationale) {
@@ -586,7 +593,10 @@ fun MapScreen(
                     Uri.fromParts("package", context.packageName, null)))
           }
         },
-        onDismiss = { showLocationPermissionDialog = false },
+        onDismiss = {
+          showLocationPermissionDialog = false
+          centerMapOnUserPosition = false
+        },
         simpleMessage = !locationPermissionState.shouldShowRationale)
   }
 
@@ -653,7 +663,6 @@ fun MapScreen(
                 }
                 // If the user yet needs to grant the permission, show a custom educational alert
                 else {
-                  // TODO : Maintain state so that if the user grants the permission, the map centers on the user's location
                   showLocationPermissionDialog = true
                 }
               },

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -419,7 +419,7 @@ object MapScreen {
             .show()
       }
       if (centerMapOnUserPosition) {
-        centerMapOnUserLocation(context, mapView)
+        centerMapOnUserLocation(context, mapView, userLocationMarker)
       }
     }
 
@@ -430,7 +430,7 @@ object MapScreen {
     }
   }
 
-  fun centerMapOnUserLocation(context: Context, mapView: MapView) {
+  fun centerMapOnUserLocation(context: Context, mapView: MapView, userLocationMarker: Marker?) {
     val fusedLocationClient: FusedLocationProviderClient =
         LocationServices.getFusedLocationProviderClient(context)
 
@@ -443,6 +443,16 @@ object MapScreen {
               centerMapOnUserLocation(mapView, it)
             } else {
               Log.e(LOG_TAG, "Location obtained in centerMapOnUserLocation is null")
+
+              // Clear the user's position on the map
+              clearUserPosition(userLocationMarker, mapView, invalidate = true)
+
+              // Notify the user that they must enable location services
+              Toast.makeText(
+                      context,
+                      context.getString(R.string.map_screen_location_not_available),
+                      Toast.LENGTH_LONG)
+                  .show()
             }
           }
           .addOnFailureListener {
@@ -716,7 +726,7 @@ fun MapScreen(
                 // If the user has granted at least one of the two permissions, center the map on
                 // the user's location
                 if (hasLocationPermission) {
-                  MapScreen.centerMapOnUserLocation(context, mapView)
+                  MapScreen.centerMapOnUserLocation(context, mapView, userLocationMarker)
                 }
                 // If the user yet needs to grant the permission, show a custom educational alert
                 else {

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -195,7 +195,6 @@ object MapScreen {
     clearUserPosition(previous, mapView)
 
     // Create a new marker with the new position
-    // TODO : Make the user location marker centered on the pin's bottom, not the image center
     // TODO : Make the user location marker look nicer
     val newMarker =
         Marker(mapView).apply {
@@ -206,6 +205,7 @@ object MapScreen {
                 marker.position, mapView.zoomLevelDouble, CENTER_MAP_ON_MARKER_ANIMATION_TIME)
             true
           }
+          setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
         }
 
     // Add the new marker to the map

--- a/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
@@ -1,0 +1,220 @@
+package ch.hikemate.app.utils
+
+import android.content.Context
+import android.location.Location
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import ch.hikemate.app.R
+import ch.hikemate.app.ui.map.MapScreen
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.CancellationToken
+import com.google.android.gms.tasks.CancellationTokenSource
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+
+object LocationUtils {
+  private const val LOG_TAG = "LocationUtils"
+
+  /**
+   * Util function to check if the user has granted the location permission.
+   *
+   * Does not check whether fine location permission has been granted, checks that at least coarse
+   * location was granted.
+   *
+   * @param locationPermissionState The state of the location permission
+   * @return True if the user has granted the location permission, false otherwise
+   */
+  @OptIn(ExperimentalPermissionsApi::class)
+  fun hasLocationPermission(locationPermissionState: MultiplePermissionsState): Boolean {
+    return PermissionUtils.anyPermissionGranted(locationPermissionState)
+  }
+
+  fun getUserLocation(
+      context: Context,
+      onLocation: (Location?) -> Unit,
+      priority: Int = Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+      cancellationToken: CancellationToken = CancellationTokenSource().token
+  ) {
+    // Create a client to work with user location
+    val fusedLocationProviderClient: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+
+    try {
+      fusedLocationProviderClient
+          // Ask for the user's current location
+          .getCurrentLocation(priority, cancellationToken)
+          // In case of success, call the callback with the location
+          .addOnSuccessListener { onLocation(it) }
+          // In case of failure, call the callback with null
+          .addOnFailureListener {
+            Log.e(LOG_TAG, "Error while accessing location", it)
+            onLocation(null)
+          }
+    }
+    // If an error occurs (lack of permission), call the callback with null
+    catch (e: SecurityException) {
+      Log.e(LOG_TAG, "Security exception while accessing location", e)
+      onLocation(null)
+    }
+  }
+
+  /**
+   * Starts listening for user location updates. Make sure to stop the updates when they are no
+   * longer needed to avoid draining the battery, or when the permission is revoked.
+   *
+   * This function handles exceptions when the location permission is not granted, but won't disable
+   * updates even if a [SecurityException] is caught. It is up to the caller to handle the exception
+   * and stop the updates if needed.
+   *
+   * @param context The context where the location updates will be requested
+   * @param locationCallback The callback that will be called when the user's location is updated
+   * @see [stopUserLocationUpdates]
+   */
+  fun startUserLocationUpdates(context: Context, locationCallback: LocationCallback): Boolean {
+    // Create a client to work with user location
+    val fusedLocationProviderClient: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+
+    // Calls can produce SecurityExceptions if the permission is not granted
+    try {
+      // Request periodic updates of the user's location when it changes
+      fusedLocationProviderClient.requestLocationUpdates(
+          LocationRequest.Builder(
+                  // Whether to prioritize battery or position accuracy
+                  Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                  // Update interval in milliseconds
+                  MapScreen.USER_LOCATION_UPDATE_INTERVAL)
+              .build(),
+          locationCallback,
+          Looper.getMainLooper())
+
+      Log.d(LOG_TAG, "User location updates requested through FusedLocationProviderClient")
+
+      // Periodic updates were started successfully
+      return true
+    } catch (e: SecurityException) {
+      // Periodic updates could not be started
+      return false
+    }
+  }
+
+  /**
+   * Stops listening for user location updates. Make sure to stop the updates when they are no
+   * longer needed to avoid draining the battery, or when the permission is revoked.
+   *
+   * @param context The context where the location updates were requested
+   * @param locationCallback The callback that was called when the user's location was updated
+   * @see [startUserLocationUpdates]
+   */
+  fun stopUserLocationUpdates(context: Context, locationCallback: LocationCallback) {
+    // Create a client to work with user location
+    val fusedLocationProviderClient: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+
+    // Notify the client we don't want location updates anymore
+    fusedLocationProviderClient.removeLocationUpdates(locationCallback)
+
+    Log.d(LOG_TAG, "User location updates stopped through FusedLocationProviderClient")
+  }
+
+  /**
+   * Handles a user location update received by the location callback.
+   *
+   * Does not display any feedback to the user (toast, ...).
+   *
+   * If no location is available, the user's position is cleared from the map.
+   *
+   * @param locationResult The location update result received by the callback
+   * @param mapView The map view where the user's location will be displayed
+   * @param userLocationMarker The marker representing the user's location on the map
+   * @return The updated user location marker, if any, or null if no position was available.
+   */
+  fun onUserLocationUpdate(
+      locationResult: LocationResult,
+      mapView: MapView,
+      userLocationMarker: Marker?
+  ): Marker? {
+    // Extract the actual location from the update result
+    val location = locationResult.lastLocation
+
+    Log.d(LOG_TAG, "User location update received: $locationResult")
+
+    // The result might be null if the location is not available
+    var result: Marker? = null
+    if (location != null) {
+      // If a new position is available, show it on the map
+      result = MapUtils.updateUserPosition(userLocationMarker, mapView, location)
+    } else {
+      Log.e(LOG_TAG, "User location update contains null location")
+
+      // If no location is available, clear the user's position from the map
+      MapUtils.clearUserPosition(userLocationMarker, mapView, invalidate = true)
+    }
+
+    // Return the updated user location marker, if any
+    return result
+  }
+
+  /**
+   * To be called when the user grants a new location permission or revokes one.
+   *
+   * @param context The context where the location permission was updated
+   * @param locationPermissionState State about the location revoked/granted permissions
+   * @param mapView Map view used to update the user's location or center the map if needed
+   * @param locationUpdatedCallback Callback used to start or stop listening for location updates
+   * @param centerMapOnUserPosition Whether the map should be centered on the user's position
+   * @param userLocationMarker The marker representing the user's location on the map
+   * @return The new value of centerMapOnUserPosition. If the map was centered on the user's
+   *   position, the value will be false, otherwise the same value as provided in parameters will be
+   *   returned.
+   */
+  @OptIn(ExperimentalPermissionsApi::class)
+  fun onLocationPermissionsUpdated(
+      context: Context,
+      locationPermissionState: MultiplePermissionsState,
+      mapView: MapView,
+      locationUpdatedCallback: LocationCallback,
+      centerMapOnUserPosition: Boolean,
+      userLocationMarker: Marker?
+  ) {
+    Log.d(
+        MapScreen.LOG_TAG,
+        "Location permission changed (revoked: ${locationPermissionState.revokedPermissions})")
+    val hasLocationPermission = hasLocationPermission(locationPermissionState)
+
+    // The user just enabled location permission for the app, start location features
+    if (hasLocationPermission) {
+      Log.d(MapScreen.LOG_TAG, "Location permission granted, requesting location updates")
+      PermissionUtils.setFirstTimeAskingPermission(
+          context, android.Manifest.permission.ACCESS_FINE_LOCATION, true)
+      PermissionUtils.setFirstTimeAskingPermission(
+          context, android.Manifest.permission.ACCESS_COARSE_LOCATION, true)
+      val featuresEnabledSuccessfully = startUserLocationUpdates(context, locationUpdatedCallback)
+      if (!featuresEnabledSuccessfully) {
+        Log.e(MapScreen.LOG_TAG, "Failed to enable location features")
+        Toast.makeText(
+                context,
+                context.getString(R.string.map_screen_location_features_failed),
+                Toast.LENGTH_LONG)
+            .show()
+      }
+      if (centerMapOnUserPosition) {
+        MapUtils.centerMapOnUserLocation(context, mapView, userLocationMarker)
+      }
+    }
+
+    // The user just revoked location permission for the app, stop location features
+    else {
+      stopUserLocationUpdates(context, locationUpdatedCallback)
+      MapUtils.clearUserPosition(userLocationMarker, mapView, invalidate = true)
+    }
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
@@ -1,0 +1,142 @@
+package ch.hikemate.app.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.location.Location
+import android.util.Log
+import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
+import ch.hikemate.app.R
+import ch.hikemate.app.ui.map.MapScreen
+import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+
+object MapUtils {
+  private const val LOG_TAG = "MapUtils"
+
+  /**
+   * Clears the marker representing the user's position from the map.
+   *
+   * The map is NOT invalidated. If needed, use [org.osmdroid.views.MapView.invalidate].
+   *
+   * To update the user's position to a new location, use [updateUserPosition].
+   *
+   * @param previous The previous marker representing the user's position
+   * @param mapView The map view where the marker is displayed
+   */
+  fun clearUserPosition(previous: Marker?, mapView: MapView, invalidate: Boolean = false) {
+    previous?.let { mapView.overlays.remove(it) }
+    if (invalidate) {
+      mapView.invalidate()
+    }
+  }
+
+  /**
+   * Get the icon to use for the user's location marker.
+   *
+   * @param context The context where the icon will be used
+   * @return The icon to use for the user's location marker
+   */
+  fun getUserLocationMarkerIcon(context: Context): Drawable {
+    // Retrieve the actual drawable resource
+    val originalDrawable = AppCompatResources.getDrawable(context, R.drawable.user_location)
+
+    // Resize the vector resource to look good on the map
+    val bitmap =
+        Bitmap.createBitmap(
+            MapScreen.USER_LOCATION_MARKER_ICON_SIZE,
+            MapScreen.USER_LOCATION_MARKER_ICON_SIZE,
+            Bitmap.Config.ARGB_8888)
+    val canvas = android.graphics.Canvas(bitmap)
+    originalDrawable?.setBounds(0, 0, canvas.width, canvas.height)
+    originalDrawable?.draw(canvas)
+
+    return BitmapDrawable(context.resources, bitmap)
+  }
+
+  /**
+   * Draws a new marker on the map representing the user's position. The previous marker is cleared
+   * to avoid duplicates. The map is invalidated to redraw the map with the new marker.
+   *
+   * @param previous The previous marker representing the user's position
+   * @param mapView The map view where the marker will be displayed
+   * @param location The new location of the user
+   * @return The new marker representing the user's position
+   */
+  fun updateUserPosition(previous: Marker?, mapView: MapView, location: Location): Marker {
+    // Clear the previous marker to avoid duplicates
+    clearUserPosition(previous, mapView)
+
+    // Create a new marker with the new position
+    val newMarker =
+        Marker(mapView).apply {
+          icon = getUserLocationMarkerIcon(mapView.context)
+          position = GeoPoint(location.latitude, location.longitude)
+          setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
+          setOnMarkerClickListener { marker, mapView ->
+            mapView.controller.animateTo(
+                marker.position,
+                mapView.zoomLevelDouble,
+                MapScreen.CENTER_MAP_ON_MARKER_ANIMATION_TIME)
+            true
+          }
+        }
+
+    // Add the new marker to the map
+    mapView.overlays.add(newMarker)
+    mapView.invalidate()
+
+    return newMarker
+  }
+
+  /**
+   * Retrieves the user's current location and centers the map on it.
+   *
+   * If the location is not available, the user is notified that they must enable location services.
+   *
+   * @param context The context where the location is requested
+   * @param mapView The map view to center
+   * @param userLocationMarker The marker representing the user's location on the map
+   * @see [LocationUtils.getUserLocation]
+   */
+  fun centerMapOnUserLocation(context: Context, mapView: MapView, userLocationMarker: Marker?) {
+    LocationUtils.getUserLocation(
+        context = context,
+        onLocation = { location ->
+          if (location == null) {
+            Log.e(LOG_TAG, "User location is null, cannot center map")
+
+            // Clear the user's position from the map
+            clearUserPosition(userLocationMarker, mapView, invalidate = true)
+
+            // Notify the user that they must enable location services
+            Toast.makeText(
+                    context,
+                    context.getString(R.string.map_screen_location_not_available),
+                    Toast.LENGTH_LONG)
+                .show()
+          } else {
+            // Center the map on the user's location
+            centerMapOnUserLocation(mapView, location)
+          }
+        })
+  }
+
+  /**
+   * Centers the map on the user's location.
+   *
+   * Animates the map so that the transition is smooth and not instant.
+   *
+   * @param mapView The map view to center
+   * @param location The user's location to center the map on
+   */
+  fun centerMapOnUserLocation(mapView: MapView, location: Location) {
+    mapView.controller.animateTo(
+        GeoPoint(location.latitude, location.longitude),
+        mapView.zoomLevelDouble,
+        MapScreen.CENTER_MAP_ANIMATION_TIME)
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/utils/PermissionUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/PermissionUtils.kt
@@ -1,6 +1,8 @@
 package ch.hikemate.app.utils
 
 import android.content.Context
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
 
 /**
  * Utility class for handling permissions.
@@ -41,5 +43,10 @@ object PermissionUtils {
     return context
         .getSharedPreferences(PERMISSIONS_SHARED_PREFERENCES, Context.MODE_PRIVATE)
         .getBoolean(permission, true)
+  }
+
+  @OptIn(ExperimentalPermissionsApi::class)
+  fun anyPermissionGranted(state: MultiplePermissionsState): Boolean {
+    return state.revokedPermissions.size != state.permissions.size
   }
 }

--- a/app/src/main/java/ch/hikemate/app/utils/PermissionUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/PermissionUtils.kt
@@ -1,0 +1,45 @@
+package ch.hikemate.app.utils
+
+import android.content.Context
+
+/**
+ * Utility class for handling permissions.
+ *
+ * Strongly inspired (if not copy-pasted) from this Stack Overflow answer:
+ * https://stackoverflow.com/a/40639430
+ */
+object PermissionUtils {
+  /** The name of the shared preferences file that stores persistent data about permissions. */
+  private const val PERMISSIONS_SHARED_PREFERENCES = "permissions"
+
+  /**
+   * Sets whether the user has been asked for a permission before.
+   *
+   * @param context The context to use.
+   * @param permission The permission to set the first time asking status for.
+   * @param isFirstTime Whether the user has been asked for the permission before.
+   * @see firstTimeAskingPermission
+   */
+  fun setFirstTimeAskingPermission(context: Context, permission: String, isFirstTime: Boolean) {
+    val sharedPreferences =
+        context.getSharedPreferences(PERMISSIONS_SHARED_PREFERENCES, Context.MODE_PRIVATE)
+    sharedPreferences.edit().putBoolean(permission, isFirstTime).apply()
+  }
+
+  /**
+   * Returns whether the user has been asked for a permission before.
+   *
+   * Default value is true, meaning the user has not been asked for the permission before. This is
+   * because the shared preferences entry might never have been set if this is the first time.
+   *
+   * @param context The context to use.
+   * @param permission The permission to check the first time asking status for.
+   * @return Whether the user has been asked for the permission before.
+   * @see setFirstTimeAskingPermission
+   */
+  fun firstTimeAskingPermission(context: Context, permission: String): Boolean {
+    return context
+        .getSharedPreferences(PERMISSIONS_SHARED_PREFERENCES, Context.MODE_PRIVATE)
+        .getBoolean(permission, true)
+  }
+}

--- a/app/src/main/res/drawable/my_location.xml
+++ b/app/src/main/res/drawable/my_location.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,918v-80q-125,-14 -214.5,-103.5T122,520L42,520v-80h80q14,-125 103.5,-214.5T440,122v-80h80v80q125,14 214.5,103.5T838,440h80v80h-80q-14,125 -103.5,214.5T520,838v80h-80ZM480,760q116,0 198,-82t82,-198q0,-116 -82,-198t-198,-82q-116,0 -198,82t-82,198q0,116 82,198t198,82ZM480,640q-66,0 -113,-47t-47,-113q0,-66 47,-113t113,-47q66,0 113,47t47,113q0,66 -47,113t-113,47ZM480,560q33,0 56.5,-23.5T560,480q0,-33 -23.5,-56.5T480,400q-33,0 -56.5,23.5T400,480q0,33 23.5,56.5T480,560ZM480,480Z"
+      android:fillColor="#5f6368"/>
+</vector>

--- a/app/src/main/res/drawable/user_location.xml
+++ b/app/src/main/res/drawable/user_location.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+  <path
+      android:pathData="M50,50m-45,0a45,45 0,1 1,90 0a45,45 0,1 1,-90 0"
+      android:strokeWidth="10"
+      android:fillColor="#0000ff"
+      android:strokeColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,19 @@
     <string name="map_screen_hike_title_default">Unnamed Hike</string>
     <string name="map_screen_location_features_failed">Failed to enable location features</string>
     <string name="map_screen_center_on_pos_content_description">Center map on my position</string>
+    <string name="map_screen_location_rationale_title">Permission Required</string>
+    <string name="map_screen_location_rationale_simple">Please grant HikeMate access to your location to center the map there.</string>
+    <string name="map_screen_location_rationale">
+        HikeMate needs access to your localization to
+        \n\n
+        1. Show your location on the screen and
+        \n\n
+        2. Center the map on your position at the click of a button
+        \n\n
+        If you do not grant the permission, the app will function normally, but the location features won\'t be available.
+    </string>
+    <string name="map_screen_location_rationale_cancel_button">No thanks</string>
+    <string name="map_screen_location_rationale_grant_button">Grant permission</string>
     <string name="zoom_in">Zoom in</string>
     <string name="zoom_out">Zoom out</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     </string>
     <string name="map_screen_location_rationale_cancel_button">No thanks</string>
     <string name="map_screen_location_rationale_grant_button">Grant permission</string>
+    <string name="map_screen_location_not_available">Please enable location in settings</string>
     <string name="zoom_in">Zoom in</string>
     <string name="zoom_out">Zoom out</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
         Too many hikes to display on the map. Only %d hikes are shown.
     </string>
     <string name="map_screen_hike_title_default">Unnamed Hike</string>
+    <string name="map_screen_location_features_failed">Failed to enable location features</string>
+    <string name="map_screen_center_on_pos_content_description">Center map on my position</string>
     <string name="zoom_in">Zoom in</string>
     <string name="zoom_out">Zoom out</string>
 

--- a/app/src/test/java/ch/hikemate/app/utils/LocationUtilsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/utils/LocationUtilsTest.kt
@@ -1,0 +1,153 @@
+package ch.hikemate.app.utils
+
+import android.content.Context
+import android.location.Location
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import io.mockk.CapturingSlot
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+
+class LocationUtilsTest {
+  private lateinit var successCallbackSlot: CapturingSlot<OnSuccessListener<Location>>
+  private lateinit var failureCallbackSlot: CapturingSlot<OnFailureListener>
+  private lateinit var task: Task<Location>
+  private lateinit var fusedClient: FusedLocationProviderClient
+  private lateinit var context: Context
+  private lateinit var location: Location
+
+  @Before
+  fun setUp() {
+    successCallbackSlot = slot()
+    failureCallbackSlot = slot()
+    task = mockk()
+    fusedClient = mockk()
+    mockkStatic(LocationServices::class)
+    context = mockk()
+    every { LocationServices.getFusedLocationProviderClient(context) } returns fusedClient
+    location = mockk()
+  }
+
+  @Test
+  fun getUserLocationWorksOnSuccess() {
+    // Given
+    every { fusedClient.getCurrentLocation(any<Int>(), any()) } returns task
+    every { task.addOnSuccessListener(capture(successCallbackSlot)) } returns task
+    every { task.addOnFailureListener(any()) } returns task
+    var successCallbackWasCalled = false
+
+    // When
+    LocationUtils.getUserLocation(context, { successCallbackWasCalled = true })
+    successCallbackSlot.captured.onSuccess(location)
+
+    // Then
+    assert(successCallbackWasCalled)
+  }
+
+  @Test
+  fun getUserLocationWorksOnFailure() {
+    // Given
+    every { fusedClient.getCurrentLocation(any<Int>(), any()) } returns task
+    every { task.addOnSuccessListener(any()) } returns task
+    every { task.addOnFailureListener(capture(failureCallbackSlot)) } returns task
+    var failureCallbackWasCalled = false
+
+    // When
+    LocationUtils.getUserLocation(context, { failureCallbackWasCalled = it == null })
+    failureCallbackSlot.captured.onFailure(Exception())
+
+    // Then
+    assert(failureCallbackWasCalled)
+  }
+
+  @Test
+  fun getUserLocationWorksOnSecurityException() {
+    // Given
+    every { fusedClient.getCurrentLocation(any<Int>(), any()) } throws SecurityException()
+    var failureCallbackWasCalled = false
+
+    // When
+    LocationUtils.getUserLocation(context, { failureCallbackWasCalled = it == null })
+
+    // Then
+    assert(failureCallbackWasCalled)
+  }
+
+  @Test
+  fun startUserLocationUpdatesReturnsFalseOnSecurityException() {
+    // Given
+    every {
+      fusedClient.requestLocationUpdates(any<LocationRequest>(), any<LocationCallback>(), any())
+    } throws SecurityException()
+
+    // When
+    val result = LocationUtils.startUserLocationUpdates(context, mockk())
+
+    // Then
+    verify {
+      fusedClient.requestLocationUpdates(any<LocationRequest>(), any<LocationCallback>(), any())
+    }
+    assert(!result)
+  }
+
+  @Test
+  fun onUserLocationUpdateClearsPositionWhenLocationIsNull() {
+    // Given
+    val marker = mockk<Marker>()
+    val mapView = mockk<MapView>()
+    val locationResult = mockk<LocationResult>()
+    every { locationResult.lastLocation } returns null
+    mockkObject(MapUtils)
+    every { MapUtils.clearUserPosition(any(), any(), any()) } returns Unit
+
+    // When
+    val result = LocationUtils.onUserLocationUpdate(locationResult, mapView, marker)
+
+    // Then
+    verify { MapUtils.clearUserPosition(marker, mapView, true) }
+    assert(result == null)
+  }
+
+  @Test
+  fun onUserLocationUpdateUpdatesPositionWhenLocationIsNotNull() {
+    // Given
+    val marker = mockk<Marker>()
+    val mapView = mockk<MapView>()
+    val locationResult = mockk<LocationResult>()
+    val location = mockk<Location>()
+    every { locationResult.lastLocation } returns location
+    mockkObject(MapUtils)
+    every { MapUtils.updateUserPosition(any(), any(), any()) } returns marker
+
+    // When
+    val result = LocationUtils.onUserLocationUpdate(locationResult, mapView, marker)
+
+    // Then
+    verify { MapUtils.updateUserPosition(marker, mapView, location) }
+    assert(result == marker)
+  }
+
+  @After
+  fun tearDown() {
+    // Reset all mocks
+    clearAllMocks()
+    unmockkAll()
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/utils/MapUtilsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/utils/MapUtilsTest.kt
@@ -1,0 +1,135 @@
+package ch.hikemate.app.utils
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.location.Location
+import android.widget.Toast
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Test
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+
+class MapUtilsTest {
+  @Test
+  fun updateUserPositionClearsOldPositionAndCreatesNewOne() {
+    // Given
+    // Spy on the MapUtils object so that only specific methods are mocked
+    mockkObject(MapUtils)
+    val dummyDrawable = mockk<Drawable>(relaxed = true)
+
+    // Mock only `getUserLocationMarkerIcon`, while other methods remain as-is
+    every { MapUtils.getUserLocationMarkerIcon(any()) } returns dummyDrawable
+
+    // Mock or set up other test dependencies
+    val map = mockk<MapView>(relaxed = true)
+    val previous = mockk<Marker>(relaxed = true)
+    map.overlays.add(previous)
+    val location = mockk<Location>()
+    every { location.latitude } returns 46.0
+    every { location.longitude } returns 7.0
+    val newOverlayCapture = slot<Marker>()
+
+    // Capture the new overlay added to the map
+    every { map.overlays.add(capture(newOverlayCapture)) } returns true
+
+    // When the user position is udpated
+    MapUtils.updateUserPosition(previous, map, location)
+
+    // Then the previous marker is removed, map is invalidated, and a new marker is added
+    verify { map.overlays.remove(previous) }
+    verify { map.invalidate() }
+    verify { map.overlays.add(any()) }
+    val capturedMarker = newOverlayCapture.captured
+    assertEquals(location.latitude, capturedMarker.position.latitude, 0.0)
+    assertEquals(location.longitude, capturedMarker.position.longitude, 0.0)
+  }
+
+  @Test
+  fun centerMapOnUserLocationCentersMapIfLocationIsReceived() {
+    // Given
+    mockkObject(MapUtils)
+    every { MapUtils.centerMapOnUserLocation(any(), any()) } returns Unit
+    mockkObject(LocationUtils)
+    val callbackSlot = slot<(Location?) -> Unit>()
+    every { LocationUtils.getUserLocation(any(), capture(callbackSlot), any(), any()) } returns Unit
+    val context = mockk<Context>(relaxed = true)
+    val map = mockk<MapView>(relaxed = true)
+    val fakeLocation = mockk<Location>()
+    every { fakeLocation.latitude } returns 46.0
+    every { fakeLocation.longitude } returns 7.0
+
+    // When
+    MapUtils.centerMapOnUserLocation(context, map, null)
+
+    // Then
+    verify { LocationUtils.getUserLocation(context, any(), any(), any()) }
+
+    // When
+    callbackSlot.captured(fakeLocation)
+
+    // Then
+    verify { MapUtils.centerMapOnUserLocation(map, fakeLocation) }
+  }
+
+  @Test
+  fun centerMapOnUserLocationClearsUserPositionIfLocationIsNull() {
+    // Given
+    mockkObject(MapUtils)
+    every { MapUtils.centerMapOnUserLocation(any(), any()) } returns Unit
+    mockkObject(LocationUtils)
+    val callbackSlot = slot<(Location?) -> Unit>()
+    every { LocationUtils.getUserLocation(any(), capture(callbackSlot), any(), any()) } returns Unit
+    val context = mockk<Context>(relaxed = true)
+    every { context.getString(any()) } returns "Test"
+    val map = mockk<MapView>(relaxed = true)
+    val fakeToast = mockk<Toast>(relaxed = true)
+    mockkStatic(Toast::class)
+    every { Toast.makeText(any<Context>(), any<CharSequence>(), any<Int>()) } returns fakeToast
+    every { fakeToast.show() } returns Unit
+
+    // When
+    MapUtils.centerMapOnUserLocation(context, map, null)
+
+    // Then
+    verify { LocationUtils.getUserLocation(context, any(), any(), any()) }
+
+    // When
+    callbackSlot.captured(null)
+
+    // Then
+    verify { MapUtils.clearUserPosition(null, map, true) }
+    verify { fakeToast.show() }
+  }
+
+  @Test
+  fun centerMapOnUserLocationWithLocationAnimatesMap() {
+    // Given
+    val map = mockk<MapView>(relaxed = true)
+    val location = mockk<Location>()
+    every { location.latitude } returns 46.0
+    every { location.longitude } returns 7.0
+
+    // When
+    MapUtils.centerMapOnUserLocation(map, location)
+    Thread.sleep(500)
+
+    // Then
+    verify { map.controller.animateTo(any(), any(), any()) }
+  }
+
+  @After
+  fun tearDown() {
+    // Clears all mocks and resets the global state to avoid interference between tests
+    clearAllMocks()
+    unmockkAll()
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/utils/PermissionUtilsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/utils/PermissionUtilsTest.kt
@@ -1,0 +1,48 @@
+package ch.hikemate.app.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class PermissionUtilsTest {
+  @Test
+  fun firstTimeAskingPermissionGetsFromSharedPreferences() {
+    // Given
+    val permissionName = "location"
+    val sharedPreferences = mockk<SharedPreferences>()
+    every { sharedPreferences.getBoolean(eq(permissionName), eq(true)) } returns false
+    val context = mockk<Context>()
+    every { context.getSharedPreferences(any(), eq(Context.MODE_PRIVATE)) } returns
+        sharedPreferences
+
+    // When
+    val isFirstTime = PermissionUtils.firstTimeAskingPermission(context, permissionName)
+
+    // Then
+    verify { context.getSharedPreferences(any(), eq(Context.MODE_PRIVATE)) }
+    verify { sharedPreferences.getBoolean(permissionName, true) }
+    assert(!isFirstTime)
+  }
+
+  @OptIn(ExperimentalPermissionsApi::class)
+  @Test
+  fun anyPermissionGrantedChecksRevokedPermissions() {
+    // Given
+    val state = mockk<MultiplePermissionsState>()
+    every { state.revokedPermissions } returns listOf()
+    every { state.permissions } returns listOf()
+
+    // When
+    val anyGranted = PermissionUtils.anyPermissionGranted(state)
+
+    // Then
+    verify { state.revokedPermissions }
+    verify { state.permissions }
+    assert(!anyGranted)
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ mockkAgent = "1.13.12"
 mockkAgentVersion = "1.13.12"
 mockkAndroid = "1.13.12"
 mockkAndroidVersion = "1.13.12"
+playServicesLocation = "21.3.0"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 
@@ -78,6 +79,7 @@ mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockkAgent" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 osmdroid = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanistPermissions = "0.36.0"
 agp = "8.7.0"
 firebaseBom = "33.4.0"
 kotlin =  "1.8.10"
@@ -46,6 +47,7 @@ okhttp = "4.12.0"
 googleid = "1.1.1"
 
 [libraries]
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }


### PR DESCRIPTION
# Summary

This PR introduces two new features :

1. A button to center the map view on the user's location
2. A background loop that displays the current user on the map every 5 seconds to keep it up-to-date

The permission logic is handled as well, with popups to explain the user why those permissions are needed. The app can be used without the permission.

# Details

The code of the `MapScreen` composable is becoming very hard to read and understand, I'm sorry for that. I'll see with the SCRUM master if I can be assigned to refactoring this screen's code in a future sprint, because it has become a mess.

## "Center map on me" button

In essence, this pull request has two main axes, the two features listed in the summary (center the map, update the user's location periodically).

- A "Center map on me" button was added to the map
- When you click on this button, the app checks its permissions. If it can, it will center the map on the user's location. Otherwise, it will ask for permission to access user's location.
- When asking for the permission, first a custom popup will open, explaining why the app needs the permission.
- If the user chooses to grant, the permission is requested. This logic is convoluted because of Android's permission system. Basically you have to either ask the user directly (a system popup comes into play), or bring the user to the Android settings.

## User location periodic updates

Parallel to this, the app listens to the permission state :

- When the location permission is granted, it starts periodic updates to display the up-to-date user location on the map, every five seconds
- When the location permission is revoked, it stops the periodic updates and hides the user location from the map

I also added util functions to clear the user's position, add it to a given location, and so on...

## `MapScreen` cognitive complexity

The code for the `MapScreen` composable became too complex, so I had to move some of the existing logic elsewhere to make Sonar happy.

I'm not going to refactor the entire `MapScreen.kt` file in this PR, because it is already quite significant, however I believe this is something to do, I will start the discussion on Telegram to plan such a task.

## CI

The CI does not pass yet because Sonar sees the new permission requests (coarse and fine location) as potential security issues. I believe this is the role of the reviewer to approve those issues on Sonar Cloud directly, let me know if we need to discuss it.