### PR TITLE
Fix/Sign up button not shown

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -17,7 +17,7 @@ import ch.hikemate.app.ui.auth.CreateAccountScreen
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
 import ch.hikemate.app.ui.components.CenteredLoadingAnimation
-import ch.hikemate.app.ui.map.MapScreen.TEST_TAG_MAP
+import ch.hikemate.app.ui.map.MapScreen
 import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.ui.navigation.Screen.PROFILE
@@ -109,10 +109,11 @@ class EndToEndTest : TestCase() {
     composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
 
     // Wait for the map to load
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag(TEST_TAG_MAP), timeoutMillis = 10000)
+    composeTestRule.waitUntilExactlyOneExists(
+        hasTestTag(MapScreen.TEST_TAG_MAP), timeoutMillis = 10000)
 
     // Check that we are on the map
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_MAP).assertIsDisplayed()
 
     // Check that the menu is displayed
     composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_BAR).assertIsDisplayed()
@@ -132,7 +133,7 @@ class EndToEndTest : TestCase() {
     composeTestRule
         .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.SAVED_HIKES.route)
         .performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_MAP).assertIsNotDisplayed()
     composeTestRule
         .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
         .assertIsDisplayed()
@@ -141,7 +142,7 @@ class EndToEndTest : TestCase() {
     composeTestRule
         .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.MAP.route)
         .performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_MAP).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SECTION_CONTAINER)
         .assertIsNotDisplayed()
@@ -150,7 +151,7 @@ class EndToEndTest : TestCase() {
     composeTestRule
         .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.PROFILE.route)
         .performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_MAP).assertIsNotDisplayed()
 
     composeTestRule.waitUntilDoesNotExist(
         hasTestTag(CenteredLoadingAnimation.TEST_TAG_CENTERED_LOADING_ANIMATION),
@@ -162,6 +163,6 @@ class EndToEndTest : TestCase() {
     composeTestRule
         .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.MAP.route)
         .performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_MAP).assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -106,7 +106,11 @@ class EndToEndTest : TestCase() {
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
         .performTextInput(password)
-    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON)
+        .assertHasClickAction()
+        .assertIsDisplayed()
+        .performClick()
 
     composeTestRule.waitForIdle()
 

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -6,14 +6,15 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import ch.hikemate.app.HikeMateApp
+import ch.hikemate.app.MainActivity
 import ch.hikemate.app.ui.auth.CreateAccountScreen
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
@@ -39,7 +40,8 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class EndToEndTest : TestCase() {
-  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createEmptyComposeRule()
+  private var scenario: ActivityScenario<MainActivity>? = null
   private val auth = FirebaseAuth.getInstance()
   private val myUuid = UUID.randomUUID()
   private val myUuidAsString = myUuid.toString()
@@ -72,7 +74,7 @@ class EndToEndTest : TestCase() {
     }
 
     // Make sure the log out is considered in the MainActivity
-    composeTestRule.setContent { HikeMateApp() }
+    scenario = ActivityScenario.launch(MainActivity::class.java)
   }
 
   @After
@@ -82,6 +84,11 @@ class EndToEndTest : TestCase() {
     auth.currentUser?.reauthenticate(credential)
     auth.currentUser?.delete()
     auth.signOut()
+  }
+
+  @After
+  public override fun tearDown() {
+    scenario?.close()
   }
 
   @OptIn(ExperimentalTestApi::class)

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.MainActivity
 import ch.hikemate.app.ui.auth.CreateAccountScreen
@@ -106,13 +107,14 @@ class EndToEndTest : TestCase() {
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
         .performTextInput(password)
+
+    Espresso.closeSoftKeyboard()
+
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON)
         .assertHasClickAction()
         .assertIsDisplayed()
         .performClick()
