### PR TITLE
fix: dark mode for back button

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/components/BackButton.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/BackButton.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import ch.hikemate.app.ui.navigation.NavigationActions
@@ -36,7 +35,10 @@ fun BackButton(navigationActions: NavigationActions) {
               .size(50.dp)
               .padding(8.dp)
               .background(color = MaterialTheme.colorScheme.surface, shape = RoundedCornerShape(20))
-              .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(20))) {
+              .border(
+                  width = 1.dp,
+                  color = MaterialTheme.colorScheme.onSurface,
+                  shape = RoundedCornerShape(20))) {
         Icon(
             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
             modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
# Summary
The back button would render with a black border in dark mode which would not appear very well.

# Details
Used the `MaterialThem.colorScheme.onSurface` instead of the hardcoded one.
