### PR TITLE
fix: firebase can't deserialize saved hikes

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHike.kt
@@ -12,17 +12,17 @@ data class SavedHike(
      * The unique ID of the hike. Allows to retrieve additional information about the hike from the
      * API in case the user wants more details.
      */
-    val id: String,
+    val id: String = "",
 
     /**
      * The human-friendly and readable name of the hike. Can be used, for example, to be displayed
      * in a list of saved hikes without querying the API to get all the names.
      */
-    val name: String,
+    val name: String = "",
 
     /**
      * The date at which the user plans to go on the hike. Can be null if the user has not set a
      * date yet or does not plan to add one.
      */
-    val date: Timestamp?
+    val date: Timestamp? = null
 )

--- a/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHikesRepositoryFirestore.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHikesRepositoryFirestore.kt
@@ -11,7 +11,7 @@ class SavedHikesRepositoryFirestore(
     private val auth: FirebaseAuth
 ) : SavedHikesRepository {
 
-  data class UserSavedHikes(val savedHikes: List<SavedHike>)
+  data class UserSavedHikes(val savedHikes: List<SavedHike> = emptyList())
 
   override suspend fun loadSavedHikes(): List<SavedHike> {
     checkNotNull(auth.currentUser) { ERROR_MSG_USER_NOT_AUTHENTICATED }


### PR DESCRIPTION
Firebase throws an error when the object to deserialize don't have an empty constructor. This simple PR add a default argument for `SavedHike` and `UserSavedHike`

**Since this PR is needed urgently, the reviewer is allowed to merge it himself after approving**