### PR TITLE
feat: improve error handling in profile view model

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -50,7 +50,25 @@ class EndToEndTest : TestCase() {
     val context = ApplicationProvider.getApplicationContext<Context>()
     FirebaseApp.initializeApp(context)
 
+    var signedOut = false
+
+    // Wait for sign out to complete
+    FirebaseAuth.getInstance().addAuthStateListener {
+      if (it.currentUser == null) {
+        signedOut = true
+      }
+    }
+
     auth.signOut()
+
+    val timeout = System.currentTimeMillis() + 10000 // 10 seconds
+    while (!signedOut && System.currentTimeMillis() < timeout) {
+      Thread.sleep(100)
+    }
+
+    if (!signedOut) {
+      throw Exception("Failed to sign out")
+    }
   }
 
   @After

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -1,9 +1,11 @@
 package ch.hikemate.app.endtoend
 
 import android.content.Context
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -11,8 +13,10 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.MainActivity
+import ch.hikemate.app.ui.auth.CreateAccountScreen
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
+import ch.hikemate.app.ui.components.CenteredLoadingAnimation
 import ch.hikemate.app.ui.map.MapScreen.TEST_TAG_MAP
 import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import ch.hikemate.app.ui.navigation.Screen
@@ -46,7 +50,6 @@ class EndToEndTest : TestCase() {
     val context = ApplicationProvider.getApplicationContext<Context>()
     FirebaseApp.initializeApp(context)
 
-    auth.createUserWithEmailAndPassword(email, password)
     auth.signOut()
   }
 
@@ -59,6 +62,7 @@ class EndToEndTest : TestCase() {
     auth.signOut()
   }
 
+  @OptIn(ExperimentalTestApi::class)
   @Test
   fun test() {
     composeTestRule.waitForIdle()
@@ -70,15 +74,24 @@ class EndToEndTest : TestCase() {
     composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL).performClick()
     composeTestRule.onNodeWithTag(Screen.SIGN_IN_WITH_EMAIL).assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT)
-        .performTextInput(email)
+        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON)
+        .performClick()
+    composeTestRule.onNodeWithTag(Screen.CREATE_ACCOUNT).assertIsDisplayed()
+
     composeTestRule
-        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT)
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .performTextInput(myUuidAsString)
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT).performTextInput(email)
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT)
         .performTextInput(password)
-    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .performTextInput(password)
+    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
 
     // Wait for the map to load
-    Thread.sleep(1000)
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag(TEST_TAG_MAP), timeoutMillis = 10000)
 
     // Check that we are on the map
     composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
@@ -120,6 +133,11 @@ class EndToEndTest : TestCase() {
         .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.PROFILE.route)
         .performClick()
     composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsNotDisplayed()
+
+    composeTestRule.waitUntilDoesNotExist(
+        hasTestTag(CenteredLoadingAnimation.TEST_TAG_CENTERED_LOADING_ANIMATION),
+        timeoutMillis = 10000)
+
     composeTestRule.onNodeWithTag(PROFILE).assertIsDisplayed()
 
     // Check that we can go back to the map

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -48,7 +48,26 @@ class EndToEndTest2 {
     FirebaseApp.initializeApp(context)
 
     auth.createUserWithEmailAndPassword(email, password)
+
+    var signedOut = false
+
+    // Wait for sign out to complete
+    FirebaseAuth.getInstance().addAuthStateListener {
+      if (it.currentUser == null) {
+        signedOut = true
+      }
+    }
+
     auth.signOut()
+
+    val timeout = System.currentTimeMillis() + 10000 // 10 seconds
+    while (!signedOut && System.currentTimeMillis() < timeout) {
+      Thread.sleep(100)
+    }
+
+    if (!signedOut) {
+      throw Exception("Failed to sign out")
+    }
   }
 
   @After

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
@@ -1,22 +1,15 @@
 package ch.hikemate.app.navigation
 
-import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.HikeMateApp
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
 import ch.hikemate.app.ui.components.BackButton
