### PR TITLE
feat(saved): better error handling

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -22,7 +22,7 @@ import ch.hikemate.app.ui.navigation.TEST_TAG_DRAWER_CONTENT
 import ch.hikemate.app.ui.navigation.TEST_TAG_DRAWER_ITEM_PREFIX
 import ch.hikemate.app.ui.navigation.TEST_TAG_SIDEBAR_BUTTON
 import ch.hikemate.app.ui.navigation.TopLevelDestinations
-import ch.hikemate.app.ui.saved.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER
+import ch.hikemate.app.ui.saved.SavedHikesScreen
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
@@ -121,7 +121,9 @@ class EndToEndTest : TestCase() {
         .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + TopLevelDestinations.SAVED_HIKES.route)
         .performClick()
     composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SECTION_CONTAINER).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
+        .assertIsDisplayed()
 
     // Check that we can go back to the map
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
@@ -129,7 +131,9 @@ class EndToEndTest : TestCase() {
         .onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + TopLevelDestinations.MAP.route)
         .performClick()
     composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SECTION_CONTAINER).assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
+        .assertIsNotDisplayed()
 
     // Check that we can go to the profile screen
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
@@ -16,7 +16,7 @@ import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.TEST_TAG_DRAWER_ITEM_PREFIX
 import ch.hikemate.app.ui.navigation.TEST_TAG_SIDEBAR_BUTTON
-import ch.hikemate.app.ui.saved.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER
+import ch.hikemate.app.ui.saved.SavedHikesScreen
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
@@ -108,7 +108,9 @@ class HikeMateAppNavigationTest {
     // Go to planned hikes
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()
     composeTestRule.onNodeWithTag(TEST_TAG_DRAWER_ITEM_PREFIX + Route.SAVED_HIKES).performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SECTION_CONTAINER).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
+        .assertIsDisplayed()
 
     // Go to profile screen
     composeTestRule.onNodeWithTag(TEST_TAG_SIDEBAR_BUTTON).performClick()

--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import ch.hikemate.app.model.route.saved.SavedHike
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.model.route.saved.SavedHikesViewModel
+import ch.hikemate.app.ui.components.CenteredErrorAction
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.TEST_TAG_SIDEBAR_BUTTON
 import com.google.firebase.Timestamp
@@ -187,10 +188,10 @@ class SavedHikesScreenTest : TestCase() {
         composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
         composeTestRule
-            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_ERROR_MESSAGE)
+            .onNodeWithTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_MESSAGE)
             .assertIsDisplayed()
         composeTestRule
-            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_REFRESH_BUTTON)
+            .onNodeWithTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON)
             .assertIsDisplayed()
             .assertHasClickAction()
             .performClick()

--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -15,8 +15,9 @@ import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.TEST_TAG_SIDEBAR_BUTTON
 import com.google.firebase.Timestamp
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
-import io.mockk.verify
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -33,11 +34,12 @@ class SavedHikesScreenTest : TestCase() {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     savedHikesRepository = mock(SavedHikesRepository::class.java)
-    savedHikesViewModel = SavedHikesViewModel(savedHikesRepository)
+    savedHikesViewModel = SavedHikesViewModel(savedHikesRepository, UnconfinedTestDispatcher())
   }
 
   @Test

--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.ui.saved
 
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -14,6 +15,7 @@ import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.TEST_TAG_SIDEBAR_BUTTON
 import com.google.firebase.Timestamp
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.mockk.verify
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -21,6 +23,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 
 class SavedHikesScreenTest : TestCase() {
   private lateinit var savedHikesRepository: SavedHikesRepository
@@ -171,5 +175,24 @@ class SavedHikesScreenTest : TestCase() {
         composeTestRule
             .onAllNodesWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD)
             .assertCountEquals(2)
+      }
+
+  @Test
+  fun errorIsDisplayedIfOneOccurs() =
+      runTest(timeout = 5.seconds) {
+        `when`(savedHikesRepository.loadSavedHikes()).thenThrow(RuntimeException("Error"))
+
+        composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
+
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_ERROR_MESSAGE)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_REFRESH_BUTTON)
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performClick()
+
+        verify(savedHikesRepository, times(2)).loadSavedHikes()
       }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -47,10 +47,13 @@ class SavedHikesScreenTest : TestCase() {
   fun bottomMenuIsDisplayedAndHasItems() {
     composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_BOTTOM_MENU)
+        .assertIsDisplayed()
     for (element in SavedHikesSection.values()) {
       composeTestRule
-          .onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + element.name)
+          .onNodeWithTag(
+              SavedHikesScreen.TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + element.name)
           .assertIsDisplayed()
     }
   }
