### PR TITLE
refactor(details): hike difficulty as enum

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
@@ -1,11 +1,14 @@
 package ch.hikemate.app.ui.map
 
+import android.content.Context
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.model.elevation.ElevationService
 import ch.hikemate.app.model.route.Bounds
 import ch.hikemate.app.model.route.DetailedHikeRoute
+import ch.hikemate.app.model.route.HikeDifficulty
 import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.LatLong
@@ -63,8 +66,7 @@ class HikeDetailScreenTest {
           totalDistance = 13.543077559212616,
           elevationGain = 68.0,
           estimatedTime = 169.3169307105514,
-          difficulty = "Difficult",
-      )
+          difficulty = HikeDifficulty.DIFFICULT)
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Before
@@ -271,6 +273,9 @@ class HikeDetailScreenTest {
         .assertAny(hasText("${hourString}:${minuteString}"))
     composeTestRule
         .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
-        .assertAny(hasText(detailedRoute.difficulty))
+        .assertAny(
+            hasText(
+                ApplicationProvider.getApplicationContext<Context>()
+                    .getString(detailedRoute.difficulty.nameResourceId)))
   }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/DetailedHikeRoute.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/DetailedHikeRoute.kt
@@ -23,7 +23,7 @@ data class DetailedHikeRoute(
     val totalDistance: Double,
     val estimatedTime: Double,
     val elevationGain: Double,
-    val difficulty: String
+    val difficulty: HikeDifficulty
 ) {
 
   /**
@@ -133,10 +133,10 @@ private fun estimateTime(distance: Double, elevationGain: Double): Double {
  * @return A `String` representing the difficulty level: "Easy", "Moderate", or "Difficult".
  * @link https://www.parks.ca.gov/?page_id=24055
  */
-private fun determineDifficulty(distance: Double, elevationGain: Double): String {
+private fun determineDifficulty(distance: Double, elevationGain: Double): HikeDifficulty {
   return when {
-    distance < 3 && elevationGain < 250 -> "Easy"
-    distance in 0.0..6.0 && elevationGain in 0.0..500.0 -> "Moderate"
-    else -> "Difficult"
+    distance < 3 && elevationGain < 250 -> HikeDifficulty.EASY
+    distance in 0.0..6.0 && elevationGain in 0.0..500.0 -> HikeDifficulty.MODERATE
+    else -> HikeDifficulty.DIFFICULT
   }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeDifficulty.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeDifficulty.kt
@@ -1,0 +1,17 @@
+package ch.hikemate.app.model.route
+
+import androidx.annotation.StringRes
+import ch.hikemate.app.R
+
+/**
+ * Represents the difficulty level of a hike route.
+ *
+ * Three possible levels: easy, moderate or difficult.
+ *
+ * @param nameResourceId The string resource ID of the localizable name of the difficulty level
+ */
+enum class HikeDifficulty(@StringRes val nameResourceId: Int) {
+  EASY(R.string.hike_difficulty_easy),
+  MODERATE(R.string.hike_difficulty_moderate),
+  DIFFICULT(R.string.hike_difficulty_difficult)
+}

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -276,7 +276,7 @@ fun HikeDetails(
               value = "${hourString}:${minuteString}")
           DetailRow(
               label = stringResource(R.string.hike_detail_screen_label_difficulty),
-              value = detailedRoute.difficulty,
+              value = stringResource(detailedRoute.difficulty.nameResourceId),
               valueColor = Color.Green)
           DateDetailRow(isSaved, plannedDate, updatePlannedDate)
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,11 @@
     <string name="hike_detail_screen_value_planned">Planned</string>
     <string name="hike_detail_screen_add_a_date_button_text">Add a date</string>
 
+    <!-- Hike Difficulty Levels -->
+    <string name="hike_difficulty_easy">Easy</string>
+    <string name="hike_difficulty_moderate">Moderate</string>
+    <string name="hike_difficulty_difficult">Difficult</string>
+
 
     <!-- Saved Hikes Screen -->
     <string name="saved_hikes_screen_generic_error">

--- a/app/src/test/java/ch/hikemate/app/model/route/DetailedHikeRouteTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/DetailedHikeRouteTest.kt
@@ -1,6 +1,7 @@
 import ch.hikemate.app.model.elevation.ElevationServiceRepository
 import ch.hikemate.app.model.route.Bounds
 import ch.hikemate.app.model.route.DetailedHikeRoute
+import ch.hikemate.app.model.route.HikeDifficulty
 import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.LatLong
 import io.mockk.coEvery
@@ -51,7 +52,7 @@ class DetailedHikeRouteTest {
     assertEquals(314.4, detailedHikeRoute.totalDistance, 1.0)
     assertEquals(0.0, detailedHikeRoute.elevationGain, 0.0001)
     assertEquals(3772.0, detailedHikeRoute.estimatedTime, 1.0)
-    assertEquals("Difficult", detailedHikeRoute.difficulty)
+    assertEquals(HikeDifficulty.DIFFICULT, detailedHikeRoute.difficulty)
   }
 
   @Test
@@ -74,7 +75,7 @@ class DetailedHikeRouteTest {
     assertEquals(1.322, detailedHikeRoute.totalDistance, 1.0)
     assertEquals(0.0, detailedHikeRoute.elevationGain, 0.0001)
     assertEquals(18.0, detailedHikeRoute.estimatedTime, 1.0)
-    assertEquals("Easy", detailedHikeRoute.difficulty)
+    assertEquals(HikeDifficulty.EASY, detailedHikeRoute.difficulty)
   }
 
   @Test
@@ -97,7 +98,7 @@ class DetailedHikeRouteTest {
     assertEquals(5.56, detailedHikeRoute.totalDistance, 1.0)
     assertEquals(0.0, detailedHikeRoute.elevationGain, 0.0001)
     assertEquals(66.0, detailedHikeRoute.estimatedTime, 1.0)
-    assertEquals("Moderate", detailedHikeRoute.difficulty)
+    assertEquals(HikeDifficulty.MODERATE, detailedHikeRoute.difficulty)
   }
 
   @Test
@@ -120,7 +121,7 @@ class DetailedHikeRouteTest {
     assertEquals(11.12, detailedHikeRoute.totalDistance, 1.0)
     assertEquals(0.0, detailedHikeRoute.elevationGain, 0.0001)
     assertEquals(133.0, detailedHikeRoute.estimatedTime, 1.0)
-    assertEquals("Difficult", detailedHikeRoute.difficulty)
+    assertEquals(HikeDifficulty.DIFFICULT, detailedHikeRoute.difficulty)
   }
 
   @Test
@@ -148,7 +149,7 @@ class DetailedHikeRouteTest {
         assertEquals(12.75, detailedHikeRoute.totalDistance, 1.0)
         assertEquals(200.0, detailedHikeRoute.elevationGain, 0.0001)
         assertEquals(173.0, detailedHikeRoute.estimatedTime, 1.0)
-        assertEquals("Difficult", detailedHikeRoute.difficulty)
+        assertEquals(HikeDifficulty.DIFFICULT, detailedHikeRoute.difficulty)
       }
 
   @Test
@@ -204,6 +205,6 @@ class DetailedHikeRouteTest {
     assertEquals(207.59, detailedHikeRoute.totalDistance, 0.1)
     assertEquals(400.0, detailedHikeRoute.elevationGain, 0.0001)
     assertEquals(2531.0, detailedHikeRoute.estimatedTime, 1.0)
-    assertEquals("Difficult", detailedHikeRoute.difficulty)
+    assertEquals(HikeDifficulty.DIFFICULT, detailedHikeRoute.difficulty)
   }
 }


### PR DESCRIPTION
# Summary

This is a refactoring PR that turns the detailed hike's difficulty property type into an `enum` instead of a `String`. It also makes the name of the difficulty level translatable by moving it to the `strings.xml` file.

Not much more to say, this is a quite straight-forward PR.