-import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
-import ch.hikemate.app.ui.navigation.TEST_TAG_MENU_ITEM_PREFIX
-import ch.hikemate.app.ui.saved.SavedHikesScreen
-import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import java.util.UUID
@@ -39,14 +32,6 @@ class HikeMateAppNavigationTest {
   @Before
   fun setUp() {
     composeTestRule.setContent { HikeMateApp() }
-    auth.signOut()
-  }
-
-  private fun setupUser() {
-    val context = ApplicationProvider.getApplicationContext<Context>()
-    FirebaseApp.initializeApp(context)
-
-    auth.createUserWithEmailAndPassword(email, password)
     auth.signOut()
   }
 
@@ -76,42 +61,5 @@ class HikeMateAppNavigationTest {
     composeTestRule.onNodeWithTag(Screen.SIGN_IN_WITH_EMAIL).assertIsDisplayed()
     composeTestRule.onNodeWithTag(BackButton.BACK_BUTTON_TEST_TAG).performClick()
     composeTestRule.onNodeWithTag(Screen.AUTH).assertIsDisplayed()
-  }
-
-  /**
-   * Tests the whole navigation flow from the auth screen to the map screen. All the screens are
-   * tested because signing in takes time.
-   */
-  @Test
-  fun testWholeNavigation() {
-    // Create a user in order to skip the auth screen
-    setupUser()
-
-    composeTestRule.onNodeWithTag(Screen.AUTH).assertIsDisplayed()
-
-    composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL).performClick()
-    composeTestRule.onNodeWithTag(Screen.SIGN_IN_WITH_EMAIL).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT)
-        .performTextInput(email)
-    composeTestRule
-        .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT)
-        .performTextInput(password)
-    composeTestRule.onNodeWithTag(SignInWithEmailScreen.TEST_TAG_SIGN_IN_BUTTON).performClick()
-
-    // Wait for the map to load
-    Thread.sleep(1000)
-
-    composeTestRule.onNodeWithTag(Screen.MAP).assertIsDisplayed()
-
-    // Go to planned hikes
-    composeTestRule.onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + Route.SAVED_HIKES).performClick()
-    composeTestRule
-        .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
-        .assertIsDisplayed()
-
-    // Go to profile screen
-    composeTestRule.onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + Route.PROFILE).performClick()
-    composeTestRule.onNodeWithTag(Screen.PROFILE).assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
@@ -10,10 +10,7 @@ import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.navigation.Screen
-import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
-import java.util.UUID
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -24,23 +21,10 @@ class HikeMateAppNavigationTest {
   // Set up the Compose test rule
   @get:Rule val composeTestRule = createComposeRule()
   private val auth = FirebaseAuth.getInstance()
-  private val myUuid = UUID.randomUUID()
-  private val myUuidAsString = myUuid.toString()
-  private val email = "$myUuidAsString@gmail.com"
-  private val password = "password"
 
   @Before
   fun setUp() {
     composeTestRule.setContent { HikeMateApp() }
-    auth.signOut()
-  }
-
-  @After
-  fun deleteUser() {
-    // Sign out after deleting for sanity check and un-reliability
-    val credential = EmailAuthProvider.getCredential(email, password)
-    auth.currentUser?.reauthenticate(credential)
-    auth.currentUser?.delete()
     auth.signOut()
   }
 

--- a/app/src/androidTest/java/ch/hikemate/app/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/profile/EditProfileScreenTest.kt
@@ -57,10 +57,6 @@ class EditProfileScreenTest : TestCase() {
     profileRepository = mock(ProfileRepository::class.java)
     profileViewModel = ProfileViewModel(profileRepository)
 
-    `when`(profileRepository.init(any())).thenAnswer {
-      val onSuccess = it.getArgument<() -> Unit>(0)
-      onSuccess()
-    }
     `when`(profileRepository.getProfileById(eq(profile.id), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile)

--- a/app/src/androidTest/java/ch/hikemate/app/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/profile/ProfileScreenTest.kt
@@ -64,10 +64,6 @@ class ProfileScreenTest : TestCase() {
     authViewModel = AuthViewModel(authRepository, profileRepository)
     profileViewModel = ProfileViewModel(profileRepository)
 
-    `when`(profileRepository.init(any())).thenAnswer {
-      val onSuccess = it.getArgument<() -> Unit>(0)
-      onSuccess()
-    }
     `when`(profileRepository.getProfileById(eq(profile.id), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(Profile) -> Unit>(1)
       onSuccess(profile)

--- a/app/src/androidTest/java/ch/hikemate/app/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/profile/ProfileScreenTest.kt
@@ -15,6 +15,7 @@ import ch.hikemate.app.model.profile.HikingLevel
 import ch.hikemate.app.model.profile.Profile
 import ch.hikemate.app.model.profile.ProfileRepository
 import ch.hikemate.app.model.profile.ProfileViewModel
+import ch.hikemate.app.ui.components.CenteredErrorAction
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.TEST_TAG_BOTTOM_BAR
@@ -179,5 +180,24 @@ class ProfileScreenTest : TestCase() {
   fun checkSignOutButton() {
     composeTestRule.onNodeWithTag(ProfileScreen.TEST_TAG_SIGN_OUT_BUTTON).performClick()
     verify(authRepository, times(1)).signOut(any())
+  }
+
+  @Test
+  fun errorIsShownWhenEmptyProfileReturnedAndUserCanGoBackHome() {
+    `when`(profileRepository.getProfileById(any(), any(), any())).thenAnswer {
+      val onError = it.getArgument<(Exception) -> Unit>(2)
+      onError(Exception("Profile not found"))
+    }
+
+    composeTestRule
+        .onNodeWithTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_MESSAGE)
+        .assertIsDisplayed()
+        .assertTextEquals(context.getString(R.string.error_loading_profile))
+    composeTestRule
+        .onNodeWithTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON)
+        .assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON).performClick()
+    verify(navigationActions).navigateTo(Screen.MAP)
   }
 }

--- a/app/src/main/java/ch/hikemate/app/MainActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/MainActivity.kt
@@ -74,10 +74,10 @@ class MainActivity : ComponentActivity() {
 fun HikeMateApp() {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
-  val firestore = FirebaseFirestore.getInstance()
-  val profileRepository = ProfileRepositoryFirestore(firestore)
-  val profileViewModel = ProfileViewModel(profileRepository)
-  val authViewModel = AuthViewModel(FirebaseAuthRepository(), profileRepository)
+  val profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
+  val authViewModel =
+      AuthViewModel(
+          FirebaseAuthRepository(), ProfileRepositoryFirestore(FirebaseFirestore.getInstance()))
 
   val isUserLoggedIn = authViewModel.isUserLoggedIn()
 

--- a/app/src/main/java/ch/hikemate/app/MainActivity.kt
+++ b/app/src/main/java/ch/hikemate/app/MainActivity.kt
@@ -93,12 +93,14 @@ fun HikeMateApp() {
             startDestination = Screen.AUTH,
             route = Route.AUTH,
         ) {
-          composable(Screen.AUTH) { SignInScreen(navigationActions, authViewModel) }
+          composable(Screen.AUTH) {
+            SignInScreen(navigationActions, authViewModel, profileViewModel)
+          }
           composable(Screen.SIGN_IN_WITH_EMAIL) {
-            SignInWithEmailScreen(navigationActions, authViewModel)
+            SignInWithEmailScreen(navigationActions, authViewModel, profileViewModel)
           }
           composable(Screen.CREATE_ACCOUNT) {
-            CreateAccountScreen(navigationActions, authViewModel)
+            CreateAccountScreen(navigationActions, authViewModel, profileViewModel)
           }
         }
 

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepository.kt
@@ -26,13 +26,6 @@ interface ProfileRepository {
   fun getNewUid(): String
 
   /**
-   * Initializes the profile repository.
-   *
-   * @param onSuccess The callback to be called when the repository is successfully initialized.
-   */
-  fun init(onSuccess: () -> Unit)
-
-  /**
    * Returns the profile with the given ID.
    *
    * @param id The ID of the profile to fetch.

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
@@ -162,12 +162,14 @@ class ProfileRepositoryFirestore(private val db: FirebaseFirestore) : ProfileRep
 
     return try {
       val uid = document.id
-      val name = document.getString("name") ?: "Invalid name"
-      val email = document.getString("email") ?: "Invalid email"
-      val hikingLevelString = document.getString("hikingLevel") ?: HikingLevel.BEGINNER
-      val hikingLevel =
-          HikingLevel.values().find { it.name == hikingLevelString } ?: HikingLevel.BEGINNER
-      val joinedDate = document.getTimestamp("joinedDate") ?: Timestamp.now()
+      val name = document.getString("name")
+      val email = document.getString("email")
+      val hikingLevelString = document.getString("hikingLevel")
+      val hikingLevel = HikingLevel.values().find { it.name == hikingLevelString }
+      val joinedDate = document.getTimestamp("joinedDate")
+      if (name == null || email == null || hikingLevel == null || joinedDate == null) {
+        return null
+      }
       Profile(uid, name, email, hikingLevel, joinedDate)
     } catch (e: Exception) {
       Log.e("ProfileRepositoryFirestore", "Error converting document to Profile", e)

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileRepositoryFirestore.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import android.util.Log
 import ch.hikemate.app.R
 import com.google.android.gms.tasks.Task
-import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseUser
-import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 
@@ -23,16 +21,6 @@ class ProfileRepositoryFirestore(private val db: FirebaseFirestore) : ProfileRep
 
   override fun getNewUid(): String {
     return db.collection(collectionPath).document().id
-  }
-
-  override fun init(onSuccess: () -> Unit) {
-    // Check if the user is logged in
-    // If the user is logged in, call onSuccess
-    Firebase.auth.addAuthStateListener {
-      if (it.currentUser != null) {
-        onSuccess()
-      }
-    }
   }
 
   override fun createProfile(
@@ -168,6 +156,7 @@ class ProfileRepositoryFirestore(private val db: FirebaseFirestore) : ProfileRep
       val hikingLevel = HikingLevel.values().find { it.name == hikingLevelString }
       val joinedDate = document.getTimestamp("joinedDate")
       if (name == null || email == null || hikingLevel == null || joinedDate == null) {
+        Log.e("ProfileRepositoryFirestore", "Error converting document to Profile: missing fields")
         return null
       }
       Profile(uid, name, email, hikingLevel, joinedDate)

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import ch.hikemate.app.R
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,12 +27,6 @@ open class ProfileViewModel(private val repository: ProfileRepository) : ViewMod
    * appropriate error message will be set in this state flow.
    */
   val errorMessageId: StateFlow<Int?> = _errorMessageId.asStateFlow()
-
-  init {
-    FirebaseAuth.getInstance().addAuthStateListener { auth ->
-      auth.currentUser?.uid?.let { userId -> getProfileById(userId) }
-    }
-  }
 
   // Factory for creating instances of ProfileViewModel
   companion object {
@@ -89,10 +82,5 @@ open class ProfileViewModel(private val repository: ProfileRepository) : ViewMod
           Log.e("ProfileViewModel", "Error deleting profile", it)
           _errorMessageId.value = R.string.an_error_occurred_while_deleting_the_profile
         })
-  }
-
-  /** Reload the profile. */
-  fun reloadProfile() {
-    profile_.value?.let { getProfileById(it.id) }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/model/profile/ProfileViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/profile/ProfileViewModel.kt
@@ -1,7 +1,9 @@
 package ch.hikemate.app.model.profile
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import ch.hikemate.app.R
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -19,6 +21,13 @@ open class ProfileViewModel(private val repository: ProfileRepository) : ViewMod
   // The profile for the detail view
   private val profile_ = MutableStateFlow<Profile?>(null)
   val profile: StateFlow<Profile?> = profile_.asStateFlow()
+
+  private val _errorMessageId = MutableStateFlow<Int?>(null)
+  /**
+   * If an error occurs while performing an operation related to saved hikes, the resource ID of an
+   * appropriate error message will be set in this state flow.
+   */
+  val errorMessageId: StateFlow<Int?> = _errorMessageId.asStateFlow()
 
   init {
     FirebaseAuth.getInstance().addAuthStateListener { auth ->
@@ -44,7 +53,12 @@ open class ProfileViewModel(private val repository: ProfileRepository) : ViewMod
    */
   fun getProfileById(id: String) {
     repository.getProfileById(
-        id, onSuccess = { profile -> profile_.value = profile }, onFailure = {})
+        id,
+        onSuccess = { profile -> profile_.value = profile },
+        onFailure = {
+          Log.e("ProfileViewModel", "Error fetching profile", it)
+          _errorMessageId.value = R.string.an_error_occurred_while_fetching_the_profile
+        })
   }
 
   /**
@@ -54,7 +68,12 @@ open class ProfileViewModel(private val repository: ProfileRepository) : ViewMod
    */
   fun updateProfile(profile: Profile) {
     repository.updateProfile(
-        profile = profile, onSuccess = { profile_.value = profile }, onFailure = {})
+        profile = profile,
+        onSuccess = { profile_.value = profile },
+        onFailure = {
+          Log.e("ProfileViewModel", "Error updating profile", it)
+          _errorMessageId.value = R.string.an_error_occurred_while_updating_the_profile
+        })
   }
 
   /**
@@ -63,7 +82,13 @@ open class ProfileViewModel(private val repository: ProfileRepository) : ViewMod
    * @param id The ID of the profile to delete.
    */
   fun deleteProfileById(id: String) {
-    repository.deleteProfileById(id = id, onSuccess = { profile_.value = null }, onFailure = {})
+    repository.deleteProfileById(
+        id = id,
+        onSuccess = { profile_.value = null },
+        onFailure = {
+          Log.e("ProfileViewModel", "Error deleting profile", it)
+          _errorMessageId.value = R.string.an_error_occurred_while_deleting_the_profile
+        })
   }
 
   /** Reload the profile. */

--- a/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/saved/SavedHikesViewModel.kt
@@ -43,12 +43,12 @@ class SavedHikesViewModel(
    */
   val savedHike: StateFlow<List<SavedHike>> = _savedHikes.asStateFlow()
 
-  private val _errorMessage = MutableStateFlow<Int?>(null)
+  private val _errorMessageId = MutableStateFlow<Int?>(null)
   /**
    * If an error occurs while performing an operation related to saved hikes, the resource ID of an
    * appropriate error message will be set in this state flow.
    */
-  val errorMessage: StateFlow<Int?> = _errorMessage.asStateFlow()
+  val errorMessageId: StateFlow<Int?> = _errorMessageId.asStateFlow()
 
   private val _loadingSavedHikes = MutableStateFlow<Boolean>(false)
   /** Whether the saved hikes list is currently being loaded or reloaded. */
@@ -75,7 +75,7 @@ class SavedHikesViewModel(
         // loading hikes again
       } catch (e: Exception) {
         Log.e(LOG_TAG, "Error adding saved hike", e)
-        _errorMessage.value = R.string.saved_hikes_screen_generic_error
+        _errorMessageId.value = R.string.saved_hikes_screen_generic_error
         return@launch
       }
       // As a side-effect, this call will reset the error message if no error occurs
@@ -98,7 +98,7 @@ class SavedHikesViewModel(
         // loading hikes again
       } catch (e: Exception) {
         Log.e(LOG_TAG, "Error removing saved hike", e)
-        _errorMessage.value = R.string.saved_hikes_screen_generic_error
+        _errorMessageId.value = R.string.saved_hikes_screen_generic_error
         return@launch
       }
       // As a side-effect, this call will reset the error message if no error occurs
@@ -111,10 +111,10 @@ class SavedHikesViewModel(
       try {
         _loadingSavedHikes.value = true
         _savedHikes.value = repository.loadSavedHikes()
-        _errorMessage.value = null
+        _errorMessageId.value = null
       } catch (e: Exception) {
         Log.e(LOG_TAG, "Error loading saved hikes", e)
-        _errorMessage.value = R.string.saved_hikes_screen_generic_error
+        _errorMessageId.value = R.string.saved_hikes_screen_generic_error
       }
       _loadingSavedHikes.value = false
     }

--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.hikemate.app.R
 import ch.hikemate.app.model.authentication.AuthViewModel
+import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
@@ -51,7 +53,11 @@ object CreateAccountScreen {
  * @param authViewModel The authentication view model.
  */
 @Composable
-fun CreateAccountScreen(navigationActions: NavigationActions, authViewModel: AuthViewModel) {
+fun CreateAccountScreen(
+    navigationActions: NavigationActions,
+    authViewModel: AuthViewModel,
+    profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
+) {
   val context = LocalContext.current
 
   // Define it here because it's used in the onClick lambda which is not a composable
@@ -97,6 +103,9 @@ fun CreateAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
             onSuccess = {
               // Navigate to the map screen
               navigationActions.navigateTo(Route.MAP)
+              if (authViewModel.currentUser.value != null) {
+                profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
+              }
             },
             onErrorAction = {
               // Show an error message in a toast

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInScreen.kt
@@ -42,8 +42,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.hikemate.app.R
 import ch.hikemate.app.model.authentication.AuthViewModel
+import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.components.AppIcon
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Screen
@@ -65,6 +67,7 @@ private const val CONNECTED_ACCOUNT_MESSAGE =
 fun SignInScreen(
     navigationActions: NavigationActions,
     authViewModel: AuthViewModel,
+    profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
 ) {
 
   val context = LocalContext.current
@@ -87,6 +90,10 @@ fun SignInScreen(
   LaunchedEffect(authViewModel.currentUser.collectAsState().value) {
     if (authViewModel.isUserLoggedIn()) {
       navigationActions.navigateTo(TopLevelDestinations.MAP)
+
+      if (authViewModel.currentUser.value != null)
+          profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
+      else Log.e("SignInScreen", "User is logged in but currentUser is null")
     }
   }
 

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.ui.auth
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,8 +30,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.hikemate.app.R
 import ch.hikemate.app.model.authentication.AuthViewModel
+import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
@@ -54,7 +57,11 @@ object SignInWithEmailScreen {
  * @param authViewModel The authentication view model.
  */
 @Composable
-fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: AuthViewModel) {
+fun SignInWithEmailScreen(
+    navigationActions: NavigationActions,
+    authViewModel: AuthViewModel,
+    profileViewModel: ProfileViewModel = viewModel(factory = ProfileViewModel.Factory)
+) {
   val context = LocalContext.current
 
   // Define the colors for the input fields
@@ -119,6 +126,11 @@ fun SignInWithEmailScreen(navigationActions: NavigationActions, authViewModel: A
                   onSuccess = {
                     // Navigate to the map screen
                     navigationActions.navigateTo(Route.MAP)
+                    if (authViewModel.currentUser.value != null) {
+                      profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
+                    } else {
+                      Log.e("SignInScreen", "User is logged in but currentUser is null")
+                    }
                   },
                   onErrorAction = {
                     // Show an error message in a toast

--- a/app/src/main/java/ch/hikemate/app/ui/components/CenteredErrorAction.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/CenteredErrorAction.kt
@@ -25,24 +25,24 @@ object CenteredErrorAction {
  * Displays an error message that takes the whole parent size and an action button.
  *
  * For an action button to be displayed, the [actionIcon] parameter and the
- * [actionContentDescription] parameter must both not be null.
+ * [actionContentDescriptionStringId] parameter must both not be null.
  *
  * Provides two test tags, [CenteredErrorAction.TEST_TAG_CENTERED_ERROR_MESSAGE] for the text
  * component, and [CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON] for the action button.
  *
- * @param errorMessage The string resource ID of the error message to display.
+ * @param errorMessageId The string resource ID of the error message to display.
  * @param actionIcon The icon to display on the action button. If null, no action button will be
  *   displayed.
- * @param actionContentDescription The string resource ID of the content description for the action
- *   button. If null, no action button will be displayed.
+ * @param actionContentDescriptionStringId The string resource ID of the content description for the
+ *   action button. If null, no action button will be displayed.
  * @param onAction The action to perform when the action button is clicked. If null, an empty
  *   callback will be used instead.
  */
 @Composable
 fun CenteredErrorAction(
-    errorMessage: Int,
+    errorMessageId: Int,
     actionIcon: ImageVector? = null,
-    actionContentDescription: Int? = null,
+    actionContentDescriptionStringId: Int? = null,
     onAction: (() -> Unit)? = null
 ) {
 
@@ -53,19 +53,19 @@ fun CenteredErrorAction(
     // each other
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
       Text(
-          text = stringResource(errorMessage),
+          text = stringResource(errorMessageId),
           style = MaterialTheme.typography.bodyLarge,
           modifier =
               Modifier.padding(16.dp).testTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_MESSAGE))
 
       // Only display the action button if both an icon and a content description are provided
-      if (actionIcon != null && actionContentDescription != null) {
+      if (actionIcon != null && actionContentDescriptionStringId != null) {
         IconButton(
             onClick = onAction ?: {},
             modifier = Modifier.testTag(CenteredErrorAction.TEST_TAG_CENTERED_ERROR_BUTTON)) {
               Icon(
                   imageVector = actionIcon,
-                  contentDescription = stringResource(actionContentDescription))
+                  contentDescription = stringResource(actionContentDescriptionStringId))
             }
       }
     }

--- a/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
@@ -34,7 +36,10 @@ import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.CenteredErrorAction
+import ch.hikemate.app.ui.components.CenteredLoadingAnimation
 import ch.hikemate.app.ui.navigation.NavigationActions
+import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.theme.primaryColor
 
@@ -62,14 +67,49 @@ fun EditProfileScreen(
 ) {
   val context = LocalContext.current
 
-  // TODO: show an error if the profile is null. For now display it for test purposes
+  val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
 
-  val profile: Profile = profileState.value ?: ProfileScreen.DEFAULT_PROFILE
+  if (errorMessageIdState.value != null) {
+    // Display an error message if an error occurred
+    return CenteredErrorAction(
+        errorMessageId = errorMessageIdState.value!!,
+        actionIcon = Icons.Outlined.Home,
+        actionContentDescriptionStringId = R.string.go_back,
+        onAction = { navigationActions.navigateTo(Route.MAP) })
+  }
+
+  if (profileState.value == null) {
+    // Display an error message if an error occurred
+    return CenteredErrorAction(
+        errorMessageId = R.string.error_loading_profile,
+        actionIcon = Icons.Outlined.Home,
+        actionContentDescriptionStringId = R.string.go_back,
+        onAction = { navigationActions.navigateTo(Route.MAP) })
+  }
+
+  // profileState.value is not null, we checked it before
+  val profile: Profile = profileState.value!!
 
   var name by remember { mutableStateOf(profile.name) }
   var hikingLevel by remember {
     mutableIntStateOf(HikingLevel.values().indexOf(profile.hikingLevel))
+  }
+
+  var savedProfile by remember { mutableStateOf<Profile?>(null) }
+
+  var isLoading by remember { mutableStateOf(false) }
+
+  if (savedProfile == profile) {
+    isLoading = false
+    savedProfile = null
+    navigationActions.goBack()
+    return
+  }
+
+  if (isLoading) {
+    // Display a loading animation while the profile is being saved
+    CenteredLoadingAnimation()
   }
 
   Column(
@@ -157,15 +197,15 @@ fun EditProfileScreen(
             buttonType = ButtonType.PRIMARY,
             label = context.getString(R.string.edit_profile_screen_save_button_text),
             onClick = {
-              val savedProfile =
+              savedProfile =
                   Profile(
                       profile.id,
                       name,
                       profile.email,
                       HikingLevel.values()[hikingLevel],
                       profile.joinedDate)
-              profileViewModel.updateProfile(profile = savedProfile)
-              navigationActions.goBack()
+              profileViewModel.updateProfile(profile = savedProfile!!)
+              isLoading = true
             })
       }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.ui.profile
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -80,12 +81,8 @@ fun EditProfileScreen(
   }
 
   if (profileState.value == null) {
-    // Display an error message if an error occurred
-    return CenteredErrorAction(
-        errorMessageId = R.string.error_loading_profile,
-        actionIcon = Icons.Outlined.Home,
-        actionContentDescriptionStringId = R.string.go_back,
-        onAction = { navigationActions.navigateTo(Route.MAP) })
+    Log.e("ProfileScreen", "Profile is null")
+    return CenteredLoadingAnimation()
   }
 
   // profileState.value is not null, we checked it before

--- a/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
@@ -4,6 +4,8 @@ import android.icu.text.DateFormat
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,12 +25,12 @@ import ch.hikemate.app.model.profile.Profile
 import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.CenteredErrorAction
 import ch.hikemate.app.ui.navigation.BottomBarNavigation
 import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
-import com.google.firebase.Timestamp
 
 object ProfileScreen {
   const val TEST_TAG_TITLE = "profileScreenTitle"
@@ -38,10 +40,6 @@ object ProfileScreen {
   const val TEST_TAG_JOIN_DATE = "profileScreenJoinDateInfo"
   const val TEST_TAG_EDIT_PROFILE_BUTTON = "profileScreenEditProfileButton"
   const val TEST_TAG_SIGN_OUT_BUTTON = "profileScreenSignOutButton"
-
-  val DEFAULT_PROFILE =
-      Profile(
-          "custom-id", "John Doe", "john.doe@gmail.com", HikingLevel.INTERMEDIATE, Timestamp.now())
 }
 /**
  * A composable to display an information of the profile.
@@ -73,13 +71,31 @@ fun ProfileScreen(
 ) {
   val context = LocalContext.current
 
-  // TODO: show an error if the profile is null. For now display it for test purposes
-
   LaunchedEffect(Unit) { profileViewModel.reloadProfile() }
 
+  val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
 
-  val profile: Profile = profileState.value ?: ProfileScreen.DEFAULT_PROFILE
+  if (errorMessageIdState.value != null) {
+    // Display an error message if an error occurred
+    return CenteredErrorAction(
+        errorMessageId = errorMessageIdState.value!!,
+        actionIcon = Icons.Outlined.Home,
+        actionContentDescriptionStringId = R.string.go_back,
+        onAction = { navigationActions.navigateTo(Route.MAP) })
+  }
+
+  if (profileState.value == null) {
+    // Display an error message if an error occurred
+    return CenteredErrorAction(
+        errorMessageId = R.string.error_loading_profile,
+        actionIcon = Icons.Outlined.Home,
+        actionContentDescriptionStringId = R.string.go_back,
+        onAction = { navigationActions.navigateTo(Route.MAP) })
+  }
+
+  // profileState.value is not null, we checked it before
+  val profile: Profile = profileState.value!!
 
   BottomBarNavigation(
       onTabSelect = { navigationActions.navigateTo(it) },

--- a/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.ui.profile
 
 import android.icu.text.DateFormat
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -13,6 +14,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -26,6 +28,7 @@ import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
 import ch.hikemate.app.ui.components.CenteredErrorAction
+import ch.hikemate.app.ui.components.CenteredLoadingAnimation
 import ch.hikemate.app.ui.navigation.BottomBarNavigation
 import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import ch.hikemate.app.ui.navigation.NavigationActions
@@ -71,12 +74,19 @@ fun ProfileScreen(
 ) {
   val context = LocalContext.current
 
-  LaunchedEffect(Unit) { profileViewModel.reloadProfile() }
+  LaunchedEffect(Unit) {
+    if (authViewModel.currentUser.value == null) {
+      Log.e("ProfileScreen", "User is not signed in")
+      return@LaunchedEffect
+    }
+    profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
+  }
 
   val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
 
   if (errorMessageIdState.value != null) {
+    Log.e("ProfileScreen", "Error message: ${stringResource(errorMessageIdState.value!!)}")
     // Display an error message if an error occurred
     return CenteredErrorAction(
         errorMessageId = errorMessageIdState.value!!,
@@ -86,12 +96,8 @@ fun ProfileScreen(
   }
 
   if (profileState.value == null) {
-    // Display an error message if an error occurred
-    return CenteredErrorAction(
-        errorMessageId = R.string.error_loading_profile,
-        actionIcon = Icons.Outlined.Home,
-        actionContentDescriptionStringId = R.string.go_back,
-        onAction = { navigationActions.navigateTo(Route.MAP) })
+    Log.e("ProfileScreen", "Profile is null")
+    return CenteredLoadingAnimation()
   }
 
   // profileState.value is not null, we checked it before

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -73,7 +73,7 @@ fun SavedHikesScreen(
   ) { paddingValues ->
     var currentSection by remember { mutableStateOf(SavedHikesSection.Saved) }
     val loading by savedHikesViewModel.loadingSavedHikes.collectAsState()
-    val errorMessageId by savedHikesViewModel.errorMessage.collectAsState()
+    val errorMessageId by savedHikesViewModel.errorMessageId.collectAsState()
     val savedHikes by savedHikesViewModel.savedHike.collectAsState()
 
     val pagerState = rememberPagerState { SavedHikesSection.values().size }
@@ -100,9 +100,10 @@ fun SavedHikesScreen(
             loading -> CenteredLoadingAnimation()
             errorMessageId != null ->
                 CenteredErrorAction(
-                    errorMessage = errorMessageId!!,
+                    errorMessageId = errorMessageId!!,
                     actionIcon = Icons.Default.Refresh,
-                    actionContentDescription = R.string.saved_hikes_screen_refresh_button_action,
+                    actionContentDescriptionStringId =
+                        R.string.saved_hikes_screen_refresh_button_action,
                     onAction = { savedHikesViewModel.loadSavedHikes() })
             else ->
                 HorizontalPager(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,6 @@
     <string name="an_error_occurred_while_fetching_the_profile">An error occurred while fetching the profile.</string>
     <string name="an_error_occurred_while_updating_the_profile">An error occurred while updating the profile.</string>
     <string name="an_error_occurred_while_deleting_the_profile">An error occurred while deleting the profile</string>
-    <string name="error_loading_profile">Error loading profile, please try again later</string>
 
 
     <!-- Edit Profile Screen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,4 +134,9 @@
 
     <!-- Elevation graph -->
     <string name="elevation_graph_loading_label">Loading graph…</string>
+    <string name="an_error_occurred_while_fetching_the_profile">An error occurred while fetching the profile.</string>
+    <string name="an_error_occurred_while_updating_the_profile">An error occurred while updating the profile.</string>
+    <string name="an_error_occurred_while_deleting_the_profile">An error occurred while deleting the profile</string>
+    <string name="error_loading_profile">Error loading profile, please try again later</string>
+    <string name="go_back">Go back</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,11 @@
     <string name="profile_screen_join_date_label">Joined HikeMate on</string>
     <string name="profile_screen_edit_profile_button_text">Edit profile</string>
     <string name="profile_screen_sign_out_button_text">Sign out</string>
+    <string name="an_error_occurred_while_fetching_the_profile">An error occurred while fetching the profile.</string>
+    <string name="an_error_occurred_while_updating_the_profile">An error occurred while updating the profile.</string>
+    <string name="an_error_occurred_while_deleting_the_profile">An error occurred while deleting the profile</string>
+    <string name="error_loading_profile">Error loading profile, please try again later</string>
+
 
     <!-- Edit Profile Screen -->
     <string name="edit_profile_screen_title">Edit your profile</string>
@@ -139,9 +144,5 @@
 
     <!-- Elevation graph -->
     <string name="elevation_graph_loading_label">Loading graph…</string>
-    <string name="an_error_occurred_while_fetching_the_profile">An error occurred while fetching the profile.</string>
-    <string name="an_error_occurred_while_updating_the_profile">An error occurred while updating the profile.</string>
-    <string name="an_error_occurred_while_deleting_the_profile">An error occurred while deleting the profile</string>
-    <string name="error_loading_profile">Error loading profile, please try again later</string>
     <string name="go_back">Go back</string>
 </resources>

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
@@ -57,11 +57,6 @@ class ProfileViewModelTest {
       null
     }
 
-    `when`(repository.init(any())).thenAnswer {
-      val initAction = it.getArgument<() -> Unit>(0)
-      initAction()
-    }
-
     profileViewModel = ProfileViewModel(repository)
   }
 

--- a/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/profile/ProfileViewModelTest.kt
@@ -3,10 +3,12 @@ package ch.hikemate.app.model.profile
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.hikemate.app.R
 import com.google.firebase.FirebaseApp
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -110,5 +112,47 @@ class ProfileViewModelTest {
     verify(repository).deleteProfileById(eq("1"), any(), any())
 
     assert(profileViewModel.profile.value == null)
+  }
+
+  @Test
+  fun getProfileById_errorThrownByRepositoryIsHandled() {
+    `when`(repository.getProfileById(any(), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(Exception(context.getString(R.string.an_error_occurred_while_fetching_the_profile)))
+    }
+
+    profileViewModel.getProfileById("1")
+
+    assertEquals(
+        profileViewModel.errorMessageId.value,
+        R.string.an_error_occurred_while_fetching_the_profile)
+  }
+
+  @Test
+  fun updateProfile_errorThrownByRepositoryIsHandled() {
+    `when`(repository.updateProfile(any(), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(Exception(context.getString(R.string.an_error_occurred_while_updating_the_profile)))
+    }
+
+    profileViewModel.updateProfile(profile)
+
+    assertEquals(
+        profileViewModel.errorMessageId.value,
+        R.string.an_error_occurred_while_updating_the_profile)
+  }
+
+  @Test
+  fun deleteProfileById_errorThrownByRepositoryIsHandled() {
+    `when`(repository.deleteProfileById(any(), any(), any())).thenAnswer {
+      val onFailure = it.getArgument<(Exception) -> Unit>(2)
+      onFailure(Exception(context.getString(R.string.an_error_occurred_while_deleting_the_profile)))
+    }
+
+    profileViewModel.deleteProfileById("1")
+
+    assertEquals(
+        profileViewModel.errorMessageId.value,
+        R.string.an_error_occurred_while_deleting_the_profile)
   }
 }

--- a/app/src/test/java/ch/hikemate/app/model/route/saved/SavedHikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/saved/SavedHikesViewModelTest.kt
@@ -53,7 +53,7 @@ class SavedHikesViewModelTest {
 
         // Then
         assertEquals(
-            R.string.saved_hikes_screen_generic_error, savedHikesViewModel.errorMessage.value)
+            R.string.saved_hikes_screen_generic_error, savedHikesViewModel.errorMessageId.value)
       }
 
   @Test
@@ -98,7 +98,7 @@ class SavedHikesViewModelTest {
 
         // Then
         assertEquals(
-            R.string.saved_hikes_screen_generic_error, savedHikesViewModel.errorMessage.value)
+            R.string.saved_hikes_screen_generic_error, savedHikesViewModel.errorMessageId.value)
       }
 
   @Test
@@ -143,6 +143,6 @@ class SavedHikesViewModelTest {
 
         // Then
         assertEquals(
-            R.string.saved_hikes_screen_generic_error, savedHikesViewModel.errorMessage.value)
+            R.string.saved_hikes_screen_generic_error, savedHikesViewModel.errorMessageId.value)
       }
 }


### PR DESCRIPTION
# Summary
- Error were not correctly handled in the profile view model, this PR implements an error handling with feedback to the user.

# Details
- I removed default values since they should not have one now, either we have the correct profile, or we don't and it's an error.
- I changed the `errorMessage` to `errorMessageId`, since it's a string ID
- I changed the way the UI handles the update of the profile, in such a way that we can now detect an error before moving the user back
- I removed a navigation test because it just creates an account, without going through the create profile process (Since he does it using direct firebase function), and thus I don't have a profile to load, which throws an error screen. Such test is in reality a E2E test and is already covered by E2E tests