@@ -59,17 +62,27 @@ class SavedHikesScreenTest : TestCase() {
   fun sectionContainerIsDisplayed() {
     composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SECTION_CONTAINER).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
+        .assertIsDisplayed()
   }
 
   @Test
   fun plannedScreenWithNoHikesDisplaysCorrectly() {
     composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_TITLE).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE)
+        .assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE)
+        .assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE)
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE)
+        .assertIsDisplayed()
   }
 
   @Test
@@ -84,15 +97,21 @@ class SavedHikesScreenTest : TestCase() {
 
         composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
-        composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_TITLE).assertIsNotDisplayed()
         composeTestRule
-            .onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE)
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE)
             .assertIsNotDisplayed()
-        composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE).assertIsDisplayed()
         composeTestRule
-            .onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE)
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE)
             .assertIsNotDisplayed()
-        composeTestRule.onAllNodesWithTag(TEST_TAG_SAVED_HIKES_HIKE_CARD).assertCountEquals(2)
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE)
+            .assertIsNotDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD)
+            .assertCountEquals(2)
       }
 
   @Test
@@ -100,13 +119,23 @@ class SavedHikesScreenTest : TestCase() {
     composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
     composeTestRule
-        .onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + SavedHikesSection.Saved.name)
+        .onNodeWithTag(
+            SavedHikesScreen.TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX +
+                SavedHikesSection.Saved.name)
         .performClick()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_TITLE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE)
+        .assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE)
+        .assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE)
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE)
+        .assertIsDisplayed()
   }
 
   @Test
@@ -123,17 +152,24 @@ class SavedHikesScreenTest : TestCase() {
 
         composeTestRule
             .onNodeWithTag(
-                TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + SavedHikesSection.Saved.name)
+                SavedHikesScreen.TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX +
+                    SavedHikesSection.Saved.name)
             .performClick()
 
-        composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE).assertIsNotDisplayed()
         composeTestRule
-            .onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE)
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE)
             .assertIsNotDisplayed()
-        composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_TITLE).assertIsDisplayed()
         composeTestRule
-            .onNodeWithTag(TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE)
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE)
             .assertIsNotDisplayed()
-        composeTestRule.onAllNodesWithTag(TEST_TAG_SAVED_HIKES_HIKE_CARD).assertCountEquals(2)
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE)
+            .assertIsNotDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD)
+            .assertCountEquals(2)
       }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -48,7 +48,7 @@ class SavedHikesScreenTest : TestCase() {
     composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU).assertIsDisplayed()
-    for (element in SavedHikesScreen.values()) {
+    for (element in SavedHikesSection.values()) {
       composeTestRule
           .onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + element.name)
           .assertIsDisplayed()
@@ -100,7 +100,7 @@ class SavedHikesScreenTest : TestCase() {
     composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
 
     composeTestRule
-        .onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + SavedHikesScreen.Saved.name)
+        .onNodeWithTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + SavedHikesSection.Saved.name)
         .performClick()
 
     composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE).assertIsNotDisplayed()
@@ -123,7 +123,7 @@ class SavedHikesScreenTest : TestCase() {
 
         composeTestRule
             .onNodeWithTag(
-                TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + SavedHikesScreen.Saved.name)
+                TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + SavedHikesSection.Saved.name)
             .performClick()
 
         composeTestRule.onNodeWithTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE).assertIsNotDisplayed()