-
-    composeTestRule.waitForIdle()
 
     // Wait for the map to load
     composeTestRule.waitUntilExactlyOneExists(

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest.kt
@@ -108,6 +108,8 @@ class EndToEndTest : TestCase() {
         .performTextInput(password)
     composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
 
+    composeTestRule.waitForIdle()
+
     // Wait for the map to load
     composeTestRule.waitUntilExactlyOneExists(
         hasTestTag(MapScreen.TEST_TAG_MAP), timeoutMillis = 10000)

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -2,6 +2,7 @@ package ch.hikemate.app.endtoend
 
 import android.content.Context
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -109,7 +110,11 @@ class EndToEndTest2 {
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
         .performTextInput(password)
-    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON)
+        .assertHasClickAction()
+        .assertIsDisplayed()
+        .performClick()
 
     composeTestRule.waitForIdle()
 

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -13,7 +13,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import ch.hikemate.app.MainActivity
+import ch.hikemate.app.HikeMateApp
 import ch.hikemate.app.ui.auth.CreateAccountScreen
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class EndToEndTest2 {
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
   private val auth = FirebaseAuth.getInstance()
   private val myUuid = UUID.randomUUID()
   private val myUuidAsString = myUuid.toString()
@@ -69,6 +69,9 @@ class EndToEndTest2 {
     if (!signedOut) {
       throw Exception("Failed to sign out")
     }
+
+    // Make sure the log out is considered in the MainActivity
+    composeTestRule.setContent { HikeMateApp() }
   }
 
   @After
@@ -96,20 +99,40 @@ class EndToEndTest2 {
     // Perform sign in with email and password
     composeTestRule.onNodeWithTag(SignInScreen.TEST_TAG_SIGN_IN_WITH_EMAIL).performClick()
 
+    composeTestRule.waitUntilExactlyOneExists(
+        hasTestTag(Screen.SIGN_IN_WITH_EMAIL), timeoutMillis = 10000)
+
     composeTestRule
         .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON)
+        .assertIsDisplayed()
+        .assertHasClickAction()
         .performClick()
     composeTestRule.onNodeWithTag(Screen.CREATE_ACCOUNT).assertIsDisplayed()
 
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_NAME_INPUT)
+        .assertIsDisplayed()
         .performTextInput(myUuidAsString)
-    composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT).performTextInput(email)
+
+    Espresso.closeSoftKeyboard()
+
+    composeTestRule
+        .onNodeWithTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT)
+        .assertIsDisplayed()
+        .performTextInput(email)
+
+    Espresso.closeSoftKeyboard()
+
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT)
+        .assertIsDisplayed()
         .performTextInput(password)
+
+    Espresso.closeSoftKeyboard()
+
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
+        .assertIsDisplayed()
         .performTextInput(password)
 
     Espresso.closeSoftKeyboard()

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.hikemate.app.MainActivity
 import ch.hikemate.app.ui.auth.CreateAccountScreen
@@ -110,13 +111,14 @@ class EndToEndTest2 {
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT)
         .performTextInput(password)
+
+    Espresso.closeSoftKeyboard()
+
     composeTestRule
         .onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON)
         .assertHasClickAction()
         .assertIsDisplayed()
         .performClick()
