### PR TITLE
feat(hikes): implement HikesViewModel

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.model.route
 
+import ch.hikemate.app.model.route.saved.SavedHike
 import com.google.firebase.Timestamp
 
 /**
@@ -43,4 +44,7 @@ data class Hike(
     val estimatedTime: DeferredData<Double> = DeferredData.NotRequested,
     val elevationGain: DeferredData<Double> = DeferredData.NotRequested,
     val difficulty: DeferredData<HikeDifficulty> = DeferredData.NotRequested
-)
+) {
+  /** Helper to convert this [Hike] to a [SavedHike] object. */
+  fun toSavedHike() = SavedHike(id, name ?: "", plannedDate)
+}

--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -9,6 +9,9 @@ import com.google.firebase.Timestamp
  * and should only be obtained if absolutely necessary. For example [waypoints] or [elevation]. See
  * [DeferredData] for more information about how this works.
  *
+ * See [ch.hikemate.app.utils.RouteUtils] for more information about how the hike's details
+ * ([distance], [estimatedTime], [elevationGain], [difficulty]) are computed.
+ *
  * @param id The unique ID of the hike.
  * @param isSaved Whether the hike has been saved by the user.
  * @param plannedDate The date at which the user plans to go on the hike. Null if the user did not

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -364,7 +364,7 @@ class HikesViewModel(
    *   automatically.
    */
   fun computeDetailsFor(hikeId: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
-      viewModelScope.launch { retrieveDetailsForAsync(hikeId, onSuccess, onFailure) }
+      viewModelScope.launch { computeDetailsForAsync(hikeId, onSuccess, onFailure) }
 
   private suspend fun selectHikeAsync(
       hikeId: String,
@@ -981,7 +981,7 @@ class HikesViewModel(
         onFailure = { exception -> continuation.resumeWithException(exception) })
   }
 
-  private suspend fun retrieveDetailsForAsync(
+  private suspend fun computeDetailsForAsync(
       hikeId: String,
       onSuccess: () -> Unit,
       onFailure: () -> Unit
@@ -1047,7 +1047,7 @@ class HikesViewModel(
       }
 
   /**
-   * Helper function for [retrieveDetailsForAsync].
+   * Helper function for [computeDetailsForAsync].
    *
    * Checks that the required data ([Hike.waypoints] and [Hike.elevation]) are available, and that a
    * request is not already ongoing. Returns the data if it is available, and indicates whether a

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -865,8 +865,7 @@ class HikesViewModel(
                       }
                     }
                   }
-                  .toMap()
-                  .toMutableMap()
+                  .toMap(mutableMapOf())
 
           // Update the selected hike if necessary
           updateSelectedHike()

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -887,6 +887,14 @@ class HikesViewModel(
             onFailure = { exception -> continuation.resumeWithException(exception) })
       }
 
+  /**
+   * Helper function to determine whether a hike has all its OSM data loaded.
+   *
+   * OSM data includes [Hike.description], [Hike.bounds] and [Hike.waypoints].
+   *
+   * @param hike The hike to check.
+   * @return True if the hike has all its OSM data loaded, false otherwise.
+   */
   private fun hasOsmData(hike: Hike): Boolean =
       hike.description is DeferredData.Obtained &&
           hike.bounds is DeferredData.Obtained &&

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -350,6 +350,17 @@ class HikesViewModel(
   fun computeDetailsFor(hikeId: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
       viewModelScope.launch { computeDetailsForAsync(hikeId, onSuccess, onFailure) }
 
+  /**
+   * Internal helper function.
+   *
+   * The exposed [hikeFlows] list directly mirrors the private mutable state flow [_hikeFlowsList].
+   * However, for the view model to work with the hikes in an easier way, it uses [_hikeFlowsMap]
+   * internally, which maps hike IDs to their corresponding state flows.
+   *
+   * [_hikeFlowsMap] is the one that actually gets updated during operations. Once it has been
+   * updated, we need to update [_hikeFlowsList] to reflect the changes. This is what this helper
+   * function does.
+   */
   private fun updateHikeFlowsList() {
     _hikeFlowsList.value = _hikeFlowsMap.values.toList()
   }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -1155,7 +1155,13 @@ class HikesViewModel(
    * request is not already ongoing. Returns the data if it is available, and indicates whether a
    * request should be performed.
    *
-   * If a request should be performed, this function will also mark the data as requested.
+   * If no request should be performed (can be either because of an error or because the data are
+   * already requested/obtained), this function ([detailsPreRequestOperations]) is responsible for
+   * calling the right callback ([onSuccess] or [onFailure]).
+   *
+   * If a request should be performed, this function will mark the data as requested (see
+   * [DeferredData.Requested]). The caller is responsible for calling the right callback
+   * ([onSuccess] or [onFailure]) once the request is done.
    *
    * Note: this function does not set its context to [dispatcher], it is the responsibility of the
    * caller to do so.

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -70,12 +70,10 @@ class HikesViewModel(
    */
   private fun updateSelectedHike() {
     // If there is no selected hike, don't bother.
-    if (_selectedHikeId == null) {
+    val selectedHike = _selectedHike.value
+    if (_selectedHikeId == null || selectedHike == null) {
       return
     }
-
-    // Retrieve the selected hike from the map. If it's null, don't bother.
-    val selectedHike = _selectedHike.value ?: return
 
     // Retrieve the corresponding flow from the map.
     val selectedHikeFlow = _hikeFlowsMap[_selectedHikeId]

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -314,6 +314,9 @@ class HikesViewModel(
   /**
    * Indicates whether all details data have been computed for the provided hike.
    *
+   * Hike details are the [Hike.distance], [Hike.estimatedTime], [Hike.elevationGain] and
+   * [Hike.difficulty].
+   *
    * This is merely a helper function and does not perform any operations on the hike.
    *
    * @param hike The hike to check.

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -697,6 +697,9 @@ class HikesViewModel(
     // Update the hike's state flow
     hikeFlow.value = hike.copy(isSaved = true, plannedDate = date)
 
+    // Update the selected hike if necessary
+    updateSelectedHikeSavedStatus()
+
     return true
   }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -637,8 +637,7 @@ class HikesViewModel(
     _savedHikesMap[hikeId] = savedHike
 
     // Update the hike's state flow
-    val newHikeState = hikeFlow.value.copy(isSaved = true)
-    hikeFlow.value = newHikeState
+    hikeFlow.value = hikeFlow.value.copy(isSaved = true)
 
     // Update the selected hike if necessary
     updateSelectedHike()
@@ -687,8 +686,7 @@ class HikesViewModel(
             updateHikeFlowsList()
           } else {
             // The hike can stay even if it is not saved, so update it
-            val newHikeState = hikeFlow.value.copy(isSaved = false, plannedDate = null)
-            hikeFlow.value = newHikeState
+            hikeFlow.value = hikeFlow.value.copy(isSaved = false, plannedDate = null)
           }
 
           // Update the selected hike if necessary

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -71,8 +71,9 @@ class HikesViewModel(
   /**
    * Whether a new list of hikes is currently being retrieved.
    *
-   * Set to true when the view model is performing an update of the whole list. For example, this
-   * can happen when calling [loadHikesInBounds] or [loadSavedHikes].
+   * Set to true when the view model is performing an update of the whole list, or of the saved
+   * hikes cache (even without updating [hikeFlows]. For example, this can happen when calling
+   * [loadHikesInBounds], [refreshSavedHikesCache] or [loadSavedHikes].
    *
    * Individual updates to particular hikes are more frequent and will not set this value to true.
    *

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -415,6 +415,11 @@ class HikesViewModel(
       }
 
   /**
+   * Loads the current user's saved hikes and updates the local cache [_savedHikesMap].
+   *
+   * If needed, updates the loaded hikes in [_hikeFlowsMap] to reflect the new saved hikes, and the
+   * [_selectedHike] as well.
+   *
    * This function performs a loading operation but DOES NOT set [_loading]. If calling it from
    * another function, please set [_loading] to true before calling the function and to false once
    * the call has ended.

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -204,7 +204,8 @@ class HikesViewModel(
    * Setting a null date on an unsaved hike will have no effect.
    *
    * @param hikeId The ID of the hike to set the planned date of.
-   * @param date The planned date for the hike.
+   * @param date The planned date for the hike. If null, the hike's planned date will be removed
+   *   (meaning the hike is still saved but without a specific planned date).
    * @param onSuccess To be called if the hike's date is successfully updated.
    * @param onFailure To be called if a problem prevents the operation's success.
    */

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -611,6 +611,9 @@ class HikesViewModel(
             hikeFlow.value = newHikeState
           }
 
+          // Update the selected hike if necessary
+          updateSelectedHikeSavedStatus()
+
           successful = true
         }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -29,13 +29,13 @@ import org.osmdroid.util.BoundingBox
  *
  * @param savedHikesRepo The repository to work with saved hikes.
  * @param osmHikesRepo The repository to work with hikes from OpenStreetMap.
- * @param elevationRepo The service to retrieve elevation data.
+ * @param elevationService The service to retrieve elevation data.
  * @param dispatcher The dispatcher to be used to launch coroutines.
  */
 class HikesViewModel(
     private val savedHikesRepo: SavedHikesRepository,
     private val osmHikesRepo: HikeRoutesRepository,
-    private val elevationRepo: ElevationService,
+    private val elevationService: ElevationService,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
   companion object {
@@ -980,7 +980,7 @@ class HikesViewModel(
       coordinates: List<LatLong>,
       hikeId: String
   ): List<Double> = suspendCoroutine { continuation ->
-    elevationRepo.getElevation(
+    elevationService.getElevation(
         coordinates = coordinates,
         hikeID = hikeId,
         onSuccess = { elevation -> continuation.resume(elevation) },

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -772,7 +772,7 @@ class HikesViewModel(
     }
 
     // Set the hike's planned date to the right one
-    val newSavedHike = hike.toSavedHike()
+    val newSavedHike = SavedHike(id = hike.id, name = hike.name ?: "", date = date)
     try {
       savedHikesRepo.addSavedHike(newSavedHike)
     } catch (e: Exception) {

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -1001,8 +1001,7 @@ class HikesViewModel(
           mutableWaypoints = hike.waypoints.data
 
           // The elevation has not been requested yet, mark it as requested
-          val hikeMarkedAsRequested = hike.copy(elevation = DeferredData.Requested)
-          hikeFlow.value = hikeMarkedAsRequested
+          hikeFlow.value = hike.copy(elevation = DeferredData.Requested)
           success = true
         }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -808,7 +808,6 @@ class HikesViewModel(
           hikes = loadHikesInBoundsRepoWrapper(boundingBox.toBounds())
         } catch (e: Exception) {
           Log.e(LOG_TAG, "Error encountered while loading hikes in bounds", e)
-          _loading.value = false
           onFailure()
           return@withContext
         }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -56,7 +56,6 @@ class HikesViewModel(
     _hikeFlowsList.value = _hikeFlowsMap.values.toList()
   }
 
-  private var _selectedHikeId: String? = null
   private val _selectedHike = MutableStateFlow<Hike?>(null)
 
   /**
@@ -70,17 +69,13 @@ class HikesViewModel(
    */
   private fun updateSelectedHike() {
     // If there is no selected hike, don't bother.
-    val selectedHike = _selectedHike.value
-    if (_selectedHikeId == null || selectedHike == null) {
-      return
-    }
+    val selectedHike = _selectedHike.value ?: return
 
     // Retrieve the corresponding flow from the map.
-    val selectedHikeFlow = _hikeFlowsMap[_selectedHikeId]
+    val selectedHikeFlow = _hikeFlowsMap[selectedHike.id]
 
     if (selectedHikeFlow == null) {
       // The selected hike is not in the map, unselect it.
-      _selectedHikeId = null
       _selectedHike.value = null
     } else {
       // The selected hike is still in the map, update it.
@@ -382,7 +377,6 @@ class HikesViewModel(
           val hike = _hikeFlowsMap[hikeId] ?: return@withLock
 
           // Mark the hike as selected
-          _selectedHikeId = hikeId
           _selectedHike.value = hike.value
           successful = true
         }
@@ -398,8 +392,7 @@ class HikesViewModel(
   private suspend fun unselectHikeAsync() =
       _hikesMutex.withLock {
         // Only emit null as a value if the selected hike was not already null
-        if (_selectedHikeId != null) {
-          _selectedHikeId = null
+        if (_selectedHike.value != null) {
           _selectedHike.value = null
         }
       }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -393,6 +393,11 @@ class HikesViewModel(
     }
   }
 
+  /**
+   * See the documentation of [selectHike].
+   *
+   * This function is called by [selectHike] to perform its work asynchronously.
+   */
   private suspend fun selectHikeAsync(
       hikeId: String,
       onSuccess: () -> Unit,
@@ -417,6 +422,11 @@ class HikesViewModel(
         }
       }
 
+  /**
+   * See the documentation of [unselectHike].
+   *
+   * This function is called by [unselectHike] to perform its work asynchronously.
+   */
   private suspend fun unselectHikeAsync() =
       _hikesMutex.withLock {
         // Only emit null as a value if the selected hike was not already null
@@ -528,6 +538,11 @@ class HikesViewModel(
     updateHikeFlowsList()
   }
 
+  /**
+   * See the documentation of [loadSavedHikes].
+   *
+   * This function is called by [loadSavedHikes] to perform its work asynchronously.
+   */
   private suspend fun loadSavedHikesAsync(onSuccess: () -> Unit, onFailure: () -> Unit) =
       withContext(dispatcher) {
         // Remember that the loaded hikes list will now only hold saved hikes
@@ -572,6 +587,11 @@ class HikesViewModel(
     }
   }
 
+  /**
+   * See the documentation of [saveHike].
+   *
+   * This function is called by [saveHike] to perform its work asynchronously.
+   */
   private suspend fun saveHikeAsync(hikeId: String, onSuccess: () -> Unit, onFailure: () -> Unit) =
       withContext(dispatcher) {
         val successful: Boolean
@@ -625,6 +645,11 @@ class HikesViewModel(
     return true
   }
 
+  /**
+   * See the documentation of [unsaveHike].
+   *
+   * This function is called by [unsaveHike] to perform its work asynchronously.
+   */
   private suspend fun unsaveHikeAsync(
       hikeId: String,
       onSuccess: () -> Unit,
@@ -679,6 +704,11 @@ class HikesViewModel(
         }
       }
 
+  /**
+   * See the documentation of [setPlannedDate].
+   *
+   * This function is called by [setPlannedDate] to perform its work asynchronously.
+   */
   private suspend fun setPlannedDateAsync(
       hikeId: String,
       date: Timestamp?,
@@ -757,6 +787,11 @@ class HikesViewModel(
     return true
   }
 
+  /**
+   * See the documentation of [loadHikesInBounds].
+   *
+   * This function is called by [loadHikesInBounds] to perform its work asynchronously.
+   */
   private suspend fun loadHikesInBoundsAsync(
       boundingBox: BoundingBox,
       onSuccess: () -> Unit,
@@ -857,6 +892,11 @@ class HikesViewModel(
           hike.bounds is DeferredData.Obtained &&
           hike.waypoints is DeferredData.Obtained
 
+  /**
+   * See the documentation of [retrieveLoadedHikesOsmData].
+   *
+   * This function is called by [retrieveLoadedHikesOsmData] to perform its work asynchronously.
+   */
   private suspend fun retrieveLoadedHikesOsmDataAsync(
       onSuccess: () -> Unit,
       onFailure: () -> Unit
@@ -920,6 +960,11 @@ class HikesViewModel(
             onFailure = { exception -> continuation.resumeWithException(exception) })
       }
 
+  /**
+   * See the documentation of [retrieveElevationDataFor].
+   *
+   * This function is called by [retrieveElevationDataFor] to perform its work asynchronously.
+   */
   private suspend fun retrieveElevationDataForAsync(
       hikeId: String,
       onSuccess: () -> Unit,
@@ -1018,6 +1063,11 @@ class HikesViewModel(
         onFailure = { exception -> continuation.resumeWithException(exception) })
   }
 
+  /**
+   * See the documentation of [computeDetailsFor].
+   *
+   * This function is called by [computeDetailsFor] to perform its work asynchronously.
+   */
   private suspend fun computeDetailsForAsync(
       hikeId: String,
       onSuccess: () -> Unit,

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -726,12 +726,8 @@ class HikesViewModel(
       onFailure: () -> Unit
   ) =
       withContext(dispatcher) {
-        var successful = false
-        _hikesMutex.withLock {
-          // Retrieve the hike to update from the loaded hikes
-          val hikeFlow = _hikeFlowsMap[hikeId] ?: return@withLock
-          successful = updateHikePlannedDateAsync(hikeFlow, date)
-        }
+        val successful: Boolean
+        _hikesMutex.withLock { successful = updateHikePlannedDateAsync(hikeId, date) }
 
         if (successful) {
           onSuccess()
@@ -749,10 +745,9 @@ class HikesViewModel(
    * @param hikeFlow The flow of the hike to update.
    * @return True if the operation was successful, false otherwise.
    */
-  private suspend fun updateHikePlannedDateAsync(
-      hikeFlow: MutableStateFlow<Hike>,
-      date: Timestamp?
-  ): Boolean {
+  private suspend fun updateHikePlannedDateAsync(hikeId: String, date: Timestamp?): Boolean {
+    // Retrieve the hike to update from the loaded hikes
+    val hikeFlow = _hikeFlowsMap[hikeId] ?: return false
     val hike = hikeFlow.value
 
     // If the hike is already saved with the provided date, don't do anything

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -294,7 +294,15 @@ class HikesViewModel(
    *   operation.
    */
   fun retrieveLoadedHikesOsmData(onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
-      viewModelScope.launch { retrieveLoadedHikesOsmDataAsync(onSuccess, onFailure) }
+      viewModelScope.launch {
+        // Notify the UI that a heavy loading operation is in progress
+        _loading.value = true
+
+        retrieveLoadedHikesOsmDataAsync(onSuccess, onFailure)
+
+        // The heavy loading operation is done now
+        _loading.value = false
+      }
 
   /**
    * Indicates whether [retrieveElevationDataFor] can be called for the provided hike.
@@ -817,9 +825,6 @@ class HikesViewModel(
       onFailure: () -> Unit
   ) =
       withContext(dispatcher) {
-        // Notify the UI that a heavy loading operation is in progress
-        _loading.value = true
-
         // Prepare a list of hikes for which we need to retrieve the data
         val idsToRetrieve: List<String>
         _hikesMutex.withLock {
@@ -828,7 +833,6 @@ class HikesViewModel(
 
         // If all routes already have their OSM data, do nothing more
         if (idsToRetrieve.isEmpty()) {
-          _loading.value = false
           onSuccess()
           return@withContext
         }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -823,7 +823,7 @@ class HikesViewModel(
         // Prepare a list of hikes for which we need to retrieve the data
         val idsToRetrieve: List<String>
         _hikesMutex.withLock {
-          idsToRetrieve = _hikeFlowsMap.values.filter { hasOsmData(it.value) }.map { it.value.id }
+          idsToRetrieve = _hikeFlowsMap.values.filter { !hasOsmData(it.value) }.map { it.value.id }
         }
 
         // Retrieve the OSM data of the hikes

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -861,6 +861,9 @@ class HikesViewModel(
                     waypoints = DeferredData.Obtained(hikeRoute.ways))
             hikeFlow.value = newHike
           }
+
+          // Update the selected hike if necessary
+          updateSelectedHike()
         }
 
         // Release the mutex before calling onSuccess to avoid deadlocks or performance issues

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -331,6 +331,8 @@ class HikesViewModel(
   /**
    * Computes all details attributes of a hike.
    *
+   * See [areDetailsComputedFor] to learn what the details of a hike are.
+   *
    * Requires the hike's way points and elevation to have been loaded before. If the way points or
    * the elevation are not available, [onFailure] will be called.
    *
@@ -343,6 +345,7 @@ class HikesViewModel(
    *   another request is already in progress, even though the data are not yet available. Do not
    *   use this callback to retrieve the details values, rather observe the hike in [hikeFlows] to
    *   be notified automatically when it is available.
+   * @see [areDetailsComputedFor]
    */
   fun computeDetailsFor(hikeId: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
       viewModelScope.launch { computeDetailsForAsync(hikeId, onSuccess, onFailure) }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -297,9 +297,11 @@ class HikesViewModel(
    * first time and mark the data as requested (see [DeferredData] and [Hike] for more information).
    *
    * @param hikeId The ID of the hike to retrieve the elevation data for.
-   * @param onSuccess To be called once the elevation has been successfully retrieved for the hike.
-   *   Do not use this to retrieve the elevation, rather observe the hike in [hikeFlows] to be
-   *   notified automatically.
+   * @param onSuccess To be called once the elevation data have been successfully requested and/or
+   *   retrieved. To avoid multiple requests for the same data, [onSuccess] will be called if
+   *   another request is already in progress, even though the data are not yet available. Do not
+   *   use this callback to retrieve the elevation data, rather observe the hike in [hikeFlows] to
+   *   be notified automatically when it is available.
    * @param onFailure To be called if a problem is encountered and prevents the elevation from being
    *   retrieved.
    */

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -951,6 +951,10 @@ class HikesViewModel(
 
           val updatedHike = hike.copy(elevation = DeferredData.Obtained(elevation))
           hikeFlow.value = updatedHike
+
+          // Update the selected hike if necessary
+          updateSelectedHike()
+
           success = true
         }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -826,6 +826,13 @@ class HikesViewModel(
           idsToRetrieve = _hikeFlowsMap.values.filter { !hasOsmData(it.value) }.map { it.value.id }
         }
 
+        // If all routes already have their OSM data, do nothing more
+        if (idsToRetrieve.isEmpty()) {
+          _loading.value = false
+          onSuccess()
+          return@withContext
+        }
+
         // Retrieve the OSM data of the hikes
         val hikeRoutes: List<HikeRoute>
         try {

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -1081,7 +1081,7 @@ class HikesViewModel(
       withContext(dispatcher) {
         // Retrieve the current value of the hike and note what computations are required
         val (performRequest, waypoints, elevation) =
-            checkDetailsCanBeRetrievedForAsync(hikeId, onSuccess, onFailure)
+            detailsPreRequestOperations(hikeId, onSuccess, onFailure)
 
         if (!performRequest) {
           return@withContext
@@ -1169,7 +1169,7 @@ class HikesViewModel(
    * - The `List` of elevation data of the hike, if available. If not available, the list will be
    *   empty and the boolean will be false.
    */
-  private suspend fun checkDetailsCanBeRetrievedForAsync(
+  private suspend fun detailsPreRequestOperations(
       hikeId: String,
       onSuccess: () -> Unit,
       onFailure: () -> Unit

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -783,6 +783,9 @@ class HikesViewModel(
                   .toMap()
                   .toMutableMap()
 
+          // Update the selected hike if necessary
+          updateSelectedHike()
+
           // Update the exposed list of hikes based on the map of hikes
           updateHikeFlowsList()
         }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -1019,6 +1019,9 @@ class HikesViewModel(
                     difficulty = DeferredData.NotRequested,
                 )
             hikeFlow.value = updatedHike
+
+            // Update the selected hike if necessary
+            updateSelectedHike()
           }
 
           onFailure()
@@ -1036,6 +1039,10 @@ class HikesViewModel(
                   estimatedTime = DeferredData.Obtained(estimatedTime),
                   difficulty = DeferredData.Obtained(difficulty))
           hikeFlow.value = updatedHike
+
+          // Update the selected hike if necessary
+          updateSelectedHike()
+
           success = true
         }
 
@@ -1117,6 +1124,9 @@ class HikesViewModel(
               elevationGain = DeferredData.Requested,
           )
       hikeFlow.value = hikeWithRequestedAttributes
+
+      // Update the selected hike if necessary
+      updateSelectedHike()
 
       success = true
     }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -815,9 +815,10 @@ class HikesViewModel(
         // Wait for the lock to avoid concurrent modifications
         _hikesMutex.withLock {
           // Keep already loaded hikes, discard the ones that do not appear in the given bounds
+          val keysToKeep = hikes.map { it.id }
           _hikeFlowsMap =
               _hikeFlowsMap
-                  .filterKeys { key -> hikes.none { hike -> hike.id == key } }
+                  .filterKeys { key -> keysToKeep.contains(key) }
                   .toMutableMap()
 
           // Add the new hikes to the map of hikes

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -333,9 +333,11 @@ class HikesViewModel(
    * first time and mark the data as requested (see [DeferredData] and [Hike] for more information).
    *
    * @param hikeId The ID of the hike to retrieve the details attributes for.
-   * @param onSuccess To be called once the details have been successfully retrieved. Do not use
-   *   this to retrieve the details values, rather observe the hike in [hikeFlows] to be notified
-   *   automatically.
+   * @param onSuccess To be called once the details have been successfully requested and/or
+   *   retrieved. To avoid multiple requests for the same data, [onSuccess] will be called if
+   *   another request is already in progress, even though the data are not yet available. Do not
+   *   use this callback to retrieve the details values, rather observe the hike in [hikeFlows] to
+   *   be notified automatically when it is available.
    */
   fun computeDetailsFor(hikeId: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
       viewModelScope.launch { computeDetailsForAsync(hikeId, onSuccess, onFailure) }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -840,8 +840,10 @@ class HikesViewModel(
                     } else {
                       // The hike is already in the map, update it
                       val existingHike = existingFlow.value
-                      // Assume bounds and waypoints don't change for a hike. If they are already
-                      // loaded, don't update them
+                      // Assume a user session won't last long enough for a hike to change its
+                      // bounds and/or waypoints. If they are already loaded, don't update them.
+                      // OSM might update bounds and waypoints, but we decided it is sufficient to
+                      // have the new values loaded the next time the user opens the app.
                       if (existingHike.bounds !is DeferredData.Obtained ||
                           existingHike.waypoints !is DeferredData.Obtained) {
                         val newHike =

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -230,7 +230,15 @@ class HikesViewModel(
    * @param onFailure Will be called if an error is encountered.
    */
   fun loadHikesInBounds(bounds: BoundingBox, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
-      viewModelScope.launch { loadHikesInBoundsAsync(bounds, onSuccess, onFailure) }
+      viewModelScope.launch {
+        // Let the user know a heavy load operation is being performed
+        _loading.value = true
+
+        loadHikesInBoundsAsync(bounds, onSuccess, onFailure)
+
+        // The heavy loading operation is done now
+        _loading.value = false
+      }
 
   /**
    * Retrieves the bounding box and way points of the currently loaded hikes.
@@ -709,9 +717,6 @@ class HikesViewModel(
       onFailure: () -> Unit
   ) =
       withContext(dispatcher) {
-        // Let the user know a heavy load operation is being performed
-        _loading.value = true
-
         // We are loading hikes from bounds, remember this to avoid overriding loaded hikes with saved
         // hikes when those get reloaded.
         _loadedHikesType = LoadedHikes.FromBounds
@@ -779,9 +784,6 @@ class HikesViewModel(
           // Update the exposed list of hikes based on the map of hikes
           updateHikeFlowsList()
         }
-
-        // The heavy loading operation is done now
-        _loading.value = false
 
         // Call the success callback once the mutex has been released to avoid locking for too long
         onSuccess()

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -1037,8 +1037,7 @@ class HikesViewModel(
           val hikeFlow = _hikeFlowsMap[hikeId] ?: return@withLock
           val hike = hikeFlow.value
 
-          val updatedHike = hike.copy(elevation = DeferredData.Obtained(elevation))
-          hikeFlow.value = updatedHike
+          hikeFlow.value = hike.copy(elevation = DeferredData.Obtained(elevation))
 
           // Update the selected hike if necessary
           updateSelectedHike()

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -1103,14 +1103,13 @@ class HikesViewModel(
           // Set the detail properties back to NotRequested
           _hikesMutex.withLock {
             val hikeFlow = _hikeFlowsMap[hikeId] ?: return@withLock
-            val updatedHike =
+            hikeFlow.value =
                 hikeFlow.value.copy(
                     distance = DeferredData.NotRequested,
                     elevationGain = DeferredData.NotRequested,
                     estimatedTime = DeferredData.NotRequested,
                     difficulty = DeferredData.NotRequested,
                 )
-            hikeFlow.value = updatedHike
 
             // Update the selected hike if necessary
             updateSelectedHike()
@@ -1124,13 +1123,12 @@ class HikesViewModel(
         var success = false
         _hikesMutex.withLock {
           val hikeFlow = _hikeFlowsMap[hikeId] ?: return@withLock
-          val updatedHike =
+          hikeFlow.value =
               hikeFlow.value.copy(
                   distance = DeferredData.Obtained(distance),
                   elevationGain = DeferredData.Obtained(elevationGain),
                   estimatedTime = DeferredData.Obtained(estimatedTime),
                   difficulty = DeferredData.Obtained(difficulty))
-          hikeFlow.value = updatedHike
 
           // Update the selected hike if necessary
           updateSelectedHike()
@@ -1208,14 +1206,13 @@ class HikesViewModel(
       nullableElevation = hike.elevation.data
 
       // Set the details of the hike to have been requested
-      val hikeWithRequestedAttributes =
+      hikeFlow.value =
           hike.copy(
               distance = DeferredData.Requested,
               estimatedTime = DeferredData.Requested,
               difficulty = DeferredData.Requested,
               elevationGain = DeferredData.Requested,
           )
-      hikeFlow.value = hikeWithRequestedAttributes
 
       // Update the selected hike if necessary
       updateSelectedHike()

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -625,15 +625,16 @@ class HikesViewModel(
     }
 
     // Save the hike using the repository
+    val savedHike = hike.toSavedHike()
     try {
-      savedHikesRepo.addSavedHike(SavedHike(hike.id, hike.name ?: "", hike.plannedDate))
+      savedHikesRepo.addSavedHike(savedHike)
     } catch (e: Exception) {
       Log.e(LOG_TAG, "Error encountered while saving hike", e)
       return false
     }
 
     // Update the saved hikes map
-    _savedHikesMap[hikeId] = SavedHike(hike.id, hike.name ?: "", hike.plannedDate)
+    _savedHikesMap[hikeId] = savedHike
 
     // Update the hike's state flow
     val newHikeState = hikeFlow.value.copy(isSaved = true)
@@ -670,7 +671,7 @@ class HikesViewModel(
 
           // Unsave the hike using the repository
           try {
-            savedHikesRepo.removeSavedHike(SavedHike(hike.id, hike.name ?: "", hike.plannedDate))
+            savedHikesRepo.removeSavedHike(hike.toSavedHike())
           } catch (e: Exception) {
             Log.e(LOG_TAG, "Error encountered while unsaving hike", e)
             successful = false
@@ -767,7 +768,7 @@ class HikesViewModel(
     }
 
     // Set the hike's planned date to the right one
-    val newSavedHike = SavedHike(id = hike.id, name = hike.name ?: "", date = date)
+    val newSavedHike = hike.toSavedHike()
     try {
       savedHikesRepo.addSavedHike(newSavedHike)
     } catch (e: Exception) {

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -817,9 +817,7 @@ class HikesViewModel(
           // Keep already loaded hikes, discard the ones that do not appear in the given bounds
           val keysToKeep = hikes.map { it.id }
           _hikeFlowsMap =
-              _hikeFlowsMap
-                  .filterKeys { key -> keysToKeep.contains(key) }
-                  .toMutableMap()
+              _hikeFlowsMap.filterKeys { key -> keysToKeep.contains(key) }.toMutableMap()
 
           // Add the new hikes to the map of hikes
           _hikeFlowsMap =

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -52,39 +52,7 @@ class HikesViewModel(
 
   private val _hikeFlowsList = MutableStateFlow<List<StateFlow<Hike>>>(emptyList())
 
-  private fun updateHikeFlowsList() {
-    _hikeFlowsList.value = _hikeFlowsMap.values.toList()
-  }
-
   private val _selectedHike = MutableStateFlow<Hike?>(null)
-
-  /**
-   * Helper function to update the selected hike once (or before) [hikeFlows] has been updated.
-   *
-   * This function does not acquire the [_hikesMutex]. It is the responsibility of the caller to
-   * call this function inside of a [Mutex.withLock] block.
-   *
-   * This function does not switch context either, it is the responsibility of the caller to call
-   * this function inside of a [withContext] block.
-   */
-  private fun updateSelectedHike() {
-    // If there is no selected hike, don't bother.
-    val selectedHike = _selectedHike.value ?: return
-
-    // Retrieve the corresponding flow from the map.
-    val selectedHikeFlow = _hikeFlowsMap[selectedHike.id]
-
-    if (selectedHikeFlow == null) {
-      // The selected hike is not in the map, unselect it.
-      _selectedHike.value = null
-    } else {
-      // The selected hike is still in the map, update it.
-      val flowValue = selectedHikeFlow.value
-      if (flowValue != selectedHike) {
-        _selectedHike.value = flowValue
-      }
-    }
-  }
 
   /** Internal type used to store where the hikes in [_hikeFlowsMap] come from. */
   private enum class LoadedHikes {
@@ -364,6 +332,38 @@ class HikesViewModel(
    */
   fun computeDetailsFor(hikeId: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
       viewModelScope.launch { computeDetailsForAsync(hikeId, onSuccess, onFailure) }
+
+  private fun updateHikeFlowsList() {
+    _hikeFlowsList.value = _hikeFlowsMap.values.toList()
+  }
+
+  /**
+   * Helper function to update the selected hike once (or before) [hikeFlows] has been updated.
+   *
+   * This function does not acquire the [_hikesMutex]. It is the responsibility of the caller to
+   * call this function inside of a [Mutex.withLock] block.
+   *
+   * This function does not switch context either, it is the responsibility of the caller to call
+   * this function inside of a [withContext] block.
+   */
+  private fun updateSelectedHike() {
+    // If there is no selected hike, don't bother.
+    val selectedHike = _selectedHike.value ?: return
+
+    // Retrieve the corresponding flow from the map.
+    val selectedHikeFlow = _hikeFlowsMap[selectedHike.id]
+
+    if (selectedHikeFlow == null) {
+      // The selected hike is not in the map, unselect it.
+      _selectedHike.value = null
+    } else {
+      // The selected hike is still in the map, update it.
+      val flowValue = selectedHikeFlow.value
+      if (flowValue != selectedHike) {
+        _selectedHike.value = flowValue
+      }
+    }
+  }
 
   private suspend fun selectHikeAsync(
       hikeId: String,

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -250,8 +250,13 @@ class HikesViewModel(
    * The bounding box and way points are then stored in the respective hikes, the state flows are
    * updated directly, no need for a return value.
    *
-   * This is a one-time operation, the OSM data will only be retrieved for the hikes that are in the
-   * list at the time of calling this function.
+   * This is a one-time operation. Calling this function does NOT start retrieving OSM data for
+   * every new hike that gets added to [hikeFlows]. Instead, it takes a snapshot of [hikeFlows] and
+   * retrieves the data for the hikes in that snapshot.
+   *
+   * Note that the snapshot might not exactly match the current state of [hikeFlows] when the
+   * calling of this function is performed, depending on what other operations are performed by the
+   * view model at the time of calling.
    *
    * @param onSuccess To be called once the data has been retrieved successfully. Do not use this
    *   callback to retrieve the data manually. Instead, observe [hikeFlows] to be notified

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -84,8 +84,7 @@ class HikesViewModel(
       // The selected hike is not in the map, unselect it.
       _selectedHikeId = null
       _selectedHike.value = null
-    }
-    else {
+    } else {
       // The selected hike is still in the map, update it.
       val flowValue = selectedHikeFlow.value
       if (flowValue != selectedHike) {
@@ -264,7 +263,11 @@ class HikesViewModel(
    * @param onSuccess To be called when hikes have been successfully loaded.
    * @param onFailure Will be called if an error is encountered.
    */
-  fun loadHikesInBounds(bounds: BoundingBox, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
+  fun loadHikesInBounds(
+      bounds: BoundingBox,
+      onSuccess: () -> Unit = {},
+      onFailure: () -> Unit = {}
+  ) =
       viewModelScope.launch {
         // Let the user know a heavy load operation is being performed
         _loading.value = true
@@ -332,8 +335,11 @@ class HikesViewModel(
    * @param onFailure To be called if a problem is encountered and prevents the elevation from being
    *   retrieved.
    */
-  fun retrieveElevationDataFor(hikeId: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
-      viewModelScope.launch { retrieveElevationDataForAsync(hikeId, onSuccess, onFailure) }
+  fun retrieveElevationDataFor(
+      hikeId: String,
+      onSuccess: () -> Unit = {},
+      onFailure: () -> Unit = {}
+  ) = viewModelScope.launch { retrieveElevationDataForAsync(hikeId, onSuccess, onFailure) }
 
   /**
    * Indicates whether all details data have been computed for the provided hike.
@@ -473,14 +479,13 @@ class HikesViewModel(
     if (_loadedHikesType == LoadedHikes.FromSaved) {
       _savedHikesMap.forEach { (hikeId, savedHike) ->
         if (!_hikeFlowsMap.containsKey(hikeId)) {
-          _hikeFlowsMap[hikeId] = MutableStateFlow(
-            Hike(
-              id = savedHike.id,
-              isSaved = true,
-              plannedDate = savedHike.date,
-              name = savedHike.name
-            )
-          )
+          _hikeFlowsMap[hikeId] =
+              MutableStateFlow(
+                  Hike(
+                      id = savedHike.id,
+                      isSaved = true,
+                      plannedDate = savedHike.date,
+                      name = savedHike.name))
         }
       }
     }
@@ -727,7 +732,8 @@ class HikesViewModel(
       onFailure: () -> Unit
   ) =
       withContext(dispatcher) {
-        // We are loading hikes from bounds, remember this to avoid overriding loaded hikes with saved
+        // We are loading hikes from bounds, remember this to avoid overriding loaded hikes with
+        // saved
         // hikes when those get reloaded.
         _loadedHikesType = LoadedHikes.FromBounds
 

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -492,9 +492,6 @@ class HikesViewModelTest {
 
   @Test
   fun saveHikeFailsIfNoCorrespondingHikeIsFound() = runTest(dispatcher) {
-    // Check that no hike was loaded for now
-    assertEquals(0, hikesViewModel.hikeFlows.value.size)
-
     // Try to save a hike that is not loaded
     var onFailureCalled = false
     hikesViewModel.saveHike(

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -969,7 +969,7 @@ class HikesViewModelTest {
     // Set the repository to throw an exception because we do not care
     coEvery { osmHikesRepo.getRoutes(any(), any(), any()) } throws Exception("Failed to load saved hikes")
 
-    // Refresh the saved hikes cache
+    // Load hikes in bounds
     hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
 
     // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now, hence

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -560,4 +560,28 @@ class HikesViewModelTest {
     // The hike should now be marked as saved
     assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
   }
+
+  @Test
+  fun `saveHike updates selected hike if its status changes`() = runTest(dispatcher) {
+    // Load some hikes to be selected
+    loadOsmHikes(singleOsmHike1)
+
+    // Select the hike to be updated
+    val hikeId = singleOsmHike1[0].id
+    hikesViewModel.selectHike(hikeId)
+    // Check that the hike is selected
+    assertNotNull(hikesViewModel.selectedHike.value)
+    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+    // Check that the hike is not marked as saved yet
+    assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+
+    // Make sure the saved hikes repository saves the hike
+    coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+
+    // Save the selected hike
+    hikesViewModel.saveHike(hikeId)
+
+    // Check that the selected hike is now marked as saved
+    assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
+  }
 }

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -121,6 +121,21 @@ class HikesViewModelTest {
   private val expectedElevationGain: Double = 3.0
   private val expectedDifficulty: HikeDifficulty = HikeDifficulty.EASY
 
+  private val completeHike =
+      Hike(
+          id = "complete",
+          isSaved = false,
+          plannedDate = null,
+          name = "Hike",
+          description = DeferredData.Obtained("Hike Description"),
+          bounds = DeferredData.Obtained(testBounds),
+          waypoints = DeferredData.Obtained(testWaypoints),
+          elevation = DeferredData.Obtained(elevationProfile1),
+          distance = DeferredData.Obtained(expectedDistance),
+          estimatedTime = DeferredData.Obtained(expectedEstimatedTime),
+          elevationGain = DeferredData.Obtained(expectedElevationGain),
+          difficulty = DeferredData.Obtained(expectedDifficulty))
+
   // ==========================================================================
   // HikesViewModel.selectHike
   // ==========================================================================
@@ -1743,4 +1758,29 @@ class HikesViewModelTest {
             expectedDifficulty,
             (hikesViewModel.selectedHike.value?.difficulty as DeferredData.Obtained).data)
       }
+
+  // ==========================================================================
+  // HikesViewModel.canElevationDataBeRetrievedFor
+  // ==========================================================================
+
+  @Test
+  fun `canElevationDataBeRetrievedFor returns false with unrequested waypoints`() {
+    val hikeWithNoWaypoints =
+        completeHike.copy(
+            waypoints = DeferredData.NotRequested, elevation = DeferredData.NotRequested)
+    assertFalse(hikesViewModel.canElevationDataBeRetrievedFor(hikeWithNoWaypoints))
+  }
+
+  @Test
+  fun `canElevationDataBeRetrievedFor returns false with requested waypoints`() {
+    val hikeWithNoWaypoints =
+        completeHike.copy(waypoints = DeferredData.Requested, elevation = DeferredData.NotRequested)
+    assertFalse(hikesViewModel.canElevationDataBeRetrievedFor(hikeWithNoWaypoints))
+  }
+
+  @Test
+  fun `canElevationDataBeRetrievedFor returns true with waypoints`() {
+    val hikeWithWaypoints = completeHike.copy(elevation = DeferredData.NotRequested)
+    assertTrue(hikesViewModel.canElevationDataBeRetrievedFor(hikeWithWaypoints))
+  }
 }

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -56,45 +56,52 @@ class HikesViewModelTest {
 
   private val firstJanuary2024 = Timestamp.from(2024, 1, 1)
 
-  private val singleSavedHike1: List<SavedHike> = listOf(SavedHike(id = "saved1", name = "Saved Hike 1", date = null))
+  private val singleSavedHike1: List<SavedHike> =
+      listOf(SavedHike(id = "saved1", name = "Saved Hike 1", date = null))
 
-  private val singleSavedHike2: List<SavedHike> = listOf(SavedHike(id = "saved2", name = "Saved Hike 2", date = firstJanuary2024))
+  private val singleSavedHike2: List<SavedHike> =
+      listOf(SavedHike(id = "saved2", name = "Saved Hike 2", date = firstJanuary2024))
 
-  private fun loadSavedHikes(savedHikes: List<SavedHike>, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {})  {
+  private fun loadSavedHikes(
+      savedHikes: List<SavedHike>,
+      onSuccess: () -> Unit = {},
+      onFailure: () -> Unit = {}
+  ) {
     coEvery { savedHikesRepo.loadSavedHikes() } returns savedHikes
     hikesViewModel.loadSavedHikes(onSuccess, onFailure)
   }
 
-  private val testBounds: Bounds = Bounds(
-    minLat = 45.8689061,
-    minLon = 6.4395807,
-    maxLat = 46.8283926,
-    maxLon = 7.2109599)
+  private val testBounds: Bounds =
+      Bounds(minLat = 45.8689061, minLon = 6.4395807, maxLat = 46.8283926, maxLon = 7.2109599)
 
-  private val testWaypoints: List<LatLong> = listOf(
-    LatLong(lat = 46.8240018, lon = 6.4395807),
-    LatLong(lat = 46.823965, lon = 6.4396698),
-    LatLong(lat = 46.8235322, lon = 6.4401168),
-    LatLong(lat = 46.8234367, lon = 6.4401715),
-    LatLong(lat = 46.8240018, lon = 6.4395807),
-    LatLong(lat = 46.823965, lon = 6.4396698),
-    LatLong(lat = 46.8235322, lon = 6.4401168)
-  )
+  private val testWaypoints: List<LatLong> =
+      listOf(
+          LatLong(lat = 46.8240018, lon = 6.4395807),
+          LatLong(lat = 46.823965, lon = 6.4396698),
+          LatLong(lat = 46.8235322, lon = 6.4401168),
+          LatLong(lat = 46.8234367, lon = 6.4401715),
+          LatLong(lat = 46.8240018, lon = 6.4395807),
+          LatLong(lat = 46.823965, lon = 6.4396698),
+          LatLong(lat = 46.8235322, lon = 6.4401168))
 
-  private val singleOsmHike1: List<HikeRoute> = listOf(HikeRoute(id = "osm1", name = "OSM Hike 1", bounds = testBounds, ways = testWaypoints))
+  private val singleOsmHike1: List<HikeRoute> =
+      listOf(HikeRoute(id = "osm1", name = "OSM Hike 1", bounds = testBounds, ways = testWaypoints))
 
-  private val singleOsmHike2: List<HikeRoute> = listOf(HikeRoute(id = "osm2", name = "OSM Hike 2", bounds = testBounds, ways = testWaypoints))
+  private val singleOsmHike2: List<HikeRoute> =
+      listOf(HikeRoute(id = "osm2", name = "OSM Hike 2", bounds = testBounds, ways = testWaypoints))
 
-  private val doubleOsmHikes1: List<HikeRoute> = listOf(
-    singleOsmHike1[0],
-    singleOsmHike2[0]
-  )
+  private val doubleOsmHikes1: List<HikeRoute> = listOf(singleOsmHike1[0], singleOsmHike2[0])
 
-  private fun loadOsmHikes(osmHikes: List<HikeRoute>, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) {
-    every { osmHikesRepo.getRoutes(any(), any(), any()) } answers {
-      val successCallback = secondArg<(List<HikeRoute>) -> Unit>()
-      successCallback(osmHikes)
-    }
+  private fun loadOsmHikes(
+      osmHikes: List<HikeRoute>,
+      onSuccess: () -> Unit = {},
+      onFailure: () -> Unit = {}
+  ) {
+    every { osmHikesRepo.getRoutes(any(), any(), any()) } answers
+        {
+          val successCallback = secondArg<(List<HikeRoute>) -> Unit>()
+          successCallback(osmHikes)
+        }
     hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0), onSuccess, onFailure)
   }
 
@@ -112,102 +119,104 @@ class HikesViewModelTest {
   // ==========================================================================
 
   @Test
-  fun selectHikeFailsIfHikeNotFound() = runTest(dispatcher) {
-    // No hike is selected initially
-    assertNull(hikesViewModel.selectedHike.value)
-    val hikeId = "nonexistent"
+  fun selectHikeFailsIfHikeNotFound() =
+      runTest(dispatcher) {
+        // No hike is selected initially
+        assertNull(hikesViewModel.selectedHike.value)
+        val hikeId = "nonexistent"
 
-    // Select a non-existent hike
-    var onFailureCalled = false
-    hikesViewModel.selectHike(
-      hikeId = hikeId,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+        // Select a non-existent hike
+        var onFailureCalled = false
+        hikesViewModel.selectHike(
+            hikeId = hikeId,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The selected hike should still be null
-    assertNull(hikesViewModel.selectedHike.value)
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The selected hike should still be null
+        assertNull(hikesViewModel.selectedHike.value)
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun selectHikeSucceedsIfHikeFound() = runTest(dispatcher) {
-    // There needs to be at least one hike in the loaded list to select it
-    loadSavedHikes(singleSavedHike1)
-    // No hike is selected initially
-    assertNull(hikesViewModel.selectedHike.value)
-    val hikeId = singleSavedHike1[0].id
+  fun selectHikeSucceedsIfHikeFound() =
+      runTest(dispatcher) {
+        // There needs to be at least one hike in the loaded list to select it
+        loadSavedHikes(singleSavedHike1)
+        // No hike is selected initially
+        assertNull(hikesViewModel.selectedHike.value)
+        val hikeId = singleSavedHike1[0].id
 
-    // Select the hike
-    var onSuccessCalled = false
-    hikesViewModel.selectHike(
-      hikeId = hikeId,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Select the hike
+        var onSuccessCalled = false
+        hikesViewModel.selectHike(
+            hikeId = hikeId,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // The selected hike should now be the one that was selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-  }
+        // The selected hike should now be the one that was selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+      }
 
   // ==========================================================================
   // HikesViewModel.selectHike
   // ==========================================================================
 
   @Test
-  fun unselectHikeSucceedsWhenHikeIsSelected() = runTest(dispatcher) {
-    // There needs to be at least one hike in the loaded list to select it
-    loadSavedHikes(singleSavedHike1)
-    // Select a hike
-    val hikeId = singleSavedHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected, otherwise the test does not make sense
-    assertNotNull(hikesViewModel.selectedHike.value)
+  fun unselectHikeSucceedsWhenHikeIsSelected() =
+      runTest(dispatcher) {
+        // There needs to be at least one hike in the loaded list to select it
+        loadSavedHikes(singleSavedHike1)
+        // Select a hike
+        val hikeId = singleSavedHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected, otherwise the test does not make sense
+        assertNotNull(hikesViewModel.selectedHike.value)
 
-    // Unselect the hike
-    hikesViewModel.unselectHike()
+        // Unselect the hike
+        hikesViewModel.unselectHike()
 
-    // Check that the hike was indeed unselected
-    assertNull(hikesViewModel.selectedHike.value)
-  }
+        // Check that the hike was indeed unselected
+        assertNull(hikesViewModel.selectedHike.value)
+      }
 
   @Test
-  fun unselectHikeSucceedsWhenNoHikeIsSelected() = runTest(dispatcher) {
-    // No hike should be selected at the start of the test
-    assertNull(hikesViewModel.selectedHike.value)
+  fun unselectHikeSucceedsWhenNoHikeIsSelected() =
+      runTest(dispatcher) {
+        // No hike should be selected at the start of the test
+        assertNull(hikesViewModel.selectedHike.value)
 
-    // Unselect the hike
-    hikesViewModel.unselectHike()
+        // Unselect the hike
+        hikesViewModel.unselectHike()
 
-    // Check that nothing has changed and that no hike is selected
-    assertNull(hikesViewModel.selectedHike.value)
-  }
+        // Check that nothing has changed and that no hike is selected
+        assertNull(hikesViewModel.selectedHike.value)
+      }
 
   // ==========================================================================
   // HikesViewModel.refreshSavedHikesCache
   // ==========================================================================
 
   @Test
-  fun refreshSavedHikesCacheFailsIfRepoFails() = runTest(dispatcher) {
-    // Whenever asked for saved hikes, the repository will throw an exception
-    coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
+  fun refreshSavedHikesCacheFailsIfRepoFails() =
+      runTest(dispatcher) {
+        // Whenever asked for saved hikes, the repository will throw an exception
+        coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
 
-    // Try refreshing the saved hikes cache through the view model
-    var onFailureCalled = false
-    hikesViewModel.refreshSavedHikesCache(
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+        // Try refreshing the saved hikes cache through the view model
+        var onFailureCalled = false
+        hikesViewModel.refreshSavedHikesCache(
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
-    // The failure callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
+        // The failure callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   /**
    * This is a specific test case. If the saved hikes are loaded (for example, we are on the saved
@@ -215,30 +224,30 @@ class HikesViewModelTest {
    * function will update [HikesViewModel.hikeFlows] with the new saved hikes.
    */
   @Test
-  fun refreshSavedHikesCacheSucceedsWhileSavedHikesAreLoaded() = runTest(dispatcher) {
-    // Load a first version of the saved hikes (to see later that it is replaced by the new one)
-    loadSavedHikes(singleSavedHike1)
-    // Check that the loading happened correctly
-    assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
+  fun refreshSavedHikesCacheSucceedsWhileSavedHikesAreLoaded() =
+      runTest(dispatcher) {
+        // Load a first version of the saved hikes (to see later that it is replaced by the new one)
+        loadSavedHikes(singleSavedHike1)
+        // Check that the loading happened correctly
+        assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
 
-    // For the second loading, provide a different list of saved hikes
-    coEvery { savedHikesRepo.loadSavedHikes() } returns singleSavedHike2
+        // For the second loading, provide a different list of saved hikes
+        coEvery { savedHikesRepo.loadSavedHikes() } returns singleSavedHike2
 
-    // Refresh the saved hikes cache through the view model
-    var onSuccessCalled = false
-    hikesViewModel.refreshSavedHikesCache(
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Refresh the saved hikes cache through the view model
+        var onSuccessCalled = false
+        hikesViewModel.refreshSavedHikesCache(
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Check that the view model uses the repository
-    coVerify(exactly = 2) { savedHikesRepo.loadSavedHikes() }
-    // Check that the view model correctly calls the success callback
-    assertTrue(onSuccessCalled)
-    // Check that the view model now contains the new saved hikes list
-    assertEquals(singleSavedHike2.size, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleSavedHike2[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-  }
+        // Check that the view model uses the repository
+        coVerify(exactly = 2) { savedHikesRepo.loadSavedHikes() }
+        // Check that the view model correctly calls the success callback
+        assertTrue(onSuccessCalled)
+        // Check that the view model now contains the new saved hikes list
+        assertEquals(singleSavedHike2.size, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleSavedHike2[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+      }
 
   /**
    * This is a specific test case. If the saved hikes are in the cache, but not the primary loaded
@@ -248,38 +257,39 @@ class HikesViewModelTest {
    * loaded hikes with the saved hikes.
    */
   @Test
-  fun refreshSavedHikesCacheSucceedsWhileSavedHikesAreNotLoaded() = runTest(dispatcher) {
-    // Load a first version of the OSM hikes (to see later that it is not replaced by the saved hikes)
-    loadOsmHikes(singleOsmHike1)
-    // Check that the loading happened correctly
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that for now, the loaded OSM hike is not marked as saved
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+  fun refreshSavedHikesCacheSucceedsWhileSavedHikesAreNotLoaded() =
+      runTest(dispatcher) {
+        // Load a first version of the OSM hikes (to see later that it is not replaced by the saved
+        // hikes)
+        loadOsmHikes(singleOsmHike1)
+        // Check that the loading happened correctly
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that for now, the loaded OSM hike is not marked as saved
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Include the loaded OSM hike in the saved hikes list, and add another unrelated one
-    // This is to make sure that the view model correctly updates the loaded hikes
-    val osmHike = singleOsmHike1[0]
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      singleSavedHike1[0],
-      SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = firstJanuary2024)
-    )
+        // Include the loaded OSM hike in the saved hikes list, and add another unrelated one
+        // This is to make sure that the view model correctly updates the loaded hikes
+        val osmHike = singleOsmHike1[0]
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                singleSavedHike1[0],
+                SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = firstJanuary2024))
 
-    // Refresh the saved hikes cache through the view model
-    var onSuccessCalled = false
-    hikesViewModel.refreshSavedHikesCache(
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Refresh the saved hikes cache through the view model
+        var onSuccessCalled = false
+        hikesViewModel.refreshSavedHikesCache(
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Check that the view model uses the repository
-    coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
-    // Check that the view model correctly calls the success callback
-    assertTrue(onSuccessCalled)
-    // Check that the loaded hikes are not replaced with the saved hikes
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that the loaded hike is now marked as saved
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
-  }
+        // Check that the view model uses the repository
+        coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
+        // Check that the view model correctly calls the success callback
+        assertTrue(onSuccessCalled)
+        // Check that the loaded hikes are not replaced with the saved hikes
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the loaded hike is now marked as saved
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+      }
 
   /**
    * This is an even more specific case than the two previous tests. Suppose one loads saved hikes
@@ -293,1213 +303,1304 @@ class HikesViewModelTest {
    * implementation.
    */
   @Test
-  fun refreshSavedHikesCacheSucceedsWhenSavedHikesWereLoadedButNotAnymore() = runTest(dispatcher) {
-    // Load a first version of the saved hikes (to mark the saved hikes as currently loaded)
-    loadSavedHikes(singleSavedHike1)
-    // Check that the loading happened correctly
-    assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleSavedHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+  fun refreshSavedHikesCacheSucceedsWhenSavedHikesWereLoadedButNotAnymore() =
+      runTest(dispatcher) {
+        // Load a first version of the saved hikes (to mark the saved hikes as currently loaded)
+        loadSavedHikes(singleSavedHike1)
+        // Check that the loading happened correctly
+        assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleSavedHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
 
-    // Then load OSM hikes to make sure that the saved hikes are not loaded anymore
-    loadOsmHikes(singleOsmHike1)
-    // Check that the loading happened correctly
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-    // Check that the loaded hike is not marked as saved
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+        // Then load OSM hikes to make sure that the saved hikes are not loaded anymore
+        loadOsmHikes(singleOsmHike1)
+        // Check that the loading happened correctly
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        // Check that the loaded hike is not marked as saved
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Include the loaded OSM hike in the saved hikes list, and add another unrelated one
-    // This is to make sure that the view model correctly updates the loaded hikes
-    val osmHike = singleOsmHike1[0]
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      singleSavedHike1[0],
-      SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = firstJanuary2024)
-    )
+        // Include the loaded OSM hike in the saved hikes list, and add another unrelated one
+        // This is to make sure that the view model correctly updates the loaded hikes
+        val osmHike = singleOsmHike1[0]
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                singleSavedHike1[0],
+                SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = firstJanuary2024))
 
-    // Refresh the saved hikes cache through the view model
-    var onSuccessCalled = false
-    hikesViewModel.refreshSavedHikesCache(
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Refresh the saved hikes cache through the view model
+        var onSuccessCalled = false
+        hikesViewModel.refreshSavedHikesCache(
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Check that the view model uses the repository
-    coVerify(exactly = 2) { savedHikesRepo.loadSavedHikes() }
-    // Check that the view model correctly calls the success callback
-    assertTrue(onSuccessCalled)
-    // Check that the loaded hikes are not replaced with the saved hikes
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-    // Check that the loaded hike is now marked as saved
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
-  }
-
-  @Test
-  fun `refreshSavedHikesCache sets loading to true then false`() = runTest(dispatcher) {
-    // Listen to the changes made to loading during the call
-    val emissions = mutableListOf<Boolean>()
-    val job = backgroundScope.launch {
-      hikesViewModel.loading.collect { emissions.add(it) }
-    }
-
-    // Set the repository to throw an exception because we do not care
-    coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
-
-    // Refresh the saved hikes cache
-    hikesViewModel.refreshSavedHikesCache()
-
-    // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now, hence
-    // we can stop listening to the values emitted by loading.
-    job.cancel()
-
-    // Check that loading was false at first, then true during the call, and false again at the end
-    assertEquals(listOf(false, true, false), emissions)
-  }
+        // Check that the view model uses the repository
+        coVerify(exactly = 2) { savedHikesRepo.loadSavedHikes() }
+        // Check that the view model correctly calls the success callback
+        assertTrue(onSuccessCalled)
+        // Check that the loaded hikes are not replaced with the saved hikes
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        // Check that the loaded hike is now marked as saved
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+      }
 
   @Test
-  fun `refreshSavedHikesCache updates selected hike if its status changes`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadOsmHikes(singleOsmHike1)
+  fun `refreshSavedHikesCache sets loading to true then false`() =
+      runTest(dispatcher) {
+        // Listen to the changes made to loading during the call
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch { hikesViewModel.loading.collect { emissions.add(it) } }
 
-    // Select the hike to be updated
-    val hikeId = singleOsmHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Set the repository to throw an exception because we do not care
+        coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
 
-    // Include the selected hike in the saved hikes list
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      SavedHike(id = hikeId, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024)
-    )
+        // Refresh the saved hikes cache
+        hikesViewModel.refreshSavedHikesCache()
 
-    // Refresh the saved hikes cache
-    hikesViewModel.refreshSavedHikesCache()
+        // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now,
+        // hence
+        // we can stop listening to the values emitted by loading.
+        job.cancel()
 
-    // Check that the selected hike is now marked as saved
-    assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
-    assertEquals(firstJanuary2024, hikesViewModel.selectedHike.value?.plannedDate)
-  }
+        // Check that loading was false at first, then true during the call, and false again at the
+        // end
+        assertEquals(listOf(false, true, false), emissions)
+      }
 
   @Test
-  fun `refreshSavedHikesCache clears selected hike if it is unloaded`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadSavedHikes(singleSavedHike1)
+  fun `refreshSavedHikesCache updates selected hike if its status changes`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadOsmHikes(singleOsmHike1)
 
-    // Select the hike to be updated
-    val hikeId = singleSavedHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Select the hike to be updated
+        val hikeId = singleOsmHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
 
-    // Remove the selected hike from the saved hikes list
-    coEvery { savedHikesRepo.loadSavedHikes() } returns emptyList()
+        // Include the selected hike in the saved hikes list
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                SavedHike(
+                    id = hikeId, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024))
 
-    // Refresh the saved hikes cache
-    hikesViewModel.refreshSavedHikesCache()
+        // Refresh the saved hikes cache
+        hikesViewModel.refreshSavedHikesCache()
 
-    // Check that the selected hike is now unselected
-    assertNull(hikesViewModel.selectedHike.value)
-  }
+        // Check that the selected hike is now marked as saved
+        assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
+        assertEquals(firstJanuary2024, hikesViewModel.selectedHike.value?.plannedDate)
+      }
+
+  @Test
+  fun `refreshSavedHikesCache clears selected hike if it is unloaded`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadSavedHikes(singleSavedHike1)
+
+        // Select the hike to be updated
+        val hikeId = singleSavedHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+
+        // Remove the selected hike from the saved hikes list
+        coEvery { savedHikesRepo.loadSavedHikes() } returns emptyList()
+
+        // Refresh the saved hikes cache
+        hikesViewModel.refreshSavedHikesCache()
+
+        // Check that the selected hike is now unselected
+        assertNull(hikesViewModel.selectedHike.value)
+      }
 
   // ==========================================================================
   // HikesViewModel.loadSavedHikes
   // ==========================================================================
 
   @Test
-  fun loadSavedHikesFailsIfRepoFails() = runTest(dispatcher) {
-    // Whenever asked for saved hikes, the repository will throw an exception
-    coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
+  fun loadSavedHikesFailsIfRepoFails() =
+      runTest(dispatcher) {
+        // Whenever asked for saved hikes, the repository will throw an exception
+        coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
 
-    // Try loading saved hikes through the view model
-    var onFailureCalled = false
-    hikesViewModel.loadSavedHikes(
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+        // Try loading saved hikes through the view model
+        var onFailureCalled = false
+        hikesViewModel.loadSavedHikes(
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
-    // The failure callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun loadSavedHikesSucceedsIfRepoSucceeds() = runTest(dispatcher) {
-    // Check nothing is in the hikes list before further operations
-    assertEquals(0, hikesViewModel.hikeFlows.value.size)
-
-    // Make sure the saved hikes repository provides a hike to be loaded
-    coEvery { savedHikesRepo.loadSavedHikes() } returns singleSavedHike1
-
-    // Load the saved hikes through the view model
-    var onSuccessCalled = false
-    hikesViewModel.loadSavedHikes(
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
-
-    // Check that the view model uses the repository
-    coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
-    // Check that the view model correctly calls the success callback
-    assertTrue(onSuccessCalled)
-    // Check that the view model now contains the loaded hikes list
-    assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
-  }
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
+        // The failure callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `loadSavedHikes sets loading to true then false`() = runTest(dispatcher) {
-    // Listen to the changes made to loading during the call
-    val emissions = mutableListOf<Boolean>()
-    val job = backgroundScope.launch {
-      hikesViewModel.loading.collect { emissions.add(it) }
-    }
+  fun loadSavedHikesSucceedsIfRepoSucceeds() =
+      runTest(dispatcher) {
+        // Check nothing is in the hikes list before further operations
+        assertEquals(0, hikesViewModel.hikeFlows.value.size)
 
-    // Set the repository to throw an exception because we do not care
-    coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
+        // Make sure the saved hikes repository provides a hike to be loaded
+        coEvery { savedHikesRepo.loadSavedHikes() } returns singleSavedHike1
 
-    // Load the saved hikes
-    hikesViewModel.loadSavedHikes()
+        // Load the saved hikes through the view model
+        var onSuccessCalled = false
+        hikesViewModel.loadSavedHikes(
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now, hence
-    // we can stop listening to the values emitted by loading.
-    job.cancel()
-
-    // Check that loading was false at first, then true during the call, and false again at the end
-    assertEquals(listOf(false, true, false), emissions)
-  }
-
-  @Test
-  fun `loadSavedHikes updates selected hike if its status changes`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadOsmHikes(singleOsmHike1)
-
-    // Select the hike to be updated
-    val hikeId = singleOsmHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
-    // Check that the hike is not marked as saved yet
-    assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
-
-    // Include the selected hike in the saved hikes list
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      SavedHike(id = hikeId, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024)
-    )
-
-    // Load the saved hikes
-    hikesViewModel.loadSavedHikes()
-
-    // Check that the selected hike is now marked as saved
-    assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
-    assertEquals(firstJanuary2024, hikesViewModel.selectedHike.value?.plannedDate)
-  }
+        // Check that the view model uses the repository
+        coVerify(exactly = 1) { savedHikesRepo.loadSavedHikes() }
+        // Check that the view model correctly calls the success callback
+        assertTrue(onSuccessCalled)
+        // Check that the view model now contains the loaded hikes list
+        assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
+      }
 
   @Test
-  fun `loadSavedHikes clears selected hike if it is unloaded`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadSavedHikes(singleSavedHike1)
+  fun `loadSavedHikes sets loading to true then false`() =
+      runTest(dispatcher) {
+        // Listen to the changes made to loading during the call
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch { hikesViewModel.loading.collect { emissions.add(it) } }
 
-    // Select the hike to be updated
-    val hikeId = singleSavedHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Set the repository to throw an exception because we do not care
+        coEvery { savedHikesRepo.loadSavedHikes() } throws Exception("Failed to load saved hikes")
 
-    // Remove the selected hike from the saved hikes list
-    coEvery { savedHikesRepo.loadSavedHikes() } returns emptyList()
+        // Load the saved hikes
+        hikesViewModel.loadSavedHikes()
 
-    // Load the saved hikes
-    hikesViewModel.loadSavedHikes()
+        // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now,
+        // hence
+        // we can stop listening to the values emitted by loading.
+        job.cancel()
 
-    // Check that the selected hike is now unselected
-    assertNull(hikesViewModel.selectedHike.value)
-  }
+        // Check that loading was false at first, then true during the call, and false again at the
+        // end
+        assertEquals(listOf(false, true, false), emissions)
+      }
+
+  @Test
+  fun `loadSavedHikes updates selected hike if its status changes`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadOsmHikes(singleOsmHike1)
+
+        // Select the hike to be updated
+        val hikeId = singleOsmHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Check that the hike is not marked as saved yet
+        assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+
+        // Include the selected hike in the saved hikes list
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                SavedHike(
+                    id = hikeId, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024))
+
+        // Load the saved hikes
+        hikesViewModel.loadSavedHikes()
+
+        // Check that the selected hike is now marked as saved
+        assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
+        assertEquals(firstJanuary2024, hikesViewModel.selectedHike.value?.plannedDate)
+      }
+
+  @Test
+  fun `loadSavedHikes clears selected hike if it is unloaded`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadSavedHikes(singleSavedHike1)
+
+        // Select the hike to be updated
+        val hikeId = singleSavedHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+
+        // Remove the selected hike from the saved hikes list
+        coEvery { savedHikesRepo.loadSavedHikes() } returns emptyList()
+
+        // Load the saved hikes
+        hikesViewModel.loadSavedHikes()
+
+        // Check that the selected hike is now unselected
+        assertNull(hikesViewModel.selectedHike.value)
+      }
 
   // ==========================================================================
   // HikesViewModel.saveHike
   // ==========================================================================
 
   @Test
-  fun saveHikeFailsIfNoCorrespondingHikeIsFound() = runTest(dispatcher) {
-    // Try to save a hike that is not loaded
-    var onFailureCalled = false
-    hikesViewModel.saveHike(
-      hikeId = "nonexistent",
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+  fun saveHikeFailsIfNoCorrespondingHikeIsFound() =
+      runTest(dispatcher) {
+        // Try to save a hike that is not loaded
+        var onFailureCalled = false
+        hikesViewModel.saveHike(
+            hikeId = "nonexistent",
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should not be called
-    coVerify(exactly = 0) { savedHikesRepo.addSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun saveHikeFailsIfRepoFails() = runTest(dispatcher) {
-    // Load a hike to be saved
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(1, hikesViewModel.hikeFlows.value.size)
-
-    // Whenever asked to save a hike, the repository will throw an exception
-    coEvery { savedHikesRepo.addSavedHike(any()) } throws Exception("Failed to save hike")
-
-    // Try to save the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.saveHike(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
-
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The saved hikes repository should not be called
+        coVerify(exactly = 0) { savedHikesRepo.addSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun saveHikeSucceedsIfRepoSucceeds() = runTest(dispatcher) {
-    // Load a hike to be saved
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(1, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike is not saved initially
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+  fun saveHikeFailsIfRepoFails() =
+      runTest(dispatcher) {
+        // Load a hike to be saved
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
 
-    // Make sure the saved hikes repository saves the hike
-    coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+        // Whenever asked to save a hike, the repository will throw an exception
+        coEvery { savedHikesRepo.addSavedHike(any()) } throws Exception("Failed to save hike")
 
-    // Try to save the loaded hike
-    var onSuccessCalled = false
-    hikesViewModel.saveHike(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Try to save the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.saveHike(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The hike should now be marked as saved
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
-  }
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `saveHike updates selected hike if its status changes`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadOsmHikes(singleOsmHike1)
+  fun saveHikeSucceedsIfRepoSucceeds() =
+      runTest(dispatcher) {
+        // Load a hike to be saved
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike is not saved initially
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Select the hike to be updated
-    val hikeId = singleOsmHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
-    // Check that the hike is not marked as saved yet
-    assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+        // Make sure the saved hikes repository saves the hike
+        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
 
-    // Make sure the saved hikes repository saves the hike
-    coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+        // Try to save the loaded hike
+        var onSuccessCalled = false
+        hikesViewModel.saveHike(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Save the selected hike
-    hikesViewModel.saveHike(hikeId)
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The hike should now be marked as saved
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+      }
 
-    // Check that the selected hike is now marked as saved
-    assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
-  }
+  @Test
+  fun `saveHike updates selected hike if its status changes`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadOsmHikes(singleOsmHike1)
+
+        // Select the hike to be updated
+        val hikeId = singleOsmHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Check that the hike is not marked as saved yet
+        assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+
+        // Make sure the saved hikes repository saves the hike
+        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+
+        // Save the selected hike
+        hikesViewModel.saveHike(hikeId)
+
+        // Check that the selected hike is now marked as saved
+        assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
+      }
 
   // ==========================================================================
   // HikesViewModel.unsaveHike
   // ==========================================================================
 
   @Test
-  fun `unsaveHike fails if no corresponding hike is found`() = runTest(dispatcher) {
-    // Try to unsave a hike that is not loaded (no hikes were loaded whatsoever)
-    var onFailureCalled = false
-    hikesViewModel.unsaveHike(
-      hikeId = "nonexistent",
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+  fun `unsaveHike fails if no corresponding hike is found`() =
+      runTest(dispatcher) {
+        // Try to unsave a hike that is not loaded (no hikes were loaded whatsoever)
+        var onFailureCalled = false
+        hikesViewModel.unsaveHike(
+            hikeId = "nonexistent",
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should not be called
-    coVerify(exactly = 0) { savedHikesRepo.removeSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `unsaveHike fails if the repository fails`() = runTest(dispatcher) {
-    // Load a hike to be unsaved
-    loadSavedHikes(singleSavedHike1)
-    // Check that the hike was loaded
-    assertEquals(1, hikesViewModel.hikeFlows.value.size)
-
-    // Whenever asked to unsave a hike, the repository will throw an exception
-    coEvery { savedHikesRepo.removeSavedHike(any()) } throws Exception("Failed to unsave hike")
-
-    // Try to unsave the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.unsaveHike(
-      hikeId = singleSavedHike1[0].id,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
-
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.removeSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The saved hikes repository should not be called
+        coVerify(exactly = 0) { savedHikesRepo.removeSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `unsaveHike updates hike in the loaded OSM hikes`() = runTest(dispatcher) {
-    // Make sure the loaded hike is included in the saved hikes
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      SavedHike(id = singleOsmHike1[0].id, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024)
-    )
-    hikesViewModel.refreshSavedHikesCache()
+  fun `unsaveHike fails if the repository fails`() =
+      runTest(dispatcher) {
+        // Load a hike to be unsaved
+        loadSavedHikes(singleSavedHike1)
+        // Check that the hike was loaded
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
 
-    // Load a hike to be unsaved (load hikes from bounds so that the hike won't be removed from the
-    // loaded hikes list after being unsaved).
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike is saved initially
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+        // Whenever asked to unsave a hike, the repository will throw an exception
+        coEvery { savedHikesRepo.removeSavedHike(any()) } throws Exception("Failed to unsave hike")
 
-    // Make sure the saved hikes repository unsaves the hike
-    coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
+        // Try to unsave the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.unsaveHike(
+            hikeId = singleSavedHike1[0].id,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // Try to unsave the loaded hike
-    var onSuccessCalled = false
-    hikesViewModel.unsaveHike(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
-
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.removeSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The hike should now be marked as unsaved
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
-  }
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.removeSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `unsaveHike removes hike from the loaded saved hikes`() = runTest(dispatcher) {
-    // Load a hike to be unsaved
-    loadSavedHikes(singleSavedHike1)
-    // Check that the hike was loaded
-    assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike is initially marked as saved
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+  fun `unsaveHike updates hike in the loaded OSM hikes`() =
+      runTest(dispatcher) {
+        // Make sure the loaded hike is included in the saved hikes
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                SavedHike(
+                    id = singleOsmHike1[0].id,
+                    name = singleOsmHike1[0].name ?: "",
+                    date = firstJanuary2024))
+        hikesViewModel.refreshSavedHikesCache()
 
-    // Make sure the saved hikes repository unsaves the hike
-    coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
+        // Load a hike to be unsaved (load hikes from bounds so that the hike won't be removed from
+        // the
+        // loaded hikes list after being unsaved).
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike is saved initially
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Try to unsave the loaded hike
-    var onSuccessCalled = false
-    hikesViewModel.unsaveHike(
-      hikeId = singleSavedHike1[0].id,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Make sure the saved hikes repository unsaves the hike
+        coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
 
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.removeSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The hike should now be removed from the loaded saved hikes
-    assertEquals(0, hikesViewModel.hikeFlows.value.size)
-  }
+        // Try to unsave the loaded hike
+        var onSuccessCalled = false
+        hikesViewModel.unsaveHike(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-  @Test
-  fun `unsaveHike updates selected hike if its status changes`() = runTest(dispatcher) {
-    // Make sure the loaded hike is included in the saved hikes
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      SavedHike(id = singleOsmHike1[0].id, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024)
-    )
-    hikesViewModel.refreshSavedHikesCache()
-
-    // Load a hike to be unsaved (load hikes from bounds so that the hike won't be removed from the
-    // loaded hikes list after being unsaved).
-    loadOsmHikes(singleOsmHike1)
-
-    // Select the saved hike that we will later unsave
-    val hikeId = singleOsmHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
-    // Check that the hike is saved
-    assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
-
-    // Make sure the saved hikes repository unsaves the hike
-    coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
-
-    // Unsave the selected hike
-    hikesViewModel.unsaveHike(hikeId)
-
-    // Check that the selected hike is now marked as unsaved
-    assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
-  }
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.removeSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The hike should now be marked as unsaved
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+      }
 
   @Test
-  fun `unsaveHike clears selected hike if it is unloaded`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadSavedHikes(singleSavedHike1)
+  fun `unsaveHike removes hike from the loaded saved hikes`() =
+      runTest(dispatcher) {
+        // Load a hike to be unsaved
+        loadSavedHikes(singleSavedHike1)
+        // Check that the hike was loaded
+        assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike is initially marked as saved
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Select the saved hike that we will later unsave
-    val hikeId = singleSavedHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Make sure the saved hikes repository unsaves the hike
+        coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
 
-    // Remove the selected hike from the saved hikes list
-    coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
+        // Try to unsave the loaded hike
+        var onSuccessCalled = false
+        hikesViewModel.unsaveHike(
+            hikeId = singleSavedHike1[0].id,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Unsave the selected hike
-    hikesViewModel.unsaveHike(hikeId)
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.removeSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The hike should now be removed from the loaded saved hikes
+        assertEquals(0, hikesViewModel.hikeFlows.value.size)
+      }
 
-    // Check that the selected hike is now unselected
-    assertNull(hikesViewModel.selectedHike.value)
-  }
+  @Test
+  fun `unsaveHike updates selected hike if its status changes`() =
+      runTest(dispatcher) {
+        // Make sure the loaded hike is included in the saved hikes
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                SavedHike(
+                    id = singleOsmHike1[0].id,
+                    name = singleOsmHike1[0].name ?: "",
+                    date = firstJanuary2024))
+        hikesViewModel.refreshSavedHikesCache()
+
+        // Load a hike to be unsaved (load hikes from bounds so that the hike won't be removed from
+        // the
+        // loaded hikes list after being unsaved).
+        loadOsmHikes(singleOsmHike1)
+
+        // Select the saved hike that we will later unsave
+        val hikeId = singleOsmHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Check that the hike is saved
+        assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
+
+        // Make sure the saved hikes repository unsaves the hike
+        coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
+
+        // Unsave the selected hike
+        hikesViewModel.unsaveHike(hikeId)
+
+        // Check that the selected hike is now marked as unsaved
+        assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+      }
+
+  @Test
+  fun `unsaveHike clears selected hike if it is unloaded`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadSavedHikes(singleSavedHike1)
+
+        // Select the saved hike that we will later unsave
+        val hikeId = singleSavedHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+
+        // Remove the selected hike from the saved hikes list
+        coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
+
+        // Unsave the selected hike
+        hikesViewModel.unsaveHike(hikeId)
+
+        // Check that the selected hike is now unselected
+        assertNull(hikesViewModel.selectedHike.value)
+      }
 
   // ==========================================================================
   // HikesViewModel.setPlannedDate
   // ==========================================================================
 
   @Test
-  fun `setPlannedDate fails if no corresponding hike is found`() = runTest(dispatcher) {
-    // Try to set a planned date for a hike that is not loaded
-    var onFailureCalled = false
-    hikesViewModel.setPlannedDate(
-      hikeId = "nonexistent",
-      date = firstJanuary2024,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+  fun `setPlannedDate fails if no corresponding hike is found`() =
+      runTest(dispatcher) {
+        // Try to set a planned date for a hike that is not loaded
+        var onFailureCalled = false
+        hikesViewModel.setPlannedDate(
+            hikeId = "nonexistent",
+            date = firstJanuary2024,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should not be called
-    coVerify(exactly = 0) { savedHikesRepo.addSavedHike(any()) }
-    coVerify(exactly = 0) { savedHikesRepo.removeSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `setPlannedDate fails if the repository fails`() = runTest(dispatcher) {
-    // Load a hike to set a planned date for
-    loadSavedHikes(singleSavedHike1)
-    // Check that the hike was loaded
-    assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
-
-    // Whenever we want to set a planned date for an already saved hike, we need to unsave it first.
-    // With the following line, we ensure the operation should fail.
-    coEvery { savedHikesRepo.removeSavedHike(any()) } throws Exception("Failed to set planned date")
-    coEvery { savedHikesRepo.addSavedHike(any()) } throws Exception("Failed to set planned date")
-
-    // Try to set a planned date for the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.setPlannedDate(
-      hikeId = singleSavedHike1[0].id,
-      date = firstJanuary2024,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
-
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The saved hikes repository should not be called
+        coVerify(exactly = 0) { savedHikesRepo.addSavedHike(any()) }
+        coVerify(exactly = 0) { savedHikesRepo.removeSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `setPlannedDate saves hike if not saved yet`() = runTest(dispatcher) {
-    // Load a hike to set a planned date for
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike is not saved initially
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+  fun `setPlannedDate fails if the repository fails`() =
+      runTest(dispatcher) {
+        // Load a hike to set a planned date for
+        loadSavedHikes(singleSavedHike1)
+        // Check that the hike was loaded
+        assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
 
-    // Make sure the saved hikes repository saves the hike
-    coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+        // Whenever we want to set a planned date for an already saved hike, we need to unsave it
+        // first.
+        // With the following line, we ensure the operation should fail.
+        coEvery { savedHikesRepo.removeSavedHike(any()) } throws
+            Exception("Failed to set planned date")
+        coEvery { savedHikesRepo.addSavedHike(any()) } throws
+            Exception("Failed to set planned date")
 
-    // Try to set a planned date for the loaded hike
-    var onSuccessCalled = false
-    hikesViewModel.setPlannedDate(
-      hikeId = singleOsmHike1[0].id,
-      date = firstJanuary2024,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Try to set a planned date for the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.setPlannedDate(
+            hikeId = singleSavedHike1[0].id,
+            date = firstJanuary2024,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The hike should now be marked as saved
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
-    // The hike should now have the planned date set
-    assertEquals(firstJanuary2024, hikesViewModel.hikeFlows.value[0].value.plannedDate)
-  }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `setPlannedDate with null date on unsaved has no effect`() = runTest(dispatcher) {
-    // Load a hike to set a planned date for
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike is not saved initially
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+  fun `setPlannedDate saves hike if not saved yet`() =
+      runTest(dispatcher) {
+        // Load a hike to set a planned date for
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike is not saved initially
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Try to set a null planned date for the loaded hike
-    hikesViewModel.setPlannedDate(
-      hikeId = singleOsmHike1[0].id,
-      date = null
-    )
+        // Make sure the saved hikes repository saves the hike
+        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
 
-    // The saved hikes repository should not be called
-    coVerify(exactly = 0) { savedHikesRepo.addSavedHike(any()) }
-    coVerify(exactly = 0) { savedHikesRepo.removeSavedHike(any()) }
-    // The hike should not be marked as saved
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
-    // The hike should not have the planned date set
-    assertNull(hikesViewModel.hikeFlows.value[0].value.plannedDate)
-  }
+        // Try to set a planned date for the loaded hike
+        var onSuccessCalled = false
+        hikesViewModel.setPlannedDate(
+            hikeId = singleOsmHike1[0].id,
+            date = firstJanuary2024,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-  @Test
-  fun `setPlannedDate updates hike in the loaded OSM hikes`() = runTest(dispatcher) {
-    // Make sure the loaded hike is included in the saved hikes, to test with a hike that is already
-    // saved
-    coEvery { savedHikesRepo.loadSavedHikes() } returns listOf(
-      SavedHike(id = singleOsmHike1[0].id, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024)
-    )
-    hikesViewModel.refreshSavedHikesCache()
-
-    // Load a hike to set a planned date for
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike is saved initially
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
-
-    // Make sure the saved hikes repository saves the hike
-    coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
-    coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
-
-    // Try to set a planned date for the loaded hike (test with setting a null date, which is valid)
-    hikesViewModel.setPlannedDate(
-      hikeId = singleOsmHike1[0].id,
-      date = null
-    )
-
-    // The saved hikes repository should be called exactly once
-    coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
-    // The hike should now have the planned date set (kinda, cause it's null)
-    assertNull(hikesViewModel.hikeFlows.value[0].value.plannedDate)
-  }
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The hike should now be marked as saved
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+        // The hike should now have the planned date set
+        assertEquals(firstJanuary2024, hikesViewModel.hikeFlows.value[0].value.plannedDate)
+      }
 
   @Test
-  fun `setPlannedDate updates selected hike if its status changes`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadOsmHikes(singleOsmHike1)
+  fun `setPlannedDate with null date on unsaved has no effect`() =
+      runTest(dispatcher) {
+        // Load a hike to set a planned date for
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike is not saved initially
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-    // Select the hike to be updated
-    val hikeId = singleOsmHike1[0].id
-    hikesViewModel.selectHike(hikeId)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
-    // Check that the hike is not marked as saved yet
-    assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+        // Try to set a null planned date for the loaded hike
+        hikesViewModel.setPlannedDate(hikeId = singleOsmHike1[0].id, date = null)
 
-    // Make sure the saved hikes repository saves the hike
-    coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+        // The saved hikes repository should not be called
+        coVerify(exactly = 0) { savedHikesRepo.addSavedHike(any()) }
+        coVerify(exactly = 0) { savedHikesRepo.removeSavedHike(any()) }
+        // The hike should not be marked as saved
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.isSaved)
+        // The hike should not have the planned date set
+        assertNull(hikesViewModel.hikeFlows.value[0].value.plannedDate)
+      }
 
-    // Set a planned date for the selected hike
-    hikesViewModel.setPlannedDate(hikeId, firstJanuary2024)
+  @Test
+  fun `setPlannedDate updates hike in the loaded OSM hikes`() =
+      runTest(dispatcher) {
+        // Make sure the loaded hike is included in the saved hikes, to test with a hike that is
+        // already
+        // saved
+        coEvery { savedHikesRepo.loadSavedHikes() } returns
+            listOf(
+                SavedHike(
+                    id = singleOsmHike1[0].id,
+                    name = singleOsmHike1[0].name ?: "",
+                    date = firstJanuary2024))
+        hikesViewModel.refreshSavedHikesCache()
 
-    // Check that the selected hike is now marked as saved
-    assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
-    // Check that the selected hike now has the planned date set
-    assertEquals(firstJanuary2024, hikesViewModel.selectedHike.value?.plannedDate)
-  }
+        // Load a hike to set a planned date for
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike is saved initially
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
+
+        // Make sure the saved hikes repository saves the hike
+        coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
+        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+
+        // Try to set a planned date for the loaded hike (test with setting a null date, which is
+        // valid)
+        hikesViewModel.setPlannedDate(hikeId = singleOsmHike1[0].id, date = null)
+
+        // The saved hikes repository should be called exactly once
+        coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
+        // The hike should now have the planned date set (kinda, cause it's null)
+        assertNull(hikesViewModel.hikeFlows.value[0].value.plannedDate)
+      }
+
+  @Test
+  fun `setPlannedDate updates selected hike if its status changes`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadOsmHikes(singleOsmHike1)
+
+        // Select the hike to be updated
+        val hikeId = singleOsmHike1[0].id
+        hikesViewModel.selectHike(hikeId)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(hikeId, hikesViewModel.selectedHike.value?.id)
+        // Check that the hike is not marked as saved yet
+        assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
+
+        // Make sure the saved hikes repository saves the hike
+        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+
+        // Set a planned date for the selected hike
+        hikesViewModel.setPlannedDate(hikeId, firstJanuary2024)
+
+        // Check that the selected hike is now marked as saved
+        assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)
+        // Check that the selected hike now has the planned date set
+        assertEquals(firstJanuary2024, hikesViewModel.selectedHike.value?.plannedDate)
+      }
 
   // ==========================================================================
   // HikesViewModel.loadHikesInBounds
   // ==========================================================================
 
   @Test
-  fun `loadHikesInBounds fails if the repository fails`() = runTest(dispatcher) {
-    // Make sure the repository throws an exception when asked for hikes in bounds
-    coEvery { osmHikesRepo.getRoutes(any(), any(), any()) } throws Exception("Failed to load hikes in bounds")
+  fun `loadHikesInBounds fails if the repository fails`() =
+      runTest(dispatcher) {
+        // Make sure the repository throws an exception when asked for hikes in bounds
+        coEvery { osmHikesRepo.getRoutes(any(), any(), any()) } throws
+            Exception("Failed to load hikes in bounds")
 
-    // Try to load hikes in bounds through the view model
-    var onFailureCalled = false
-    hikesViewModel.loadHikesInBounds(
-      bounds = BoundingBox(0.0, 0.0, 0.0, 0.0),
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+        // Try to load hikes in bounds through the view model
+        var onFailureCalled = false
+        hikesViewModel.loadHikesInBounds(
+            bounds = BoundingBox(0.0, 0.0, 0.0, 0.0),
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The OSM hikes repository should be called exactly once
-    coVerify(exactly = 1) { osmHikesRepo.getRoutes(any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `loadHikesInBounds succeeds if the repository succeeds`() = runTest(dispatcher) {
-    // Make sure the repo has some OSM hikes to return
-    every { osmHikesRepo.getRoutes(any(), any(), any()) } answers {
-      val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
-      onSuccess(doubleOsmHikes1)
-    }
-
-    // Try to load hikes in bounds through the view model
-    var onSuccessCalled = false
-    hikesViewModel.loadHikesInBounds(
-      bounds = BoundingBox(0.0, 0.0, 0.0, 0.0),
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
-
-    // The OSM hikes repository should be called exactly once
-    coVerify(exactly = 1) { osmHikesRepo.getRoutes(any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The view model should now contain the loaded hikes
-    assertEquals(doubleOsmHikes1.size, hikesViewModel.hikeFlows.value.size)
-    assertEquals(doubleOsmHikes1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-    assertEquals(doubleOsmHikes1[1].id, hikesViewModel.hikeFlows.value[1].value.id)
-  }
+        // The OSM hikes repository should be called exactly once
+        coVerify(exactly = 1) { osmHikesRepo.getRoutes(any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `loadHikesInBounds sets loading to true then false`() = runTest(dispatcher) {
-    // Listen to the changes made to loading during the call
-    val emissions = mutableListOf<Boolean>()
-    val job = backgroundScope.launch {
-      hikesViewModel.loading.collect { emissions.add(it) }
-    }
+  fun `loadHikesInBounds succeeds if the repository succeeds`() =
+      runTest(dispatcher) {
+        // Make sure the repo has some OSM hikes to return
+        every { osmHikesRepo.getRoutes(any(), any(), any()) } answers
+            {
+              val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
+              onSuccess(doubleOsmHikes1)
+            }
 
-    // Set the repository to throw an exception because we do not care
-    coEvery { osmHikesRepo.getRoutes(any(), any(), any()) } throws Exception("Failed to load saved hikes")
+        // Try to load hikes in bounds through the view model
+        var onSuccessCalled = false
+        hikesViewModel.loadHikesInBounds(
+            bounds = BoundingBox(0.0, 0.0, 0.0, 0.0),
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Load hikes in bounds
-    hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
-
-    // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now, hence
-    // we can stop listening to the values emitted by loading.
-    job.cancel()
-
-    // Check that loading was false at first, then true during the call, and false again at the end
-    assertEquals(listOf(false, true, false), emissions)
-  }
-
-  @Test
-  fun `loadHikesInBounds updates the selected hike`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    val osmHike = singleOsmHike1[0]
-    loadSavedHikes(listOf(SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = firstJanuary2024)))
-
-    // Select the hike to be updated
-    hikesViewModel.selectHike(osmHike.id)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
-    // Check that OSM details of the selected hike are not obtained yet
-    assertFalse(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
-    assertFalse(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
-    assertFalse(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
-
-    // Make sure the repo has some OSM hikes to return
-    every { osmHikesRepo.getRoutes(any(), any(), any()) } answers {
-      val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
-      onSuccess(doubleOsmHikes1)
-    }
-
-    // Load hikes in bounds
-    hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
-
-    // Check that the selected hike is still selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
-    // Check that the selected hike's OSM details have been updated
-    assertTrue(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
-    assertTrue(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
-    assertTrue(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
-  }
+        // The OSM hikes repository should be called exactly once
+        coVerify(exactly = 1) { osmHikesRepo.getRoutes(any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The view model should now contain the loaded hikes
+        assertEquals(doubleOsmHikes1.size, hikesViewModel.hikeFlows.value.size)
+        assertEquals(doubleOsmHikes1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        assertEquals(doubleOsmHikes1[1].id, hikesViewModel.hikeFlows.value[1].value.id)
+      }
 
   @Test
-  fun `loadHikesInBounds clears the selected hike if it is unloaded`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    loadSavedHikes(singleSavedHike1)
+  fun `loadHikesInBounds sets loading to true then false`() =
+      runTest(dispatcher) {
+        // Listen to the changes made to loading during the call
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch { hikesViewModel.loading.collect { emissions.add(it) } }
 
-    // Select the hike to be updated
-    hikesViewModel.selectHike(singleSavedHike1[0].id)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(singleSavedHike1[0].id, hikesViewModel.selectedHike.value?.id)
+        // Set the repository to throw an exception because we do not care
+        coEvery { osmHikesRepo.getRoutes(any(), any(), any()) } throws
+            Exception("Failed to load saved hikes")
 
-    // Make sure the repo has some OSM hikes to return
-    every { osmHikesRepo.getRoutes(any(), any(), any()) } answers {
-      val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
-      onSuccess(doubleOsmHikes1)
-    }
+        // Load hikes in bounds
+        hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
 
-    // Load hikes in bounds
-    hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
+        // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now,
+        // hence
+        // we can stop listening to the values emitted by loading.
+        job.cancel()
 
-    // Check that the selected hike is now unselected
-    assertNull(hikesViewModel.selectedHike.value)
-  }
+        // Check that loading was false at first, then true during the call, and false again at the
+        // end
+        assertEquals(listOf(false, true, false), emissions)
+      }
+
+  @Test
+  fun `loadHikesInBounds updates the selected hike`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        val osmHike = singleOsmHike1[0]
+        loadSavedHikes(
+            listOf(SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = firstJanuary2024)))
+
+        // Select the hike to be updated
+        hikesViewModel.selectHike(osmHike.id)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
+        // Check that OSM details of the selected hike are not obtained yet
+        assertFalse(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
+        assertFalse(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
+        assertFalse(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
+
+        // Make sure the repo has some OSM hikes to return
+        every { osmHikesRepo.getRoutes(any(), any(), any()) } answers
+            {
+              val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
+              onSuccess(doubleOsmHikes1)
+            }
+
+        // Load hikes in bounds
+        hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
+
+        // Check that the selected hike is still selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
+        // Check that the selected hike's OSM details have been updated
+        assertTrue(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
+        assertTrue(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
+        assertTrue(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
+      }
+
+  @Test
+  fun `loadHikesInBounds clears the selected hike if it is unloaded`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        loadSavedHikes(singleSavedHike1)
+
+        // Select the hike to be updated
+        hikesViewModel.selectHike(singleSavedHike1[0].id)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(singleSavedHike1[0].id, hikesViewModel.selectedHike.value?.id)
+
+        // Make sure the repo has some OSM hikes to return
+        every { osmHikesRepo.getRoutes(any(), any(), any()) } answers
+            {
+              val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
+              onSuccess(doubleOsmHikes1)
+            }
+
+        // Load hikes in bounds
+        hikesViewModel.loadHikesInBounds(BoundingBox(0.0, 0.0, 0.0, 0.0))
+
+        // Check that the selected hike is now unselected
+        assertNull(hikesViewModel.selectedHike.value)
+      }
 
   // ==========================================================================
   // HikesViewModel.retrieveLoadedHikesOsmData
   // ==========================================================================
 
   @Test
-  fun `retrieveLoadedHikesOsmData fails if the repository fails`() = runTest(dispatcher) {
-    // Make sure there are loaded hikes with missing OSM details
-    loadSavedHikes(singleSavedHike1)
+  fun `retrieveLoadedHikesOsmData fails if the repository fails`() =
+      runTest(dispatcher) {
+        // Make sure there are loaded hikes with missing OSM details
+        loadSavedHikes(singleSavedHike1)
 
-    // Make sure the repository throws an exception when asked for hikes IDs
-    coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } throws Exception("Failed to load hikes in bounds")
+        // Make sure the repository throws an exception when asked for hikes IDs
+        coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } throws
+            Exception("Failed to load hikes in bounds")
 
-    // Try to retrieve the OSM data for the loaded hikes
-    var onFailureCalled = false
-    hikesViewModel.retrieveLoadedHikesOsmData(
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+        // Try to retrieve the OSM data for the loaded hikes
+        var onFailureCalled = false
+        hikesViewModel.retrieveLoadedHikesOsmData(
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The OSM hikes repository should be called exactly once
-    coVerify(exactly = 1) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `retrieveLoadedHikesOsmData updates hikes with their OSM data`() = runTest(dispatcher) {
-    // Make sure there are loaded hikes with missing OSM details
-    val osmHike = singleOsmHike1[0]
-    loadSavedHikes(listOf(SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = null)))
-
-    // Make sure the repository returns the OSM data for the loaded hikes
-    coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } answers {
-      val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
-      onSuccess(singleOsmHike1)
-    }
-
-    // Retrieve the OSM data for the loaded hikes
-    var onSuccessCalled = false
-    hikesViewModel.retrieveLoadedHikesOsmData(
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
-
-    // The OSM hikes repository should be called exactly once
-    verify(exactly = 1) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The view model should now contain the loaded hikes with their OSM data
-    assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-    assertEquals(singleOsmHike1[0].description, (hikesViewModel.hikeFlows.value[0].value.description as DeferredData.Obtained).data)
-    assertEquals(singleOsmHike1[0].bounds, (hikesViewModel.hikeFlows.value[0].value.bounds as DeferredData.Obtained).data)
-    assertEquals(singleOsmHike1[0].ways, (hikesViewModel.hikeFlows.value[0].value.waypoints as DeferredData.Obtained).data)
-  }
+        // The OSM hikes repository should be called exactly once
+        coVerify(exactly = 1) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `retrieveLoadedHikesOsmData does not request already available data`() = runTest(dispatcher) {
-    // Load a first OSM hike with all its OSM data
-    loadOsmHikes(singleOsmHike1)
+  fun `retrieveLoadedHikesOsmData updates hikes with their OSM data`() =
+      runTest(dispatcher) {
+        // Make sure there are loaded hikes with missing OSM details
+        val osmHike = singleOsmHike1[0]
+        loadSavedHikes(listOf(SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = null)))
 
-    // Then load saved hikes, including the already loaded OSM hike plus another one
-    loadSavedHikes(listOf(
-      SavedHike(id = singleOsmHike1[0].id, name = singleOsmHike1[0].name ?: "", date = firstJanuary2024),
-      SavedHike(id = singleOsmHike2[0].id, name = singleOsmHike2[0].name ?: "", date = null)
-    ))
+        // Make sure the repository returns the OSM data for the loaded hikes
+        coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } answers
+            {
+              val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
+              onSuccess(singleOsmHike1)
+            }
 
-    // Make sure the repository returns the OSM data for the loaded hikes
-    every { osmHikesRepo.getRoutesByIds(any(), any(), any()) } answers {
-      val ids = firstArg<List<String>>()
-      assertEquals(1, ids.size)
-      assertEquals(singleOsmHike2[0].id, ids[0])
-      val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
-      onSuccess(singleOsmHike2)
-    }
+        // Retrieve the OSM data for the loaded hikes
+        var onSuccessCalled = false
+        hikesViewModel.retrieveLoadedHikesOsmData(
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Retrieve the OSM data for the loaded hikes
-    hikesViewModel.retrieveLoadedHikesOsmData()
-
-    // The OSM hikes repository should be called exactly once
-    verify(exactly = 1) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
-    // The view model should now contain the loaded hikes with their OSM data
-    assertEquals(singleOsmHike1.size + singleOsmHike2.size, hikesViewModel.hikeFlows.value.size)
-    val hike1 = hikesViewModel.hikeFlows.value.find { it.value.id == singleOsmHike1[0].id }?.value
-    assertNotNull(hike1)
-    assertEquals(singleOsmHike1[0].description, (hike1?.description as DeferredData.Obtained).data)
-    assertEquals(singleOsmHike1[0].bounds, (hike1.bounds as DeferredData.Obtained).data)
-    assertEquals(singleOsmHike1[0].ways, (hike1.waypoints as DeferredData.Obtained).data)
-    val hike2 = hikesViewModel.hikeFlows.value.find { it.value.id == singleOsmHike2[0].id }?.value
-    assertNotNull(hike2)
-    assertEquals(singleOsmHike2[0].description, (hike2?.description as DeferredData.Obtained).data)
-    assertEquals(singleOsmHike2[0].bounds, (hike2.bounds as DeferredData.Obtained).data)
-    assertEquals(singleOsmHike2[0].ways, (hike2.waypoints as DeferredData.Obtained).data)
-  }
-
-  @Test
-  fun `retrieveLoadedHikesOsmData does nothing if all data is available`() = runTest(dispatcher) {
-    // Make sure there are loaded hikes with their OSM details
-    loadOsmHikes(doubleOsmHikes1)
-
-    // Try to retrieve the OSM data for the loaded hikes
-    hikesViewModel.retrieveLoadedHikesOsmData()
-
-    // The OSM hikes repository should not be called
-    coVerify(exactly = 0) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
-  }
+        // The OSM hikes repository should be called exactly once
+        verify(exactly = 1) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The view model should now contain the loaded hikes with their OSM data
+        assertEquals(singleOsmHike1.size, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        assertEquals(
+            singleOsmHike1[0].description,
+            (hikesViewModel.hikeFlows.value[0].value.description as DeferredData.Obtained).data)
+        assertEquals(
+            singleOsmHike1[0].bounds,
+            (hikesViewModel.hikeFlows.value[0].value.bounds as DeferredData.Obtained).data)
+        assertEquals(
+            singleOsmHike1[0].ways,
+            (hikesViewModel.hikeFlows.value[0].value.waypoints as DeferredData.Obtained).data)
+      }
 
   @Test
-  fun `retrieveLoadedHikesOsmData sets loading to true then false`() = runTest(dispatcher) {
-    // Listen to the changes made to loading during the call
-    val emissions = mutableListOf<Boolean>()
-    val job = backgroundScope.launch {
-      hikesViewModel.loading.collect { emissions.add(it) }
-    }
+  fun `retrieveLoadedHikesOsmData does not request already available data`() =
+      runTest(dispatcher) {
+        // Load a first OSM hike with all its OSM data
+        loadOsmHikes(singleOsmHike1)
 
-    // Set the repository to throw an exception because we do not care
-    coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } throws Exception("Failed to load saved hikes")
+        // Then load saved hikes, including the already loaded OSM hike plus another one
+        loadSavedHikes(
+            listOf(
+                SavedHike(
+                    id = singleOsmHike1[0].id,
+                    name = singleOsmHike1[0].name ?: "",
+                    date = firstJanuary2024),
+                SavedHike(
+                    id = singleOsmHike2[0].id, name = singleOsmHike2[0].name ?: "", date = null)))
 
-    // Retrieve the OSM data for the loaded hikes
-    hikesViewModel.retrieveLoadedHikesOsmData()
+        // Make sure the repository returns the OSM data for the loaded hikes
+        every { osmHikesRepo.getRoutesByIds(any(), any(), any()) } answers
+            {
+              val ids = firstArg<List<String>>()
+              assertEquals(1, ids.size)
+              assertEquals(singleOsmHike2[0].id, ids[0])
+              val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
+              onSuccess(singleOsmHike2)
+            }
 
-    // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now, hence
-    // we can stop listening to the values emitted by loading.
-    job.cancel()
+        // Retrieve the OSM data for the loaded hikes
+        hikesViewModel.retrieveLoadedHikesOsmData()
 
-    // Check that loading was false at first, then true during the call, and false again at the end
-    assertEquals(listOf(false, true, false), emissions)
-  }
+        // The OSM hikes repository should be called exactly once
+        verify(exactly = 1) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
+        // The view model should now contain the loaded hikes with their OSM data
+        assertEquals(singleOsmHike1.size + singleOsmHike2.size, hikesViewModel.hikeFlows.value.size)
+        val hike1 =
+            hikesViewModel.hikeFlows.value.find { it.value.id == singleOsmHike1[0].id }?.value
+        assertNotNull(hike1)
+        assertEquals(
+            singleOsmHike1[0].description, (hike1?.description as DeferredData.Obtained).data)
+        assertEquals(singleOsmHike1[0].bounds, (hike1.bounds as DeferredData.Obtained).data)
+        assertEquals(singleOsmHike1[0].ways, (hike1.waypoints as DeferredData.Obtained).data)
+        val hike2 =
+            hikesViewModel.hikeFlows.value.find { it.value.id == singleOsmHike2[0].id }?.value
+        assertNotNull(hike2)
+        assertEquals(
+            singleOsmHike2[0].description, (hike2?.description as DeferredData.Obtained).data)
+        assertEquals(singleOsmHike2[0].bounds, (hike2.bounds as DeferredData.Obtained).data)
+        assertEquals(singleOsmHike2[0].ways, (hike2.waypoints as DeferredData.Obtained).data)
+      }
 
   @Test
-  fun `retrieveLoadedHikesOsmData updates the selected hike`() = runTest(dispatcher) {
-    // Load some hikes to be selected
-    val osmHike = singleOsmHike1[0]
-    loadSavedHikes(listOf(SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = null)))
+  fun `retrieveLoadedHikesOsmData does nothing if all data is available`() =
+      runTest(dispatcher) {
+        // Make sure there are loaded hikes with their OSM details
+        loadOsmHikes(doubleOsmHikes1)
 
-    // Select the hike to be updated
-    hikesViewModel.selectHike(osmHike.id)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
-    // Check that OSM details of the selected hike are not obtained yet
-    assertFalse(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
-    assertFalse(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
-    assertFalse(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
+        // Try to retrieve the OSM data for the loaded hikes
+        hikesViewModel.retrieveLoadedHikesOsmData()
 
-    // Make sure the repository returns the OSM data for the loaded hikes
-    coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } answers {
-      val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
-      onSuccess(singleOsmHike1)
-    }
+        // The OSM hikes repository should not be called
+        coVerify(exactly = 0) { osmHikesRepo.getRoutesByIds(any(), any(), any()) }
+      }
 
-    // Retrieve the OSM data for the loaded hikes
-    hikesViewModel.retrieveLoadedHikesOsmData()
+  @Test
+  fun `retrieveLoadedHikesOsmData sets loading to true then false`() =
+      runTest(dispatcher) {
+        // Listen to the changes made to loading during the call
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch { hikesViewModel.loading.collect { emissions.add(it) } }
 
-    // Check that the selected hike is still selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
-    // Check that the selected hike's OSM details have been updated
-    assertTrue(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
-    assertTrue(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
-    assertTrue(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
-  }
+        // Set the repository to throw an exception because we do not care
+        coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } throws
+            Exception("Failed to load saved hikes")
+
+        // Retrieve the OSM data for the loaded hikes
+        hikesViewModel.retrieveLoadedHikesOsmData()
+
+        // Because we are on an UnconfinedTestDispatcher(), the coroutine should be done by now,
+        // hence
+        // we can stop listening to the values emitted by loading.
+        job.cancel()
+
+        // Check that loading was false at first, then true during the call, and false again at the
+        // end
+        assertEquals(listOf(false, true, false), emissions)
+      }
+
+  @Test
+  fun `retrieveLoadedHikesOsmData updates the selected hike`() =
+      runTest(dispatcher) {
+        // Load some hikes to be selected
+        val osmHike = singleOsmHike1[0]
+        loadSavedHikes(listOf(SavedHike(id = osmHike.id, name = osmHike.name ?: "", date = null)))
+
+        // Select the hike to be updated
+        hikesViewModel.selectHike(osmHike.id)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
+        // Check that OSM details of the selected hike are not obtained yet
+        assertFalse(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
+        assertFalse(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
+        assertFalse(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
+
+        // Make sure the repository returns the OSM data for the loaded hikes
+        coEvery { osmHikesRepo.getRoutesByIds(any(), any(), any()) } answers
+            {
+              val onSuccess = secondArg<(List<HikeRoute>) -> Unit>()
+              onSuccess(singleOsmHike1)
+            }
+
+        // Retrieve the OSM data for the loaded hikes
+        hikesViewModel.retrieveLoadedHikesOsmData()
+
+        // Check that the selected hike is still selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(osmHike.id, hikesViewModel.selectedHike.value?.id)
+        // Check that the selected hike's OSM details have been updated
+        assertTrue(hikesViewModel.selectedHike.value?.description is DeferredData.Obtained)
+        assertTrue(hikesViewModel.selectedHike.value?.bounds is DeferredData.Obtained)
+        assertTrue(hikesViewModel.selectedHike.value?.waypoints is DeferredData.Obtained)
+      }
 
   // ==========================================================================
   // HikesViewModel.retrieveElevationDataFor
   // ==========================================================================
 
   @Test
-  fun `retrieveElevationDataFor fails if hike is not found`() = runTest(dispatcher) {
-    // Try to retrieve elevation data for a hike that is not loaded
-    var onFailureCalled = false
-    hikesViewModel.retrieveElevationDataFor(
-      hikeId = "nonexistent",
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+  fun `retrieveElevationDataFor fails if hike is not found`() =
+      runTest(dispatcher) {
+        // Try to retrieve elevation data for a hike that is not loaded
+        var onFailureCalled = false
+        hikesViewModel.retrieveElevationDataFor(
+            hikeId = "nonexistent",
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The elevation repository should not be called at all
-    verify(exactly = 0) { elevationRepo.getElevation(any(), any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `retrieveElevationDataFor fails if hike has no waypoints`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike but with no waypoints
-    loadSavedHikes(singleSavedHike1)
-
-    // Try to retrieve elevation data for the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.retrieveElevationDataFor(
-      hikeId = singleSavedHike1[0].id,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
-
-    // The elevation repository should not be called at all
-    verify(exactly = 0) { elevationRepo.getElevation(any(), any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The elevation repository should not be called at all
+        verify(exactly = 0) { elevationRepo.getElevation(any(), any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `retrieveElevationDataFor fails if the repository fails`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike with waypoints
-    loadOsmHikes(singleOsmHike1)
+  fun `retrieveElevationDataFor fails if hike has no waypoints`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike but with no waypoints
+        loadSavedHikes(singleSavedHike1)
 
-    // Make sure the repository throws an exception when asked for elevation data
-    every { elevationRepo.getElevation(any(), any(), any(), any()) } throws Exception("Failed to load elevation data")
+        // Try to retrieve elevation data for the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.retrieveElevationDataFor(
+            hikeId = singleSavedHike1[0].id,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // Try to retrieve elevation data for the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.retrieveElevationDataFor(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
-
-    // The elevation repository should be called exactly once
-    coVerify(exactly = 1) { elevationRepo.getElevation(any(), any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The elevation repository should not be called at all
+        verify(exactly = 0) { elevationRepo.getElevation(any(), any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `retrieveElevationDataFor updates the hike with its elevation data`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike with waypoints
-    loadOsmHikes(singleOsmHike1)
-    // Check that the hike was loaded
-    assertEquals(1, hikesViewModel.hikeFlows.value.size)
-    // Check that the hike does not have elevation data yet
-    assertFalse(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
+  fun `retrieveElevationDataFor fails if the repository fails`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike with waypoints
+        loadOsmHikes(singleOsmHike1)
 
-    // Make sure the repository returns the elevation data for the loaded hike
-    coEvery { elevationRepo.getElevation(any(), any(), any(), any()) } answers {
-      val onSuccess = thirdArg<(List<Double>) -> Unit>()
-      onSuccess(elevationProfile1)
-    }
+        // Make sure the repository throws an exception when asked for elevation data
+        every { elevationRepo.getElevation(any(), any(), any(), any()) } throws
+            Exception("Failed to load elevation data")
 
-    // Retrieve the elevation data for the loaded hike
-    var onSuccessCalled = false
-    hikesViewModel.retrieveElevationDataFor(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
+        // Try to retrieve elevation data for the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.retrieveElevationDataFor(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The elevation repository should be called exactly once
-    verify(exactly = 1) { elevationRepo.getElevation(any(), any(), any(), any()) }
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The view model should now contain the loaded hike with its elevation data
-    assertEquals(1, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-    assertEquals(elevationProfile1, (hikesViewModel.hikeFlows.value[0].value.elevation as DeferredData.Obtained).data)
-  }
+        // The elevation repository should be called exactly once
+        coVerify(exactly = 1) { elevationRepo.getElevation(any(), any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `retrieveElevationDataFor skips if the data is already available`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike with waypoints
-    loadOsmHikes(singleOsmHike1)
+  fun `retrieveElevationDataFor updates the hike with its elevation data`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike with waypoints
+        loadOsmHikes(singleOsmHike1)
+        // Check that the hike was loaded
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
+        // Check that the hike does not have elevation data yet
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
 
-    // Make sure the repository returns the elevation data for the loaded hike
-    coEvery { elevationRepo.getElevation(any(), any(), any(), any()) } answers {
-      val onSuccess = thirdArg<(List<Double>) -> Unit>()
-      onSuccess(elevationProfile1)
-    }
+        // Make sure the repository returns the elevation data for the loaded hike
+        coEvery { elevationRepo.getElevation(any(), any(), any(), any()) } answers
+            {
+              val onSuccess = thirdArg<(List<Double>) -> Unit>()
+              onSuccess(elevationProfile1)
+            }
 
-    // Retrieve the elevation data for the loaded hike
-    hikesViewModel.retrieveElevationDataFor(hikeId = singleOsmHike1[0].id)
+        // Retrieve the elevation data for the loaded hike
+        var onSuccessCalled = false
+        hikesViewModel.retrieveElevationDataFor(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
 
-    // Check that the hike has elevation data
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
-
-    // Request the data again to check that the repository is not called
-    hikesViewModel.retrieveElevationDataFor(hikeId = singleOsmHike1[0].id)
-
-    // The elevation repository should only be called once
-    coVerify(exactly = 1) { elevationRepo.getElevation(any(), any(), any(), any()) }
-  }
+        // The elevation repository should be called exactly once
+        verify(exactly = 1) { elevationRepo.getElevation(any(), any(), any(), any()) }
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The view model should now contain the loaded hike with its elevation data
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        assertEquals(
+            elevationProfile1,
+            (hikesViewModel.hikeFlows.value[0].value.elevation as DeferredData.Obtained).data)
+      }
 
   @Test
-  fun `retrieveElevationDataFor updates the selected hike if needed`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike with waypoints
-    loadOsmHikes(singleOsmHike1)
+  fun `retrieveElevationDataFor skips if the data is already available`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike with waypoints
+        loadOsmHikes(singleOsmHike1)
 
-    // Select the hike to be updated
-    hikesViewModel.selectHike(singleOsmHike1[0].id)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.selectedHike.value?.id)
-    // Check that the hike does not have elevation data yet
-    assertFalse(hikesViewModel.selectedHike.value?.elevation is DeferredData.Obtained)
+        // Make sure the repository returns the elevation data for the loaded hike
+        coEvery { elevationRepo.getElevation(any(), any(), any(), any()) } answers
+            {
+              val onSuccess = thirdArg<(List<Double>) -> Unit>()
+              onSuccess(elevationProfile1)
+            }
 
-    // Make sure the repository returns the elevation data for the loaded hike
-    coEvery { elevationRepo.getElevation(any(), any(), any(), any()) } answers {
-      val onSuccess = thirdArg<(List<Double>) -> Unit>()
-      onSuccess(elevationProfile1)
-    }
+        // Retrieve the elevation data for the loaded hike
+        hikesViewModel.retrieveElevationDataFor(hikeId = singleOsmHike1[0].id)
 
-    // Retrieve the elevation data for the loaded hike
-    hikesViewModel.retrieveElevationDataFor(hikeId = singleOsmHike1[0].id)
+        // Check that the hike has elevation data
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
 
-    // Check that the selected hike is still selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.selectedHike.value?.id)
-    // Check that the selected hike's elevation data has been updated
-    assertTrue(hikesViewModel.selectedHike.value?.elevation is DeferredData.Obtained)
-    assertEquals(elevationProfile1, (hikesViewModel.selectedHike.value?.elevation as DeferredData.Obtained).data)
-  }
+        // Request the data again to check that the repository is not called
+        hikesViewModel.retrieveElevationDataFor(hikeId = singleOsmHike1[0].id)
+
+        // The elevation repository should only be called once
+        coVerify(exactly = 1) { elevationRepo.getElevation(any(), any(), any(), any()) }
+      }
+
+  @Test
+  fun `retrieveElevationDataFor updates the selected hike if needed`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike with waypoints
+        loadOsmHikes(singleOsmHike1)
+
+        // Select the hike to be updated
+        hikesViewModel.selectHike(singleOsmHike1[0].id)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.selectedHike.value?.id)
+        // Check that the hike does not have elevation data yet
+        assertFalse(hikesViewModel.selectedHike.value?.elevation is DeferredData.Obtained)
+
+        // Make sure the repository returns the elevation data for the loaded hike
+        coEvery { elevationRepo.getElevation(any(), any(), any(), any()) } answers
+            {
+              val onSuccess = thirdArg<(List<Double>) -> Unit>()
+              onSuccess(elevationProfile1)
+            }
+
+        // Retrieve the elevation data for the loaded hike
+        hikesViewModel.retrieveElevationDataFor(hikeId = singleOsmHike1[0].id)
+
+        // Check that the selected hike is still selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.selectedHike.value?.id)
+        // Check that the selected hike's elevation data has been updated
+        assertTrue(hikesViewModel.selectedHike.value?.elevation is DeferredData.Obtained)
+        assertEquals(
+            elevationProfile1,
+            (hikesViewModel.selectedHike.value?.elevation as DeferredData.Obtained).data)
+      }
 
   // ==========================================================================
   // HikesViewModel.computeDetailsFor
   // ==========================================================================
 
   @Test
-  fun `computeDetailsFor fails if hike is not found`() = runTest(dispatcher) {
-    // Try to compute details for a hike that is not loaded
-    var onFailureCalled = false
-    hikesViewModel.computeDetailsFor(
-      hikeId = "nonexistent",
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+  fun `computeDetailsFor fails if hike is not found`() =
+      runTest(dispatcher) {
+        // Try to compute details for a hike that is not loaded
+        var onFailureCalled = false
+        hikesViewModel.computeDetailsFor(
+            hikeId = "nonexistent",
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `computeDetailsFor fails if hike has no waypoints`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike but with no waypoints
-    loadSavedHikes(singleSavedHike1)
-
-    // Try to compute details for the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.computeDetailsFor(
-      hikeId = singleSavedHike1[0].id,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
-
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `computeDetailsFor fails if hike has no elevation`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike but with no elevation data
-    loadOsmHikes(singleOsmHike1)
+  fun `computeDetailsFor fails if hike has no waypoints`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike but with no waypoints
+        loadSavedHikes(singleSavedHike1)
 
-    // Try to compute details for the loaded hike
-    var onFailureCalled = false
-    hikesViewModel.computeDetailsFor(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { fail("onSuccess should not have been called") },
-      onFailure = { onFailureCalled = true }
-    )
+        // Try to compute details for the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.computeDetailsFor(
+            hikeId = singleSavedHike1[0].id,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // The appropriate callback should be called
-    assertTrue(onFailureCalled)
-  }
-
-  @Test
-  fun `computeDetailsFor updates the hike with its details`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike with waypoints and elevation data
-    loadOsmHikes(singleOsmHike1)
-
-    // Make sure the elevation repository will return a valid elevation profile
-    every { elevationRepo.getElevation(any(), any(), any(), any()) } answers {
-      val onSuccess = thirdArg<(List<Double>) -> Unit>()
-      onSuccess(elevationProfile1)
-    }
-
-    // Make sure the hike has elevation
-    hikesViewModel.retrieveElevationDataFor(singleOsmHike1[0].id)
-    // Check that the hike has elevation data
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
-
-    // Compute the details for the loaded hike
-    var onSuccessCalled = false
-    hikesViewModel.computeDetailsFor(
-      hikeId = singleOsmHike1[0].id,
-      onSuccess = { onSuccessCalled = true },
-      onFailure = { fail("onFailure should not have been called") }
-    )
-
-    // The appropriate callback should be called
-    assertTrue(onSuccessCalled)
-    // The view model should now contain the loaded hike with its details
-    assertEquals(1, hikesViewModel.hikeFlows.value.size)
-    assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.distance is DeferredData.Obtained)
-    assertEquals(expectedDistance, (hikesViewModel.hikeFlows.value[0].value.distance as DeferredData.Obtained).data, doubleComparisonDelta)
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.elevationGain is DeferredData.Obtained)
-    assertEquals(expectedElevationGain, (hikesViewModel.hikeFlows.value[0].value.elevationGain as DeferredData.Obtained).data, doubleComparisonDelta)
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.estimatedTime is DeferredData.Obtained)
-    assertEquals(expectedEstimatedTime, (hikesViewModel.hikeFlows.value[0].value.estimatedTime as DeferredData.Obtained).data, doubleComparisonDelta)
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.difficulty is DeferredData.Obtained)
-    assertEquals(expectedDifficulty, (hikesViewModel.hikeFlows.value[0].value.difficulty as DeferredData.Obtained).data)
-  }
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
   @Test
-  fun `computeDetailsFor updates the selected hike if needed`() = runTest(dispatcher) {
-    // Make sure there is one loaded hike with waypoints
-    loadOsmHikes(singleOsmHike1)
+  fun `computeDetailsFor fails if hike has no elevation`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike but with no elevation data
+        loadOsmHikes(singleOsmHike1)
 
-    // Make sure the elevation repository will return a valid elevation profile
-    every { elevationRepo.getElevation(any(), any(), any(), any()) } answers {
-      val onSuccess = thirdArg<(List<Double>) -> Unit>()
-      onSuccess(elevationProfile1)
-    }
+        // Try to compute details for the loaded hike
+        var onFailureCalled = false
+        hikesViewModel.computeDetailsFor(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { fail("onSuccess should not have been called") },
+            onFailure = { onFailureCalled = true })
 
-    // Make sure the hike has elevation
-    hikesViewModel.retrieveElevationDataFor(singleOsmHike1[0].id)
-    // Check that the hike has elevation data
-    assertTrue(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
+        // The appropriate callback should be called
+        assertTrue(onFailureCalled)
+      }
 
-    // Select the hike to be updated
-    hikesViewModel.selectHike(singleOsmHike1[0].id)
-    // Check that the hike is selected
-    assertNotNull(hikesViewModel.selectedHike.value)
+  @Test
+  fun `computeDetailsFor updates the hike with its details`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike with waypoints and elevation data
+        loadOsmHikes(singleOsmHike1)
 
-    // Compute the details for the loaded hike
-    hikesViewModel.computeDetailsFor(hikeId = singleOsmHike1[0].id)
+        // Make sure the elevation repository will return a valid elevation profile
+        every { elevationRepo.getElevation(any(), any(), any(), any()) } answers
+            {
+              val onSuccess = thirdArg<(List<Double>) -> Unit>()
+              onSuccess(elevationProfile1)
+            }
 
-    // Check that the selected hike is still selected
-    assertNotNull(hikesViewModel.selectedHike.value)
-    // Check that the selected hike's details have been updated
-    assertTrue(hikesViewModel.selectedHike.value?.distance is DeferredData.Obtained)
-    assertEquals(expectedDistance, (hikesViewModel.selectedHike.value?.distance as DeferredData.Obtained).data, doubleComparisonDelta)
-    assertTrue(hikesViewModel.selectedHike.value?.elevationGain is DeferredData.Obtained)
-    assertEquals(expectedElevationGain, (hikesViewModel.selectedHike.value?.elevationGain as DeferredData.Obtained).data, doubleComparisonDelta)
-    assertTrue(hikesViewModel.selectedHike.value?.estimatedTime is DeferredData.Obtained)
-    assertEquals(expectedEstimatedTime, (hikesViewModel.selectedHike.value?.estimatedTime as DeferredData.Obtained).data, doubleComparisonDelta)
-    assertTrue(hikesViewModel.selectedHike.value?.difficulty is DeferredData.Obtained)
-    assertEquals(expectedDifficulty, (hikesViewModel.selectedHike.value?.difficulty as DeferredData.Obtained).data)
-  }
+        // Make sure the hike has elevation
+        hikesViewModel.retrieveElevationDataFor(singleOsmHike1[0].id)
+        // Check that the hike has elevation data
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
+
+        // Compute the details for the loaded hike
+        var onSuccessCalled = false
+        hikesViewModel.computeDetailsFor(
+            hikeId = singleOsmHike1[0].id,
+            onSuccess = { onSuccessCalled = true },
+            onFailure = { fail("onFailure should not have been called") })
+
+        // The appropriate callback should be called
+        assertTrue(onSuccessCalled)
+        // The view model should now contain the loaded hike with its details
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleOsmHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.distance is DeferredData.Obtained)
+        assertEquals(
+            expectedDistance,
+            (hikesViewModel.hikeFlows.value[0].value.distance as DeferredData.Obtained).data,
+            doubleComparisonDelta)
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.elevationGain is DeferredData.Obtained)
+        assertEquals(
+            expectedElevationGain,
+            (hikesViewModel.hikeFlows.value[0].value.elevationGain as DeferredData.Obtained).data,
+            doubleComparisonDelta)
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.estimatedTime is DeferredData.Obtained)
+        assertEquals(
+            expectedEstimatedTime,
+            (hikesViewModel.hikeFlows.value[0].value.estimatedTime as DeferredData.Obtained).data,
+            doubleComparisonDelta)
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.difficulty is DeferredData.Obtained)
+        assertEquals(
+            expectedDifficulty,
+            (hikesViewModel.hikeFlows.value[0].value.difficulty as DeferredData.Obtained).data)
+      }
+
+  @Test
+  fun `computeDetailsFor updates the selected hike if needed`() =
+      runTest(dispatcher) {
+        // Make sure there is one loaded hike with waypoints
+        loadOsmHikes(singleOsmHike1)
+
+        // Make sure the elevation repository will return a valid elevation profile
+        every { elevationRepo.getElevation(any(), any(), any(), any()) } answers
+            {
+              val onSuccess = thirdArg<(List<Double>) -> Unit>()
+              onSuccess(elevationProfile1)
+            }
+
+        // Make sure the hike has elevation
+        hikesViewModel.retrieveElevationDataFor(singleOsmHike1[0].id)
+        // Check that the hike has elevation data
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.elevation is DeferredData.Obtained)
+
+        // Select the hike to be updated
+        hikesViewModel.selectHike(singleOsmHike1[0].id)
+        // Check that the hike is selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+
+        // Compute the details for the loaded hike
+        hikesViewModel.computeDetailsFor(hikeId = singleOsmHike1[0].id)
+
+        // Check that the selected hike is still selected
+        assertNotNull(hikesViewModel.selectedHike.value)
+        // Check that the selected hike's details have been updated
+        assertTrue(hikesViewModel.selectedHike.value?.distance is DeferredData.Obtained)
+        assertEquals(
+            expectedDistance,
+            (hikesViewModel.selectedHike.value?.distance as DeferredData.Obtained).data,
+            doubleComparisonDelta)
+        assertTrue(hikesViewModel.selectedHike.value?.elevationGain is DeferredData.Obtained)
+        assertEquals(
+            expectedElevationGain,
+            (hikesViewModel.selectedHike.value?.elevationGain as DeferredData.Obtained).data,
+            doubleComparisonDelta)
+        assertTrue(hikesViewModel.selectedHike.value?.estimatedTime is DeferredData.Obtained)
+        assertEquals(
+            expectedEstimatedTime,
+            (hikesViewModel.selectedHike.value?.estimatedTime as DeferredData.Obtained).data,
+            doubleComparisonDelta)
+        assertTrue(hikesViewModel.selectedHike.value?.difficulty is DeferredData.Obtained)
+        assertEquals(
+            expectedDifficulty,
+            (hikesViewModel.selectedHike.value?.difficulty as DeferredData.Obtained).data)
+      }
 }

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -303,7 +303,7 @@ class HikesViewModelTest {
    * implementation.
    */
   @Test
-  fun refreshSavedHikesCacheSucceedsWhenSavedHikesWereLoadedButNotAnymore() =
+  fun `refreshSavedHikesCache remembers where hikes are loaded from`() =
       runTest(dispatcher) {
         // Load a first version of the saved hikes (to mark the saved hikes as currently loaded)
         loadSavedHikes(singleSavedHike1)

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -950,13 +950,20 @@ class HikesViewModelTest {
         // Check that the hike is saved initially
         assertTrue(hikesViewModel.hikeFlows.value[0].value.isSaved)
 
-        // Make sure the saved hikes repository saves the hike
+        // Make sure the saved hikes repository saves the hike with the right date
+        val dateToSet = null
         coEvery { savedHikesRepo.removeSavedHike(any()) } returns Unit
-        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+        coEvery { savedHikesRepo.addSavedHike(any()) } answers
+            {
+              assertEquals(
+                  "The planned date passed to the repository is different from the date that should have been set.",
+                  dateToSet,
+                  firstArg<SavedHike>().date)
+            }
 
         // Try to set a planned date for the loaded hike (test with setting a null date, which is
         // valid)
-        hikesViewModel.setPlannedDate(hikeId = singleOsmHike1[0].id, date = null)
+        hikesViewModel.setPlannedDate(hikeId = singleOsmHike1[0].id, date = dateToSet)
 
         // The saved hikes repository should be called exactly once
         coVerify(exactly = 1) { savedHikesRepo.addSavedHike(any()) }
@@ -979,11 +986,18 @@ class HikesViewModelTest {
         // Check that the hike is not marked as saved yet
         assertFalse(hikesViewModel.selectedHike.value?.isSaved ?: true)
 
-        // Make sure the saved hikes repository saves the hike
-        coEvery { savedHikesRepo.addSavedHike(any()) } returns Unit
+        // Make sure the saved hikes repository saves the hike with the right date
+        val dateToSet = firstJanuary2024
+        coEvery { savedHikesRepo.addSavedHike(any()) } answers
+            {
+              assertEquals(
+                  "The planned date passed to the repository is different from the date that should have been set.",
+                  dateToSet,
+                  firstArg<SavedHike>().date)
+            }
 
         // Set a planned date for the selected hike
-        hikesViewModel.setPlannedDate(hikeId, firstJanuary2024)
+        hikesViewModel.setPlannedDate(hikeId, dateToSet)
 
         // Check that the selected hike is now marked as saved
         assertTrue(hikesViewModel.selectedHike.value?.isSaved ?: false)

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -1076,6 +1076,41 @@ class HikesViewModelTest {
       }
 
   @Test
+  fun `loadHikesInBounds updates hikes who have no OSM data yet`() =
+      runTest(dispatcher) {
+        // Load some hike to be updated later with its OSM data
+        loadSavedHikes(singleSavedHike1)
+
+        // Make sure the hike was loaded and has no OSM data yet
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleSavedHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.bounds is DeferredData.Obtained)
+        assertFalse(hikesViewModel.hikeFlows.value[0].value.waypoints is DeferredData.Obtained)
+
+        // Call loadHikesInBounds with the hike's OSM data
+        loadOsmHikes(listOf(singleOsmHike1[0].copy(id = singleSavedHike1[0].id)))
+
+        // Make sure the hike was updated with its OSM data
+        assertEquals(1, hikesViewModel.hikeFlows.value.size)
+        assertEquals(singleSavedHike1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
+        // Description should have been obtained and updated with the right value
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.description is DeferredData.Obtained)
+        assertEquals(
+            singleOsmHike1[0].description,
+            (hikesViewModel.hikeFlows.value[0].value.description as DeferredData.Obtained).data)
+        // Bounds should have been obtained and updated with the right values
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.bounds is DeferredData.Obtained)
+        assertEquals(
+            singleOsmHike1[0].bounds,
+            (hikesViewModel.hikeFlows.value[0].value.bounds as DeferredData.Obtained).data)
+        // Waypoints should have been obtained and updated with the right values
+        assertTrue(hikesViewModel.hikeFlows.value[0].value.waypoints is DeferredData.Obtained)
+        assertEquals(
+            singleOsmHike1[0].ways,
+            (hikesViewModel.hikeFlows.value[0].value.waypoints as DeferredData.Obtained).data)
+      }
+
+  @Test
   fun `loadHikesInBounds sets loading to true then false`() =
       runTest(dispatcher) {
         // Listen to the changes made to loading during the call

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -1783,4 +1783,43 @@ class HikesViewModelTest {
     val hikeWithWaypoints = completeHike.copy(elevation = DeferredData.NotRequested)
     assertTrue(hikesViewModel.canElevationDataBeRetrievedFor(hikeWithWaypoints))
   }
+
+  // ==========================================================================
+  // HikesViewModel.areDetailsComputedFor
+  // ==========================================================================
+
+  @Test
+  fun `areDetailsComputedFor returns false with unrequested details`() {
+    val hikeWithoutDistance = completeHike.copy(distance = DeferredData.NotRequested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutDistance))
+
+    val hikeWithoutElevationGain = completeHike.copy(elevationGain = DeferredData.NotRequested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutElevationGain))
+
+    val hikeWithoutEstimatedTime = completeHike.copy(estimatedTime = DeferredData.NotRequested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutEstimatedTime))
+
+    val hikeWithoutDifficulty = completeHike.copy(difficulty = DeferredData.NotRequested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutDifficulty))
+  }
+
+  @Test
+  fun `areDetailsComputedFor returns false with requested details`() {
+    val hikeWithoutDistance = completeHike.copy(distance = DeferredData.Requested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutDistance))
+
+    val hikeWithoutElevationGain = completeHike.copy(elevationGain = DeferredData.Requested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutElevationGain))
+
+    val hikeWithoutEstimatedTime = completeHike.copy(estimatedTime = DeferredData.Requested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutEstimatedTime))
+
+    val hikeWithoutDifficulty = completeHike.copy(difficulty = DeferredData.Requested)
+    assertFalse(hikesViewModel.areDetailsComputedFor(hikeWithoutDifficulty))
+  }
+
+  @Test
+  fun `areDetailsComputedFor returns true with obtained details`() {
+    assertTrue(hikesViewModel.areDetailsComputedFor(completeHike))
+  }
 }


### PR DESCRIPTION
# Summary

The code until now had several types and view models to represent hikes, one of the core concepts of the app. As the app grows, we feel the need to assemble those types and view models into a unified system that is easier to use as a single entity, and avoids doing the same computations over and over again.

The objectives are :

- Simplify the code by using only one view model and one type for the hikes
- Avoid duplicate operations
- Improve performance

This PR is gigantic, but there's not much we can do about it, except have several reviewers instead of a single one.

It implements the view model itself, introduces the new `Hike` type, plus a new `DeferredData` type, and provides a lot of tests for the view model.

# For the reviewers

I will now try to summarize how this view model is intended to work, for the reviewers to have a vision of the big-picture and of how the view model is supposed to behave.

Here is a rough schema of the existing methods and how they fit in the usual user stories of the app.

![](https://github.com/user-attachments/assets/9369b219-e9dc-4ed0-9a1b-a53e14a47de5)

## Saved Hikes

The concept of saved hikes is part of the view model. The view model contains a cache of the current user's saved hikes. This cache can be updated with `hikesViewModel.refreshSavedHikesCache()`.

The cache is used to set the `isSaved` and `plannedDate` attributes of any hike, including when the user is not on the saved hikes screen.

## Hike Flows

Same as the old `ListOfHikesViewModel`, the new view model exposes `hikeFlows`, a state flow of a list of hikes. This is the list of the currently loaded hikes. For example, when performing a search on the map, the list will contain the list of OSM hikes inside those boundaries, loaded from the repository.

In the new implementation, though, each hike is itself wrapped into a `MutableStateFlow`. This allows for more granular updates. If a single hike changes, no need to update the list. Instead, the state flow of that specific hike will be updated.

## Loaded Hikes

The concept of "loaded hikes" is pretty important in this new implementation. A loaded hike is a hike that is in `hikeFlows`. There can be two different states for this :

- The user is in the saved hikes screen. Saved hikes have been loaded using `hikesViewModel.loadSavedHikes()`. In that case, each time the saved hikes cache is refreshed, the `hikeFlows` list will be updated to mirror the changes.
- The user is in the map screen. Hikes have been loaded from OSM using `hikesViewModel.loadHikesInBounds()`. In that case, each time the saved hikes cache is refreshed, the hikes loaded from OSM will see their saved status updated (if a hike was saved recently, it will be marked as saved in `hikeFlows`), however `hikeFlows` itself won't be changed as a whole.

## Selected hike

As before, the view model provides methods to *select* a hike. This hike is then made available through a special state flow called `selectedHike`. Note however that the selected hike continues to be in `hikeFlows` too, and is updated in both `hikeFlows` and `selectedHike` for simplicity of use.

If for some reason (new search, unsaved, ...) the selected hike is removed from `hikeFlows`, it will be unselected.

## Operations on hikes

As previously, the view model provides a public API to

- Save a hike
- Unsave a hike
- Set a hike's planned date
- Select a hike
- Unselect a hike

# Conclusion

Thanks to @Wylwi, who volunteered to review this monster. I initially proposed to split the review into two, one person for the implementation and another for the tests, but @Wylwi ended up doing the whole, since it was "easier this way" (@Wylwi's own words).

I recruited @Wylwi because we are probably the two most experienced team members when it comes to coroutines, and this PR contains plenty of them.