--- a/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHikesViewModel.kt
@@ -50,6 +50,10 @@ class SavedHikesViewModel(
    */
   val errorMessage: StateFlow<Int?> = _errorMessage.asStateFlow()
 
+  private val _loadingSavedHikes = MutableStateFlow<Boolean>(false)
+  /** Whether the saved hikes list is currently being loaded or reloaded. */
+  val loadingSavedHikes: StateFlow<Boolean> = _loadingSavedHikes.asStateFlow()
+
   /** Load saved hikes from the repository and update the [savedHike] state flow. */
   fun loadSavedHikes() {
     // Because loading saved hikes is also used by other methods, we extract it
@@ -105,12 +109,14 @@ class SavedHikesViewModel(
   private suspend fun loadSavedHikesAsync() {
     withContext(dispatcher) {
       try {
+        _loadingSavedHikes.value = true
         _savedHikes.value = repository.loadSavedHikes()
         _errorMessage.value = null
       } catch (e: Exception) {
         Log.e(LOG_TAG, "Error loading saved hikes", e)
         _errorMessage.value = R.string.saved_hikes_screen_generic_error
       }
+      _loadingSavedHikes.value = false
     }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/components/CenteredErrorAction.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/CenteredErrorAction.kt
@@ -1,0 +1,73 @@
+package ch.hikemate.app.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+object CenteredErrorAction {
+  const val TEST_TAG_CENTERED_ERROR_MESSAGE = "CenteredErrorMessage"
+  const val TEST_TAG_CENTERED_ERROR_BUTTON = "CenteredErrorButton"
+}
+
+/**
+ * Displays an error message that takes the whole parent size and an action button.
+ *
+ * For an action button to be displayed, the [actionIcon] parameter and the
+ * [actionContentDescription] parameter must both not be null.
+ *
+ * Provides two test tags, [CenteredErrorAction.TEST_TAG_CENTERED_ERROR_MESSAGE] for the text
+ * component, and [CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON] for the action button.
+ *
+ * @param errorMessage The string resource ID of the error message to display.
+ * @param actionIcon The icon to display on the action button. If null, no action button will be
+ *   displayed.
+ * @param actionContentDescription The string resource ID of the content description for the action
+ *   button. If null, no action button will be displayed.
+ * @param onAction The action to perform when the action button is clicked. If null, an empty
+ *   callback will be used instead.
+ */
+@Composable
+fun CenteredErrorAction(
+    errorMessage: Int,
+    actionIcon: ImageVector? = null,
+    actionContentDescription: Int? = null,
+    onAction: (() -> Unit)? = null
+) {
+
+  // Box to take the entire space of the parent and center the content
+  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+
+    // Column so that the error message and action button are displayed vertically and not on top of
+    // each other
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      Text(
+          text = stringResource(errorMessage),
+          style = MaterialTheme.typography.bodyLarge,
+          modifier =
+              Modifier.padding(16.dp).testTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_MESSAGE))
+
+      // Only display the action button if both an icon and a content description are provided
+      if (actionIcon != null && actionContentDescription != null) {
+        IconButton(
+            onClick = onAction ?: {},
+            modifier = Modifier.testTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON)) {
+              Icon(
+                  imageVector = actionIcon,
+                  contentDescription = stringResource(actionContentDescription))
+            }
+      }
+    }
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/ui/components/CenteredLoadingAnimation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/CenteredLoadingAnimation.kt
@@ -1,0 +1,29 @@
+package ch.hikemate.app.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+object CenteredLoadingAnimation {
+  const val TEST_TAG_CENTERED_LOADING_ANIMATION = "CenteredLoadingAnimation"
+}
+
+/**
+ * Displays a centered loading animation (moving circle).
+ *
+ * Provides [CenteredLoadingAnimation.TEST_TAG_CENTERED_LOADING_ANIMATION] as a test tag for the
+ * loading animation component.
+ *
+ * Takes the whole parent space with [Modifier.fillMaxSize].
+ */
+@Composable
+fun CenteredLoadingAnimation() {
+  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    CircularProgressIndicator(
+        modifier = Modifier.testTag(CenteredLoadingAnimation.TEST_TAG_CENTERED_LOADING_ANIMATION))
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -44,14 +44,26 @@ import ch.hikemate.app.ui.navigation.SideBarNavigation
 import ch.hikemate.app.utils.humanReadablePlannedLabel
 
 object SavedHikesScreen {
+  // Components used by several (or all) sections
   const val TEST_TAG_SAVED_HIKES_BOTTOM_MENU = "SavedHikesBottomMenu"
   const val TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX = "SavedHikesBottomMenuItem_"
   const val TEST_TAG_SAVED_HIKES_SECTION_CONTAINER = "SavedHikesSectionContainer"
+  const val TEST_TAG_SAVED_HIKES_HIKE_CARD = "SavedHikesHikeCard"
+
+  // Components specific for the Planned section
   const val TEST_TAG_SAVED_HIKES_PLANNED_TITLE = "SavedHikesPlannedTitle"
   const val TEST_TAG_SAVED_HIKES_SAVED_TITLE = "SavedHikesSavedTitle"
+
+  // Components specific for the Saved section
   const val TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE = "SavedHikesPlannedEmptyMessage"
   const val TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE = "SavedHikesSavedEmptyMessage"
-  const val TEST_TAG_SAVED_HIKES_HIKE_CARD = "SavedHikesHikeCard"
+
+  // Components specific for the Error section
+  const val TEST_TAG_SAVED_HIKES_ERROR_MESSAGE = "SavedHikesErrorMessage"
+  const val TEST_TAG_SAVED_HIKES_REFRESH_BUTTON = "SavedHikesRefreshButton"
+
+  // Components specific for the Loading section
+  const val TEST_TAG_SAVED_HIKES_LOADING_ANIMATION = "SavedHikesLoadingAnimation"
 }
 
 @Composable
@@ -95,7 +107,8 @@ fun SavedHikesScreen(
 @Composable
 private fun LoadingSavedHikes() {
   Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    CircularProgressIndicator()
+    CircularProgressIndicator(
+        modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_LOADING_ANIMATION))
   }
 }
 
@@ -106,12 +119,16 @@ private fun ErrorDisplay(errorMessage: Int, onRefresh: () -> Unit) {
       Text(
           text = stringResource(errorMessage),
           style = MaterialTheme.typography.bodyLarge,
-          modifier = Modifier.padding(16.dp))
-      IconButton(onClick = onRefresh) {
-        Icon(
-            imageVector = Icons.Default.Refresh,
-            contentDescription = stringResource(R.string.saved_hikes_screen_refresh_button_action))
-      }
+          modifier =
+              Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_ERROR_MESSAGE))
+      IconButton(
+          onClick = onRefresh,
+          modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_REFRESH_BUTTON)) {
+            Icon(
+                imageVector = Icons.Default.Refresh,
+                contentDescription =
+                    stringResource(R.string.saved_hikes_screen_refresh_button_action))
+          }
     }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -43,14 +43,16 @@ import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.SideBarNavigation
 import ch.hikemate.app.utils.humanReadablePlannedLabel
 
