### PR TITLE
feat(hikes): add selectRouteById

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepository.kt
@@ -1,7 +1,7 @@
 package ch.hikemate.app.model.route
 
 /** Interface for the hiking route provider repository. */
-fun interface HikeRoutesRepository {
+interface HikeRoutesRepository {
   /**
    * Returns the routes inside the given bounding box and zoom level.
    *
@@ -14,4 +14,11 @@ fun interface HikeRoutesRepository {
       onSuccess: (List<HikeRoute>) -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  /**
+   * From a route ID, retrieves the details of that hike.
+   *
+   * @param routeId The ID of the route to get more info about.
+   */
+  fun getRouteById(routeId: String, onSuccess: (HikeRoute) -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepository.kt
@@ -19,6 +19,8 @@ interface HikeRoutesRepository {
    * From a route ID, retrieves the details of that hike.
    *
    * @param routeId The ID of the route to get more info about.
+   * @param onSuccess The callback to be called when the route is successfully fetched.
+   * @param onFailure The callback to be called when the route could not be fetched.
    */
   fun getRouteById(routeId: String, onSuccess: (HikeRoute) -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
@@ -82,4 +82,27 @@ open class ListOfHikeRoutesViewModel(
   fun selectRoute(hikeRoute: HikeRoute) {
     selectedHikeRoute_.value = hikeRoute
   }
+
+  private suspend fun selectRouteByIdAsync(hikeId: String) {
+    withContext(dispatcher) {
+      hikeRoutesRepository.getRouteById(
+          routeId = hikeId,
+          onSuccess = { route -> selectedHikeRoute_.value = route },
+          onFailure = { exception ->
+            Log.d(LOG_TAG, "[selectRouteByIdAsync] Failed to get route: $exception")
+          })
+    }
+  }
+
+  /**
+   * Selects a particular hike (for example to then display it in the details screen).
+   *
+   * Use this function if only the route ID is available. If a [HikeRoute] instance is available,
+   * use [selectRoute] instead.
+   *
+   * @param hikeId The ID of the route to be selected
+   */
+  fun selectRouteById(hikeId: String) {
+    viewModelScope.launch { selectRouteByIdAsync(hikeId) }
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
@@ -52,7 +52,7 @@ open class ListOfHikeRoutesViewModel(
             onSuccess()
           },
           onFailure = { exception ->
-            Log.d(LOG_TAG, "[getRoutesAsync] Failed to get routes: $exception")
+            Log.e(LOG_TAG, "[getRoutesAsync] Failed to get routes", exception)
             onFailure()
           })
     }
@@ -89,7 +89,7 @@ open class ListOfHikeRoutesViewModel(
           routeId = hikeId,
           onSuccess = { route -> selectedHikeRoute_.value = route },
           onFailure = { exception ->
-            Log.d(LOG_TAG, "[selectRouteByIdAsync] Failed to get route: $exception")
+            Log.e(LOG_TAG, "[selectRouteByIdAsync] Failed to get route", exception)
           })
     }
   }

--- a/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
@@ -96,4 +96,29 @@ class ListOfHikeRoutesViewModelTest {
 
     verify(hikesRepository, times(1)).getRoutes(eq(Bounds(0.0, 0.0, 0.0, 0.0)), any(), any())
   }
+
+  @Test
+  fun selectRouteByIdCallsRepoAndSelectsHike() {
+    // Given
+    val hike =
+        HikeRoute(
+            id = "Route 1",
+            bounds = Bounds(0.0, 0.0, 0.0, 0.0),
+            ways = emptyList(),
+            name = "Name of Route 1",
+            description = "Description of Route 1")
+
+    `when`(hikesRepository.getRouteById(eq("Route 1"), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(HikeRoute) -> Unit>(1)
+      onSuccess(hike)
+    }
+
+    // When
+    // Since we use UnconfinedTestDispatcher, we don't need to wait for the coroutine to finish
+    listOfHikeRoutesViewModel.selectRouteById("Route 1")
+
+    // Then
+    verify(hikesRepository, times(1)).getRouteById(eq("Route 1"), any(), any())
+    assertEquals(hike, listOfHikeRoutesViewModel.selectedHikeRoute.value)
+  }
 }

--- a/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
@@ -108,17 +108,17 @@ class ListOfHikeRoutesViewModelTest {
             name = "Name of Route 1",
             description = "Description of Route 1")
 
-    `when`(hikesRepository.getRouteById(eq("Route 1"), any(), any())).thenAnswer {
+    `when`(hikesRepository.getRouteById(eq(hike.id), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(HikeRoute) -> Unit>(1)
       onSuccess(hike)
     }
 
     // When
     // Since we use UnconfinedTestDispatcher, we don't need to wait for the coroutine to finish
-    listOfHikeRoutesViewModel.selectRouteById("Route 1")
+    listOfHikeRoutesViewModel.selectRouteById(hike.id)
 
     // Then
-    verify(hikesRepository, times(1)).getRouteById(eq("Route 1"), any(), any())
+    verify(hikesRepository, times(1)).getRouteById(eq(hike.id), any(), any())
     assertEquals(hike, listOfHikeRoutesViewModel.selectedHikeRoute.value)
   }
 }


### PR DESCRIPTION
# Summary

In the saved hikes screen, when we click on one of the hikes in the list, we want to open the details screen for this hike.

However, the saved hikes screen does not have an instance of `HikeRoute`, it only has a `SavedHike`. This does not contain the geographical points of the hike, hence we need to retrieve it somehow.

This PR introduces a function `getRouteById` in the Overpass API repository, along with a `selectRouteById` in the view model that complements `selectRoute`. It takes an ID, retrieves the information of the route and selects it.

## Details

The error handling in the view model is part of another task, so it was left on the side for now. Will be done in another PR.

Tests were added for the added functions.