-
-    composeTestRule.waitForIdle()
 
     // Wait for the sign-in to be performed and the map to load
     composeTestRule.waitUntilExactlyOneExists(

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -5,15 +5,16 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import ch.hikemate.app.HikeMateApp
+import ch.hikemate.app.MainActivity
 import ch.hikemate.app.ui.auth.CreateAccountScreen
 import ch.hikemate.app.ui.auth.SignInScreen
 import ch.hikemate.app.ui.auth.SignInWithEmailScreen
@@ -30,6 +31,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import java.util.UUID
+import junit.framework.TestCase
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -37,8 +39,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class EndToEndTest2 {
-  @get:Rule val composeTestRule = createComposeRule()
+class EndToEndTest2 : TestCase() {
+  @get:Rule val composeTestRule = createEmptyComposeRule()
+  private var scenario: ActivityScenario<MainActivity>? = null
   private val auth = FirebaseAuth.getInstance()
   private val myUuid = UUID.randomUUID()
   private val myUuidAsString = myUuid.toString()
@@ -71,7 +74,7 @@ class EndToEndTest2 {
     }
 
     // Make sure the log out is considered in the MainActivity
-    composeTestRule.setContent { HikeMateApp() }
+    scenario = ActivityScenario.launch(MainActivity::class.java)
   }
 
   @After
@@ -81,6 +84,11 @@ class EndToEndTest2 {
     auth.currentUser?.reauthenticate(credential)
     auth.currentUser?.delete()
     auth.signOut()
+  }
+
+  @After
+  public override fun tearDown() {
+    scenario?.close()
   }
 
   @OptIn(ExperimentalTestApi::class)

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -111,6 +111,8 @@ class EndToEndTest2 {
         .performTextInput(password)
     composeTestRule.onNodeWithTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON).performClick()
 
+    composeTestRule.waitForIdle()
+
     // Wait for the sign-in to be performed and the map to load
     composeTestRule.waitUntilExactlyOneExists(
         hasTestTag(MapScreen.TEST_TAG_MAP), timeoutMillis = 10000)

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/HikeMateAppNavigationTest.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.navigation
 
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -37,6 +38,8 @@ class HikeMateAppNavigationTest {
     composeTestRule.onNodeWithTag(Screen.SIGN_IN_WITH_EMAIL).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(SignInWithEmailScreen.TEST_TAG_GO_TO_SIGN_UP_BUTTON)
+        .assertHasClickAction()
+        .assertIsDisplayed()
         .performClick()
     composeTestRule.onNodeWithTag(Screen.CREATE_ACCOUNT).assertIsDisplayed()
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.HikeMate"
         tools:targetApi="31"
+        android:windowSoftInputMode="adjustResize"
         android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -101,7 +101,7 @@ class AuthViewModel(
                         onSuccess()
                       },
                       onFailure = {
-                        Log.e("AuthViewModel", "Error creating user profile")
+                        Log.e("AuthViewModel", "Error creating user profile", it)
                         onErrorAction(it)
                       },
                       context = context)

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -3,6 +3,7 @@ package ch.hikemate.app.model.authentication
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
 import androidx.lifecycle.ViewModel
@@ -96,12 +97,17 @@ class AuthViewModel(
                       user,
                       onSuccess = {
                         _currentUser.value = user
+                        Log.d("AuthViewModel", "User profile created")
                         onSuccess()
                       },
-                      onFailure = onErrorAction,
+                      onFailure = {
+                        Log.e("AuthViewModel", "Error creating user profile")
+                        onErrorAction(it)
+                      },
                       context = context)
                 } else {
                   // TODO handle errors in a unanimous way
+                  Log.e("AuthViewModel", "Error updating user profile")
                   onErrorAction(Exception("Error updating user profile"))
                 }
               }