-const val TEST_TAG_SAVED_HIKES_BOTTOM_MENU = "SavedHikesBottomMenu"
-const val TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX = "SavedHikesBottomMenuItem_"
-const val TEST_TAG_SAVED_HIKES_SECTION_CONTAINER = "SavedHikesSectionContainer"
-const val TEST_TAG_SAVED_HIKES_PLANNED_TITLE = "SavedHikesPlannedTitle"
-const val TEST_TAG_SAVED_HIKES_SAVED_TITLE = "SavedHikesSavedTitle"
-const val TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE = "SavedHikesPlannedEmptyMessage"
-const val TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE = "SavedHikesSavedEmptyMessage"
-const val TEST_TAG_SAVED_HIKES_HIKE_CARD = "SavedHikesHikeCard"
+object SavedHikesScreen {
+  const val TEST_TAG_SAVED_HIKES_BOTTOM_MENU = "SavedHikesBottomMenu"
+  const val TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX = "SavedHikesBottomMenuItem_"
+  const val TEST_TAG_SAVED_HIKES_SECTION_CONTAINER = "SavedHikesSectionContainer"
+  const val TEST_TAG_SAVED_HIKES_PLANNED_TITLE = "SavedHikesPlannedTitle"
+  const val TEST_TAG_SAVED_HIKES_SAVED_TITLE = "SavedHikesSavedTitle"
+  const val TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE = "SavedHikesPlannedEmptyMessage"
+  const val TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE = "SavedHikesSavedEmptyMessage"
+  const val TEST_TAG_SAVED_HIKES_HIKE_CARD = "SavedHikesHikeCard"
+}
 
 @Composable
 fun SavedHikesScreen(
@@ -71,15 +73,18 @@ fun SavedHikesScreen(
     LaunchedEffect(Unit) { savedHikesViewModel.loadSavedHikes() }
 
     Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
-      Column(modifier = Modifier.weight(1f).testTag(TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)) {
-        when {
-          loading -> LoadingSavedHikes()
-          errorMessageId != null ->
-              ErrorDisplay(errorMessageId!!) { savedHikesViewModel.loadSavedHikes() }
-          currentSection == SavedHikesSection.Planned -> PlannedHikes(savedHikes)
-          currentSection == SavedHikesSection.Saved -> SavedHikes(savedHikes)
-        }
-      }
+      Column(
+          modifier =
+              Modifier.weight(1f)
+                  .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)) {
+            when {
+              loading -> LoadingSavedHikes()
+              errorMessageId != null ->
+                  ErrorDisplay(errorMessageId!!) { savedHikesViewModel.loadSavedHikes() }
+              currentSection == SavedHikesSection.Planned -> PlannedHikes(savedHikes)
+              currentSection == SavedHikesSection.Saved -> SavedHikes(savedHikes)
+            }
+          }
 
       // Navigation items between nearby hikes, planned hikes, and saved hikes
       SavedHikesBottomMenu(currentSection) { currentSection = it }
@@ -117,7 +122,8 @@ private fun PlannedHikes(hikes: List<SavedHike>?) {
   Text(
       context.getString(R.string.saved_hikes_screen_planned_section_title),
       style = MaterialTheme.typography.titleLarge,
-      modifier = Modifier.padding(16.dp).testTag(TEST_TAG_SAVED_HIKES_PLANNED_TITLE))
+      modifier =
+          Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE))
 
   val plannedHikes = hikes?.filter { it.date != null }?.sortedBy { it.date }
 
