### PR TITLE
feat(details): limit map scroll and zoom

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -78,8 +78,8 @@ import org.osmdroid.views.MapView
 
 object HikeDetailScreen {
   const val MAP_MAX_ZOOM = 18.0
-  const val MAP_MAX_LONGITUDE = 175.0
-  const val MAP_MIN_LONGITUDE = -175.0
+  const val MAP_MAX_LONGITUDE = 180.0
+  const val MAP_MIN_LONGITUDE = -180.0
   const val MAP_BOUNDS_MARGIN: Int = 100
 
   const val TEST_TAG_MAP = "map"


### PR DESCRIPTION
# Summary

The purpose of the details screen is to see more details about a particular hike. To this end, I was assigned to limit the scrolling and zooming the user can do on that screen, so that the map stays around the detailed hike.

# Details

I had to use an event provided by OSMDroid.

When creating the map (`val mapView = remember { ... }`), the center and the initial zoom level are provided to the map. However, the map does not compute its bounding box right away. I listen to the event that gets triggered when the map is ready to be displayed. By this point, the initial bounding box has been computed, and I can limit the scroll to that.