### PR TITLE
Fix/signout is too fast

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -140,9 +140,12 @@ class AuthViewModel(
   }
 
   /** Signs out the current user. On successful sign-out, the _currentUser is set to null. */
-  fun signOut() {
+  fun signOut(onSuccess: () -> Unit) {
     repository.signOut(
-        onSuccess = { _currentUser.value = null },
+        onSuccess = {
+          _currentUser.value = null
+          onSuccess()
+        },
     )
   }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
@@ -137,8 +137,7 @@ fun ProfileScreen(
                   buttonType = ButtonType.SECONDARY,
                   label = context.getString(R.string.profile_screen_sign_out_button_text),
                   onClick = {
-                    authViewModel.signOut()
-                    navigationActions.navigateTo(Screen.AUTH)
+                    authViewModel.signOut({ navigationActions.navigateTo(Screen.AUTH) })
                   },
                   Modifier.testTag(ProfileScreen.TEST_TAG_SIGN_OUT_BUTTON))
             }

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -338,6 +338,8 @@ class AuthViewModelTest {
   fun signOut_calls_repository_signOut_and_updates_currentUser_to_null() = runTest {
     setupSignedInUser()
 
+    val mockOnSuccess: (() -> Unit) = mock()
+
     // Simulate a successful sign-out by invoking the onSuccess callback
     doAnswer { arguments ->
           val onSuccess = arguments.getArgument<() -> Unit>(0)
@@ -350,11 +352,13 @@ class AuthViewModelTest {
     // Verify that currentUser is initially mockFirebaseUser
     assertEquals(mockFirebaseUser, viewModel.currentUser.first())
 
-    viewModel.signOut()
+    viewModel.signOut { mockOnSuccess() }
 
     // Verify that the repository's signOut was called
     verify(mockRepository).signOut(any())
     // Verify that currentUser is updated to null
     assertEquals(null, viewModel.currentUser.value)
+    // Verify that the onSuccess callback was called
+    verify(mockOnSuccess).invoke()
   }
 }


### PR DESCRIPTION
# Summary

Add a onSuccess callback so we get better control what happens after signout, this fixes the the end2end test failing. Also updated the auth vM tests accordingly.