@@ -126,7 +132,9 @@ private fun PlannedHikes(hikes: List<SavedHike>?) {
       Text(
           text = context.getString(R.string.saved_hikes_screen_planned_section_empty_message),
           style = MaterialTheme.typography.bodyLarge,
-          modifier = Modifier.padding(16.dp).testTag(TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE))
+          modifier =
+              Modifier.padding(16.dp)
+                  .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE))
     }
   } else {
     LazyColumn {
@@ -145,7 +153,7 @@ private fun PlannedHikes(hikes: List<SavedHike>?) {
                   .show()
             },
             messageContent = hike.date!!.humanReadablePlannedLabel(LocalContext.current),
-            modifier = Modifier.testTag(TEST_TAG_SAVED_HIKES_HIKE_CARD),
+            modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD),
             styleProperties =
                 HikeCardStyleProperties(
                     messageIcon = painterResource(R.drawable.calendar_today),
@@ -161,7 +169,7 @@ private fun SavedHikes(hikes: List<SavedHike>?) {
   Text(
       context.getString(R.string.saved_hikes_screen_saved_section_title),
       style = MaterialTheme.typography.titleLarge,
-      modifier = Modifier.padding(16.dp).testTag(TEST_TAG_SAVED_HIKES_SAVED_TITLE))
+      modifier = Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE))
 
   val savedHikes = hikes?.filter { it.date == null }
 
@@ -170,7 +178,9 @@ private fun SavedHikes(hikes: List<SavedHike>?) {
       Text(
           text = context.getString(R.string.saved_hikes_screen_saved_section_empty_message),
           style = MaterialTheme.typography.bodyLarge,
-          modifier = Modifier.padding(16.dp).testTag(TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE))
+          modifier =
+              Modifier.padding(16.dp)
+                  .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE))
     }
   } else {
     LazyColumn {
@@ -188,7 +198,7 @@ private fun SavedHikes(hikes: List<SavedHike>?) {
             // This generates a random list of elevation data for the hike
             // with a random number of points and altitude between 0 and 1000
             elevationData = (0..(0..1000).random()).map { it.toDouble() }.shuffled(),
-            modifier = Modifier.testTag(TEST_TAG_SAVED_HIKES_HIKE_CARD))
+            modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD))
       }
     }
   }
