### PR TITLE
Implement a way to get a batch of routes from overpass

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepository.kt
@@ -23,4 +23,17 @@ interface HikeRoutesRepository {
    * @param onFailure The callback to be called when the route could not be fetched.
    */
   fun getRouteById(routeId: String, onSuccess: (HikeRoute) -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
+   * From a list of route IDs, retrieves the details of those hikes.
+   *
+   * @param routeIds The list of route IDs to get more info about.
+   * @param onSuccess The callback to be called when the routes are successfully fetched.
+   * @param onFailure The callback to be called when the routes could not be fetched.
+   */
+  fun getRoutesByIds(
+      routeIds: List<String>,
+      onSuccess: (List<HikeRoute>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
@@ -69,6 +69,36 @@ open class ListOfHikeRoutesViewModel(
     viewModelScope.launch { getRoutesAsync(onSuccess = onSuccess, onFailure = onFailure) }
   }
 
+  /** Gets the routes with the given IDs */
+  fun getRoutesByIds(
+      routeIds: List<String>,
+      onSuccess: (List<HikeRoute>) -> Unit = {},
+      onFailure: () -> Unit = {}
+  ) {
+    viewModelScope.launch {
+      getRoutesByIdsAsync(routeIds, onSuccess = onSuccess, onFailure = onFailure)
+    }
+  }
+
+  private suspend fun getRoutesByIdsAsync(
+      routeIds: List<String>,
+      onSuccess: (List<HikeRoute>) -> Unit = {},
+      onFailure: () -> Unit = {}
+  ) {
+    withContext(dispatcher) {
+      hikeRoutesRepository.getRoutesByIds(
+          routeIds = routeIds,
+          onSuccess = { routes ->
+            hikeRoutes_.value = routes
+            onSuccess(routes)
+          },
+          onFailure = { exception ->
+            Log.e(LOG_TAG, "[getRoutesFromIds] Failed to get routes", exception)
+            onFailure()
+          })
+    }
+  }
+
   private suspend fun getRoutesElevationAsync(
       route: HikeRoute,
       onSuccess: (List<Double>) -> Unit = {},

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
@@ -333,7 +333,7 @@ class HikeRoutesRepositoryOverpassTest {
         },
         {
             "type": "relation",
-            "id": 124582,
+            "id": 124583,
             "bounds": {
                 "minlat": 45.8689061,
                 "minlon": 6.4395807,
@@ -699,6 +699,29 @@ class HikeRoutesRepositoryOverpassTest {
               "Camino de Santiago",
               "Lausanne - Roll"))
 
+  private val doubleRoutes: List<HikeRoute> =
+      listOf(
+          HikeRoute(
+              "124582",
+              Bounds(45.8689061, 6.4395807, 46.8283926, 7.2109599),
+              listOf(
+                  LatLong(46.8240018, 6.4395807),
+                  LatLong(46.8239650, 6.4396698),
+                  LatLong(46.8235322, 6.4401168),
+                  LatLong(46.8234367, 6.4401715)),
+              "Camino de Santiago",
+              "Lausanne - Roll"),
+          HikeRoute(
+              "124583",
+              Bounds(45.8689061, 6.4395807, 46.8283926, 7.2109599),
+              listOf(
+                  LatLong(46.8240018, 6.4395807),
+                  LatLong(46.8239650, 6.4396698),
+                  LatLong(46.8235322, 6.4401168),
+                  LatLong(46.8234367, 6.4401715)),
+              "Camino de Santiago",
+              "Lausanne - Roll"))
+
   private val combinedRoutes: List<HikeRoute> =
       listOf(
           HikeRoute(
@@ -957,7 +980,9 @@ class HikeRoutesRepositoryOverpassTest {
     var failCalled = false
 
     hikingRouteProviderRepositoryOverpass.getRouteById(
-        "124582", { fail("onSuccess shouldn't have been called") }, { failCalled = true })
+        simpleRoutes.first().id,
+        { fail("onSuccess shouldn't have been called") },
+        { failCalled = true })
 
     assert(failCalled)
   }
@@ -976,7 +1001,9 @@ class HikeRoutesRepositoryOverpassTest {
     var failCalled = false
 
     hikingRouteProviderRepositoryOverpass.getRouteById(
-        "124582", { fail("onSuccess shouldn't have been called") }, { failCalled = true })
+        simpleRoutes.first().id,
+        { fail("onSuccess shouldn't have been called") },
+        { failCalled = true })
 
     assert(failCalled)
   }
@@ -995,7 +1022,9 @@ class HikeRoutesRepositoryOverpassTest {
     var failCalled = false
 
     hikingRouteProviderRepositoryOverpass.getRouteById(
-        "124582", { fail("onSuccess shouldn't have been called") }, { failCalled = true })
+        simpleRoutes.first().id,
+        { fail("onSuccess shouldn't have been called") },
+        { failCalled = true })
 
     assert(failCalled)
   }
@@ -1011,11 +1040,85 @@ class HikeRoutesRepositoryOverpassTest {
       callbackCapture.firstValue.onResponse(mockCall, simpleResponse)
     }
 
+    hikingRouteProviderRepositoryOverpass.getRouteById(
+        simpleRoutes.first().id,
+        { assertEquals(simpleRoutes.first(), it) },
+        { fail("onFailure shouldn't have been called") })
+  }
+
+  @Test
+  fun getRoutesByIds_hasEmptyListOnEmptyResponse() {
+    val mockCall = mock(Call::class.java)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+
+    val callbackCapture = argumentCaptor<okhttp3.Callback>()
+
+    `when`(mockCall.enqueue(callbackCapture.capture())).then {
+      callbackCapture.firstValue.onResponse(mockCall, emptyResponse)
+    }
+
+    hikingRouteProviderRepositoryOverpass.getRoutesByIds(
+        listOf(simpleRoutes.first().id),
+        { assertEquals(emptyList<HikeRoute>(), it) },
+        { fail("onFailure shouldn't have been called") })
+  }
+
+  @Test
+  fun getRoutesByIds_failsOnFailedResponse() {
+    val mockCall = mock(Call::class.java)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+
+    val callbackCapture = argumentCaptor<okhttp3.Callback>()
+
+    `when`(mockCall.enqueue(callbackCapture.capture())).then {
+      callbackCapture.firstValue.onResponse(mockCall, failedResponse)
+    }
+
+    var failCalled = false
+
+    hikingRouteProviderRepositoryOverpass.getRoutesByIds(
+        listOf(simpleRoutes.first().id),
+        { fail("onSuccess shouldn't have been called") },
+        { failCalled = true })
+
+    assert(failCalled)
+  }
+
+  @Test
+  fun getRoutesByIds_succeedsOnSingleRoute() {
+    val mockCall = mock(Call::class.java)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+
+    val callbackCapture = argumentCaptor<okhttp3.Callback>()
+
+    `when`(mockCall.enqueue(callbackCapture.capture())).then {
+      callbackCapture.firstValue.onResponse(mockCall, simpleResponse)
+    }
+
     var successCalled = false
 
-    hikingRouteProviderRepositoryOverpass.getRouteById(
-        "124582", { successCalled = true }, { fail("onFailure shouldn't have been called") })
+    hikingRouteProviderRepositoryOverpass.getRoutesByIds(
+        listOf(simpleRoutes.first().id),
+        { successCalled = true },
+        { fail("onFailure shouldn't have been called") })
 
     assert(successCalled)
+  }
+
+  @Test
+  fun getRoutesByIds_succeedsOnMultipleRoutes() {
+    val mockCall = mock(Call::class.java)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+
+    val callbackCapture = argumentCaptor<okhttp3.Callback>()
+
+    `when`(mockCall.enqueue(callbackCapture.capture())).then {
+      callbackCapture.firstValue.onResponse(mockCall, doubleResponse)
+    }
+
+    hikingRouteProviderRepositoryOverpass.getRoutesByIds(
+        listOf(doubleRoutes[0].id, doubleRoutes[1].id),
+        { assertEquals(doubleRoutes, it) },
+        { fail("onFailure shouldn't have been called") })
   }
 }

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
@@ -1057,10 +1057,17 @@ class HikeRoutesRepositoryOverpassTest {
       callbackCapture.firstValue.onResponse(mockCall, emptyResponse)
     }
 
+    var onSuccessCalled = false
+
     hikingRouteProviderRepositoryOverpass.getRoutesByIds(
         listOf(simpleRoutes.first().id),
-        { assertEquals(emptyList<HikeRoute>(), it) },
+        {
+          assertEquals(emptyList<HikeRoute>(), it)
+          onSuccessCalled = true
+        },
         { fail("onFailure shouldn't have been called") })
+
+    assert(onSuccessCalled)
   }
 
   @Test
@@ -1116,9 +1123,16 @@ class HikeRoutesRepositoryOverpassTest {
       callbackCapture.firstValue.onResponse(mockCall, doubleResponse)
     }
 
+    var onSuccessCalled = false
+
     hikingRouteProviderRepositoryOverpass.getRoutesByIds(
         listOf(doubleRoutes[0].id, doubleRoutes[1].id),
-        { assertEquals(doubleRoutes, it) },
+        {
+          assertEquals(doubleRoutes, it)
+          onSuccessCalled = true
+        },
         { fail("onFailure shouldn't have been called") })
+
+    assert(onSuccessCalled)
   }
 }


### PR DESCRIPTION
# Summary
- The objective is to provide an interface to recover multiple routes from IDs. This PR implements it in the same style as other Overpass requests are implemented.