--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -75,10 +75,10 @@ class FirebaseAuthRepository : AuthRepository {
         // Sign in with the Firebase credential (async task)
         auth.signInWithCredential(firebaseCredential).addOnCompleteListener { task ->
           if (task.isSuccessful) {
-            Log.d("SignInButton", "signInWithCredential:success")
+            Log.d("FirebaseAuthRepository", "signInWithCredential:success")
             onSuccess(auth.currentUser)
           } else {
-            Log.d("SignInButton", "signInWithCredential:failure")
+            Log.d("FirebaseAuthRepository", "signInWithCredential:failure")
             onErrorAction(task.exception ?: Exception())
           }
         }
@@ -108,8 +108,10 @@ class FirebaseAuthRepository : AuthRepository {
     val auth = FirebaseAuth.getInstance()
     auth.createUserWithEmailAndPassword(email, password).addOnCompleteListener { task ->
       if (task.isSuccessful) {
+        Log.d("FirebaseAuthRepository", "createAccountWithEmailAndPassword:success")
         onSuccess(auth.currentUser)
       } else {
+        Log.e("FirebaseAuthRepository", "createAccountWithEmailAndPassword:failure", task.exception)
         onErrorAction(task.exception ?: Exception())
       }
     }
@@ -124,8 +126,10 @@ class FirebaseAuthRepository : AuthRepository {
     val auth = FirebaseAuth.getInstance()
     auth.signInWithEmailAndPassword(email, password).addOnCompleteListener { task ->
       if (task.isSuccessful) {
+        Log.d("FirebaseAuthRepository", "signInWithEmailAndPassword:success")
         onSuccess(auth.currentUser)
       } else {
+        Log.e("FirebaseAuthRepository", "signInWithEmailAndPassword:failure", task.exception)
         onErrorAction(task.exception ?: Exception())
       }
     }

--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.OutlinedTextField
@@ -114,11 +115,10 @@ fun CreateAccountScreen(
       modifier =
           Modifier.testTag(Screen.CREATE_ACCOUNT)
               .padding(
-                  // Add for the status bar
                   start = 16.dp,
                   end = 16.dp,
-                  top = 40.dp,
-              ),
+              )
+              .safeDrawingPadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(

--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -3,8 +3,9 @@ package ch.hikemate.app.ui.auth
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
@@ -54,6 +55,7 @@ object CreateAccountScreen {
  * @param navigationActions The navigation actions.
  * @param authViewModel The authentication view model.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CreateAccountScreen(
     navigationActions: NavigationActions,
@@ -123,9 +125,9 @@ fun CreateAccountScreen(
                   start = 16.dp,
                   end = 16.dp,
               )
-              .safeDrawingPadding()
               .verticalScroll(scrollState)
-              .imePadding(),
+              .imeNestedScroll()
+              .safeDrawingPadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(

--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -4,10 +4,13 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -57,6 +60,8 @@ fun CreateAccountScreen(
     authViewModel: AuthViewModel,
 ) {
   val context = LocalContext.current
+
+  val scrollState = rememberScrollState()
 
   // Define it here because it's used in the onClick lambda which is not a composable
   val mismatchErrorMessage = stringResource(R.string.create_account_password_mismatch_error)
@@ -118,7 +123,9 @@ fun CreateAccountScreen(
                   start = 16.dp,
                   end = 16.dp,
               )
-              .safeDrawingPadding(),
+              .safeDrawingPadding()
+              .verticalScroll(scrollState)
+              .imePadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(
@@ -131,7 +138,8 @@ fun CreateAccountScreen(
             colors = inputColors,
             value = name,
             onValueChange = { name = it },
-            label = { Text(stringResource(R.string.create_account_name_label)) })
+            label = { Text(stringResource(R.string.create_account_name_label)) },
+            singleLine = true)
 
         OutlinedTextField(
             modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT),
@@ -139,7 +147,8 @@ fun CreateAccountScreen(
             colors = inputColors,
             value = email,
             onValueChange = { email = it },
-            label = { Text(stringResource(R.string.create_account_email_label)) })
+            label = { Text(stringResource(R.string.create_account_email_label)) },
+            singleLine = true)
 
         OutlinedTextField(
             modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT),
@@ -147,7 +156,8 @@ fun CreateAccountScreen(
             colors = inputColors,
             value = password,
             onValueChange = { password = it },
-            label = { Text(stringResource(R.string.create_account_password_label)) })
+            label = { Text(stringResource(R.string.create_account_password_label)) },
+            singleLine = true)
 
         OutlinedTextField(
             modifier =
@@ -157,7 +167,8 @@ fun CreateAccountScreen(
             colors = inputColors,
             value = confirmPassword,
             onValueChange = { confirmPassword = it },
-            label = { Text(stringResource(R.string.create_account_repeat_password_label)) })
+            label = { Text(stringResource(R.string.create_account_repeat_password_label)) },
+            singleLine = true)
 
         BigButton(
             modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON),

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -60,6 +63,8 @@ fun SignInWithEmailScreen(
 ) {
   val context = LocalContext.current
 
+  val scrollState = rememberScrollState()
+
   // Define the colors for the input fields
   val inputColors =
       OutlinedTextFieldDefaults.colors()
@@ -84,7 +89,9 @@ fun SignInWithEmailScreen(
                   start = 16.dp,
                   end = 16.dp,
               )
-              .safeDrawingPadding(),
+              .safeDrawingPadding()
+              .verticalScroll(scrollState)
+              .imePadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(
@@ -98,7 +105,8 @@ fun SignInWithEmailScreen(
             colors = inputColors,
             value = email,
             onValueChange = { email = it },
-            label = { Text(stringResource(R.string.sign_in_with_email_email_label)) })
+            label = { Text(stringResource(R.string.sign_in_with_email_email_label)) },
+            singleLine = true)
 
         OutlinedTextField(
             modifier =
@@ -107,7 +115,8 @@ fun SignInWithEmailScreen(
             colors = inputColors,
             value = password,
             onValueChange = { password = it },
-            label = { Text(stringResource(R.string.sign_in_with_email_password_label)) })
+            label = { Text(stringResource(R.string.sign_in_with_email_password_label)) },
+            singleLine = true)
 
         BigButton(
             modifier =
@@ -129,7 +138,7 @@ fun SignInWithEmailScreen(
             })
 
         Column(
-            modifier = Modifier.fillMaxSize().padding(bottom = 16.dp),
+            modifier = Modifier.fillMaxSize().padding(bottom = 16.dp).weight(1f),
             verticalArrangement = Arrangement.Bottom,
             horizontalAlignment = Alignment.CenterHorizontally) {
               TextButton(

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -2,9 +2,8 @@ package ch.hikemate.app.ui.auth
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
@@ -129,12 +128,10 @@ fun SignInWithEmailScreen(
                   })
             })
 
-        // Push the sign up button to the bottom of the screen by adding a spacer
-        Spacer(modifier = Modifier.weight(1f))
-
-        Box(
-            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
-            contentAlignment = Alignment.Center) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally) {
               TextButton(
                   onClick = {
                     // Navigate to the sign up screen

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -3,8 +3,10 @@ package ch.hikemate.app.ui.auth
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
@@ -91,7 +93,8 @@ fun SignInWithEmailScreen(
               )
               .safeDrawingPadding()
               .verticalScroll(scrollState)
-              .imePadding(),
+              .imePadding()
+              .height(IntrinsicSize.Max),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(
@@ -138,7 +141,7 @@ fun SignInWithEmailScreen(
             })
 
         Column(
-            modifier = Modifier.fillMaxSize().padding(bottom = 16.dp).weight(1f),
+            modifier = Modifier.padding(bottom = 16.dp).fillMaxSize(),
             verticalArrangement = Arrangement.Bottom,
             horizontalAlignment = Alignment.CenterHorizontally) {
               TextButton(

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -3,11 +3,12 @@ package ch.hikemate.app.ui.auth
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
@@ -58,6 +59,7 @@ object SignInWithEmailScreen {
  * @param navigationActions The navigation actions.
  * @param authViewModel The authentication view model.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SignInWithEmailScreen(
     navigationActions: NavigationActions,
@@ -91,9 +93,9 @@ fun SignInWithEmailScreen(
                   start = 16.dp,
                   end = 16.dp,
               )
+              .imeNestedScroll()
               .safeDrawingPadding()
               .verticalScroll(scrollState)
-              .imePadding()
               .height(IntrinsicSize.Max),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.OutlinedTextField
@@ -80,11 +81,10 @@ fun SignInWithEmailScreen(
       modifier =
           Modifier.testTag(Screen.SIGN_IN_WITH_EMAIL)
               .padding(
-                  // Add for the status bar
                   start = 16.dp,
                   end = 16.dp,
-                  top = 40.dp,
-              ),
+              )
+              .safeDrawingPadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -89,14 +89,14 @@ object HikeDetailScreen {
   const val MAP_MIN_LONGITUDE = -180.0
   const val MAP_BOUNDS_MARGIN: Int = 100
 
-  const val TEST_TAG_MAP = "map"
-  const val TEST_TAG_HIKE_NAME = "hikeName"
-  const val TEST_TAG_BOOKMARK_ICON = "bookmarkIcon"
-  const val TEST_TAG_ELEVATION_GRAPH = "elevationGraph"
-  const val TEST_TAG_DETAIL_ROW_TAG = "detailRowTag"
-  const val TEST_TAG_DETAIL_ROW_VALUE = "detailRowValue"
-  const val TEST_TAG_ADD_DATE_BUTTON = "addDateButton"
-  const val TEST_TAG_PLANNED_DATE_TEXT_BOX = "plannedDateTextBox"
+  const val TEST_TAG_MAP = "HikeDetailScreenMap"
+  const val TEST_TAG_HIKE_NAME = "HikeDetailScreenHikeName"
+  const val TEST_TAG_BOOKMARK_ICON = "HikeDetailScreenBookmarkIcon"
+  const val TEST_TAG_ELEVATION_GRAPH = "HikeDetailScreenElevationGraph"
+  const val TEST_TAG_DETAIL_ROW_TAG = "HikeDetailScreenDetailRowTag"
+  const val TEST_TAG_DETAIL_ROW_VALUE = "HikeDetailScreenDetailRowValue"
+  const val TEST_TAG_ADD_DATE_BUTTON = "HikeDetailScreenAddDateButton"
+  const val TEST_TAG_PLANNED_DATE_TEXT_BOX = "HikeDetailScreenPlannedDateTextBox"
 }
 
 @Composable

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -221,7 +222,7 @@ fun HikeDetailScreen(
       // Back Button at the top of the screen
       BackButton(
           navigationActions = navigationActions,
-          modifier = Modifier.padding(top = 40.dp, start = 16.dp, end = 16.dp),
+          modifier = Modifier.padding(start = 16.dp, end = 16.dp).safeContentPadding(),
           onClick = { listOfHikeRoutesViewModel.clearSelectedRoute() })
       // Zoom buttons at the bottom right of the screen
       ZoomMapButton(

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -222,7 +222,7 @@ fun HikeDetailScreen(
       // Back Button at the top of the screen
       BackButton(
           navigationActions = navigationActions,
-          modifier = Modifier.padding(start = 16.dp, end = 16.dp).safeContentPadding(),
+          modifier = Modifier.padding(start = 16.dp, end = 16.dp).safeDrawingPadding(),
           onClick = { listOfHikeRoutesViewModel.clearSelectedRoute() })
       // Zoom buttons at the bottom right of the screen
       ZoomMapButton(

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -153,17 +153,17 @@ object MapScreen {
 
   const val LOG_TAG = "MapScreen"
 
-  const val TEST_TAG_MAP = "map"
-  const val TEST_TAG_SEARCH_BUTTON = "searchButton"
-  const val TEST_TAG_HIKES_LIST = "hikesList"
-  const val TEST_TAG_HIKE_ITEM = "hikeItem"
-  const val TEST_TAG_EMPTY_HIKES_LIST_MESSAGE = "emptyHikesListMessage"
-  const val TEST_TAG_SEARCHING_MESSAGE = "searchingMessage"
-  const val TEST_TAG_SEARCH_LOADING_ANIMATION = "searchLoadingAnimation"
-  const val TEST_TAG_CENTER_MAP_BUTTON = "centerMapButton"
-  const val TEST_TAG_LOCATION_PERMISSION_ALERT = "locationPermissionAlert"
-  const val TEST_TAG_NO_THANKS_ALERT_BUTTON = "noThanksAlertButton"
-  const val TEST_TAG_GRANT_ALERT_BUTTON = "grantAlertButton"
+  const val TEST_TAG_MAP = "MapScreenMap"
+  const val TEST_TAG_SEARCH_BUTTON = "MapScreenSearchButton"
+  const val TEST_TAG_HIKES_LIST = "MapScreenHikesList"
+  const val TEST_TAG_HIKE_ITEM = "MapScreenHikeItem"
+  const val TEST_TAG_EMPTY_HIKES_LIST_MESSAGE = "MapScreenEmptyHikesListMessage"
+  const val TEST_TAG_SEARCHING_MESSAGE = "MapScreenSearchingMessage"
+  const val TEST_TAG_SEARCH_LOADING_ANIMATION = "MapScreenSearchLoadingAnimation"
+  const val TEST_TAG_CENTER_MAP_BUTTON = "MapScreenCenterMapButton"
+  const val TEST_TAG_LOCATION_PERMISSION_ALERT = "MapScreenLocationPermissionAlert"
+  const val TEST_TAG_NO_THANKS_ALERT_BUTTON = "MapScreenNoThanksAlertButton"
+  const val TEST_TAG_GRANT_ALERT_BUTTON = "MapScreenGrantAlertButton"
 
   const val MINIMAL_SEARCH_TIME_IN_MS = 500 // ms
 

--- a/app/src/main/java/ch/hikemate/app/ui/profile/DeleteAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/DeleteAccountScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -76,8 +77,8 @@ fun DeleteAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
                   // Add padding to the sidebar padding
                   start = 16.dp,
                   end = 16.dp,
-                  top = 16.dp,
-              ),
+              )
+              .safeDrawingPadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(

--- a/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
@@ -2,7 +2,9 @@ package ch.hikemate.app.ui.profile
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
@@ -61,6 +63,7 @@ object EditProfileScreen {
  * @param navigationActions The navigation actions.
  * @param profileViewModel The profile view model.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun EditProfileScreen(
     navigationActions: NavigationActions,
@@ -107,6 +110,7 @@ fun EditProfileScreen(
                     start = 16.dp,
                     end = 16.dp,
                 )
+                .imeNestedScroll()
                 .safeDrawingPadding()
                 .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(16.dp)) {

--- a/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
@@ -66,6 +68,8 @@ fun EditProfileScreen(
 ) {
   val context = LocalContext.current
 
+  val scrollState = rememberScrollState()
+
   val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
 
@@ -103,7 +107,8 @@ fun EditProfileScreen(
                     start = 16.dp,
                     end = 16.dp,
                 )
-                .safeDrawingPadding(),
+                .safeDrawingPadding()
+                .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(16.dp)) {
           BackButton(navigationActions)
           Text(

--- a/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
@@ -113,11 +114,10 @@ fun EditProfileScreen(
       modifier =
           Modifier.testTag(Screen.EDIT_PROFILE)
               .padding(
-                  // Add for the status bar
                   start = 16.dp,
                   end = 16.dp,
-                  top = 16.dp,
-              ),
+              )
+              .safeDrawingPadding(),
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         BackButton(navigationActions)
         Text(
@@ -140,7 +140,8 @@ fun EditProfileScreen(
                             )),
             value = name,
             onValueChange = { name = it },
-            label = { Text(context.getString(R.string.profile_screen_name_label)) })
+            label = { Text(context.getString(R.string.profile_screen_name_label)) },
+            singleLine = true)
 
         Column(
             verticalArrangement = Arrangement.spacedBy(2.dp),

--- a/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/ProfileScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.MaterialTheme
@@ -116,14 +117,10 @@ fun ProfileScreen(
             modifier =
                 Modifier.testTag(Screen.PROFILE)
                     .padding(
-                        // Here we have 2 calls to padding. The first one is for the status bar
-                        // padding
-                        // and the second one is for the content padding. 2 padding will add up.
-                        // There is another way to do but we decided that this version was cleaner.
                         start = 16.dp,
                         end = 16.dp,
-                        top = 40.dp,
-                    ),
+                    )
+                    .safeDrawingPadding(),
             verticalArrangement = Arrangement.spacedBy(16.dp)) {
               Text(
                   context.getString(R.string.profile_screen_title),


### PR DESCRIPTION
# Summary
- Sign up button is cropped in small screen, due to the absolute positioning of the Button
- This has enabled us to discover other problems, which are resolved in this PR, unrelated to the scope of this task, but necessary to pass the tests. See the below details

# Details
- I changed the absolute position behavior to a Column and positioning system (similar to HTML Flex box), to make it scalable on every phone size
- I changed the paddings for the insets to use an android made function to handle it correctly, and no longer manually
- I made several edits to the End2End too, like making the button display being asserted, in addition to pressing it, since pressing it doesn't assert it's displayed neither than it's clickable
- The End2End should be more reliable too, with an improvement in the sign-out process of the End2End

# Issue fixed
The main issue fixed in this PR (i.e. the sign-up button not being shown) was because the Edge2Edge behavior was not handled correctly. I hence fixed it, but putting the correct padding on screens that were having a supplementary padding for the status bar, with the correct function. 

This led to the E2E failing because of a button being pushed out of the screen in the create account screen. This bug was indeed a recurrent bug, we failed to identify before. The fix was hard to find, but quite simple, it's just to retract the keyboard before checking if the button is there or not. This took a loooong time to find it.

This leads to another issue, a UI one. With the keyboard, the text fields were getting crushed. This was solved by making the screen scrollable. I fixed it on the 2 other screens with TextField too (SignInWithEmail and EditProfile).