@@ -199,14 +209,16 @@ private fun SavedHikesBottomMenu(
     selected: SavedHikesSection,
     onSelectedChange: (SavedHikesSection) -> Unit
 ) {
-  NavigationBar(modifier = Modifier.testTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU)) {
+  NavigationBar(modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_BOTTOM_MENU)) {
     SavedHikesSection.values().forEach { screen ->
       NavigationBarItem(
           icon = { Icon(painter = painterResource(screen.icon), contentDescription = null) },
           label = { Text(screen.label) },
           selected = selected == screen,
           onClick = { onSelectedChange(screen) },
-          modifier = Modifier.testTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + screen.name))
+          modifier =
+              Modifier.testTag(
+                  SavedHikesScreen.TEST_TAG_SAVED_HIKES_BOTTOM_MENU_ITEM_PREFIX + screen.name))
     }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -63,7 +63,7 @@ fun SavedHikesScreen(
       tabList = LIST_TOP_LEVEL_DESTINATIONS,
       selectedItem = Route.SAVED_HIKES,
   ) { paddingValues ->
-    var currentSection by remember { mutableStateOf(SavedHikesScreen.Planned) }
+    var currentSection by remember { mutableStateOf(SavedHikesSection.Planned) }
     val loading by savedHikesViewModel.loadingSavedHikes.collectAsState()
     val errorMessageId by savedHikesViewModel.errorMessage.collectAsState()
     val savedHikes by savedHikesViewModel.savedHike.collectAsState()
@@ -76,8 +76,8 @@ fun SavedHikesScreen(
           loading -> LoadingSavedHikes()
           errorMessageId != null ->
               ErrorDisplay(errorMessageId!!) { savedHikesViewModel.loadSavedHikes() }
-          currentSection == SavedHikesScreen.Planned -> PlannedHikes(savedHikes)
-          currentSection == SavedHikesScreen.Saved -> SavedHikes(savedHikes)
+          currentSection == SavedHikesSection.Planned -> PlannedHikes(savedHikes)
+          currentSection == SavedHikesSection.Saved -> SavedHikes(savedHikes)
         }
       }
 
@@ -196,11 +196,11 @@ private fun SavedHikes(hikes: List<SavedHike>?) {
 
 @Composable
 private fun SavedHikesBottomMenu(
-    selected: SavedHikesScreen,
-    onSelectedChange: (SavedHikesScreen) -> Unit
+    selected: SavedHikesSection,
+    onSelectedChange: (SavedHikesSection) -> Unit
 ) {
   NavigationBar(modifier = Modifier.testTag(TEST_TAG_SAVED_HIKES_BOTTOM_MENU)) {
-    SavedHikesScreen.values().forEach { screen ->
+    SavedHikesSection.values().forEach { screen ->
       NavigationBarItem(
           icon = { Icon(painter = painterResource(screen.icon), contentDescription = null) },
           label = { Text(screen.label) },
@@ -217,7 +217,7 @@ private fun SavedHikesBottomMenu(
  * The order of the enum values determines the order of the sections in the bottom menu. The first
  * element of the enum will be the left-most section in the bottom menu.
  */
-enum class SavedHikesScreen(val label: String, @DrawableRes val icon: Int) {
+enum class SavedHikesSection(val label: String, @DrawableRes val icon: Int) {
   Planned("Planned", R.drawable.calendar_today),
   Saved("Saved", R.drawable.bookmark)
 }

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -29,12 +27,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.hikemate.app.R
 import ch.hikemate.app.model.route.saved.SavedHike
 import ch.hikemate.app.model.route.saved.SavedHikesViewModel
+import ch.hikemate.app.ui.components.CenteredErrorAction
+import ch.hikemate.app.ui.components.CenteredLoadingAnimation
 import ch.hikemate.app.ui.components.HikeCard
 import ch.hikemate.app.ui.components.HikeCardStyleProperties
 import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
@@ -90,9 +89,14 @@ fun SavedHikesScreen(
               Modifier.weight(1f)
                   .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)) {
             when {
-              loading -> LoadingSavedHikes()
+              loading -> CenteredLoadingAnimation()
               errorMessageId != null ->
-                  ErrorDisplay(errorMessageId!!) { savedHikesViewModel.loadSavedHikes() }
+                CenteredErrorAction(
+                  errorMessage = errorMessageId!!,
+                  actionIcon = Icons.Default.Refresh,
+                  actionContentDescription = R.string.saved_hikes_screen_refresh_button_action,
+                  onAction = { savedHikesViewModel.loadSavedHikes() }
+                )
               currentSection == SavedHikesSection.Planned -> PlannedHikes(savedHikes)
               currentSection == SavedHikesSection.Saved -> SavedHikes(savedHikes)
             }
@@ -100,35 +104,6 @@ fun SavedHikesScreen(
 
       // Navigation items between nearby hikes, planned hikes, and saved hikes
       SavedHikesBottomMenu(currentSection) { currentSection = it }
-    }
-  }
-}
-
-@Composable
-private fun LoadingSavedHikes() {
-  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    CircularProgressIndicator(
-        modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_LOADING_ANIMATION))
-  }
-}
-
-@Composable
-private fun ErrorDisplay(errorMessage: Int, onRefresh: () -> Unit) {
-  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-      Text(
-          text = stringResource(errorMessage),
-          style = MaterialTheme.typography.bodyLarge,
-          modifier =
-              Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_ERROR_MESSAGE))
-      IconButton(
-          onClick = onRefresh,
-          modifier = Modifier.testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_REFRESH_BUTTON)) {
-            Icon(
-                imageVector = Icons.Default.Refresh,
-                contentDescription =
-                    stringResource(R.string.saved_hikes_screen_refresh_button_action))
-          }
     }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -56,13 +56,6 @@ object SavedHikesScreen {
   // Components specific for the Saved section
   const val TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE = "SavedHikesPlannedEmptyMessage"
   const val TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE = "SavedHikesSavedEmptyMessage"
-
-  // Components specific for the Error section
-  const val TEST_TAG_SAVED_HIKES_ERROR_MESSAGE = "SavedHikesErrorMessage"
-  const val TEST_TAG_SAVED_HIKES_REFRESH_BUTTON = "SavedHikesRefreshButton"
-
-  // Components specific for the Loading section
-  const val TEST_TAG_SAVED_HIKES_LOADING_ANIMATION = "SavedHikesLoadingAnimation"
 }
 
 @Composable
@@ -91,12 +84,11 @@ fun SavedHikesScreen(
             when {
               loading -> CenteredLoadingAnimation()
               errorMessageId != null ->
-                CenteredErrorAction(
-                  errorMessage = errorMessageId!!,
-                  actionIcon = Icons.Default.Refresh,
-                  actionContentDescription = R.string.saved_hikes_screen_refresh_button_action,
-                  onAction = { savedHikesViewModel.loadSavedHikes() }
-                )
+                  CenteredErrorAction(
+                      errorMessage = errorMessageId!!,
+                      actionIcon = Icons.Default.Refresh,
+                      actionContentDescription = R.string.saved_hikes_screen_refresh_button_action,
+                      onAction = { savedHikesViewModel.loadSavedHikes() })
               currentSection == SavedHikesSection.Planned -> PlannedHikes(savedHikes)
               currentSection == SavedHikesSection.Saved -> SavedHikes(savedHikes)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
         An error occurred while loading saved hikes.
         Please check your Internet connection and try again.
     </string>
+    <string name="saved_hikes_screen_refresh_button_action">Refresh</string>
     <string name="saved_hikes_screen_saved_section_title">Saved hikes</string>
     <string name="saved_hikes_screen_saved_section_empty_message">No saved hikes to display</string>
     <string name="saved_hikes_screen_planned_section_title">Planned hikes</string>


### PR DESCRIPTION
# Summary

As part of #132, this PR implements better error handling for the Saved Hikes screen and consequently for the `SavedHikesViewModel`.

# Details

There was a bit of refactoring, so a lot of lines might have changed but most of those changes are trivial (renaming, moving, ...).

- Added a `loadingSavedHikes` state to the view model that is set to `true` when saved hikes are being loaded
- Added a `ErrorDisplay` composable to saved hikes for when retrieving saved hikes fails
- Added a `LoadingSavedHikes` composable to saved hikes for when the view model is loading the hikes

Refactoring was made :

- The `SavedHikesScreen` enum was renamed to `SavedHikesSection` to leave space for a `SavedHikesScreen` object
- Test tags were moved into the `SavedHikesScreen` object

Tests were added :

- Test tags were added for the new components
- One integration test was added for the error display