### PR TITLE
fix: date line issues for hikes crossing and searching

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/extensions/BoundingBoxExtension.kt
+++ b/app/src/main/java/ch/hikemate/app/model/extensions/BoundingBoxExtension.kt
@@ -1,0 +1,19 @@
+package ch.hikemate.app.model.extensions
+
+import org.osmdroid.util.BoundingBox
+
+/** Return true if the bounding box crosses the date line */
+fun BoundingBox.crossesDateLine(): Boolean {
+  return lonEast < lonWest
+}
+
+/** Split the bounding box by the date line */
+fun BoundingBox.splitByDateLine(): Pair<BoundingBox, BoundingBox> {
+  return if (crossesDateLine()) {
+    Pair(
+        BoundingBox(latNorth, 180.0, latSouth, lonWest),
+        BoundingBox(latNorth, lonEast, latSouth, -180.0))
+  } else {
+    Pair(this, this)
+  }
+}

--- a/app/src/main/java/ch/hikemate/app/model/extensions/BoundingBoxExtension.kt
+++ b/app/src/main/java/ch/hikemate/app/model/extensions/BoundingBoxExtension.kt
@@ -1,5 +1,7 @@
 package ch.hikemate.app.model.extensions
 
+import android.util.Log
+import ch.hikemate.app.model.route.Bounds
 import org.osmdroid.util.BoundingBox
 
 /** Return true if the bounding box crosses the date line */
@@ -16,4 +18,11 @@ fun BoundingBox.splitByDateLine(): Pair<BoundingBox, BoundingBox> {
   } else {
     Pair(this, this)
   }
+}
+
+fun BoundingBox.toBounds(): Bounds {
+  Log.i(
+      "BoundingBox",
+      "Converting BoundingBox to Bounds(n:$latNorth, e:$lonEast, s:$latSouth, w:$lonWest)")
+  return Bounds(latSouth, lonWest, latNorth, lonEast)
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.model.route
 
-import android.util.Log
 import ch.hikemate.app.ui.theme.hikeColors
 import kotlin.math.abs
 import kotlin.math.asin
@@ -77,13 +76,6 @@ data class Bounds(val minLat: Double, val minLon: Double, val maxLat: Double, va
       return Bounds(minLat, minLon, maxLat, maxLon)
     }
   }
-}
-
-fun BoundingBox.toBounds(): Bounds {
-  Log.i(
-      "BoundingBox",
-      "Converting BoundingBox to Bounds(n:$latNorth, e:$lonEast, s:$latSouth, w:$lonWest)")
-  return Bounds(latSouth, lonWest, latNorth, lonEast)
 }
 
 fun Bounds.toBoundingBox(): BoundingBox {

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.model.route
 
+import android.util.Log
 import ch.hikemate.app.ui.theme.hikeColors
 import kotlin.math.abs
 import kotlin.math.asin
@@ -68,6 +69,10 @@ data class Bounds(val minLat: Double, val minLon: Double, val maxLat: Double, va
       return this
     }
 
+    fun isCrossingDateLine(): Boolean {
+      return minLon > maxLon
+    }
+
     fun build(): Bounds {
       return Bounds(minLat, minLon, maxLat, maxLon)
     }
@@ -75,6 +80,7 @@ data class Bounds(val minLat: Double, val minLon: Double, val maxLat: Double, va
 }
 
 fun BoundingBox.toBounds(): Bounds {
+  Log.i("BoundingBox", " searching at n:$latNorth, e:$lonEast, s:$latSouth, w:$lonWest")
   return Bounds(latSouth, lonWest, latNorth, lonEast)
 }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoute.kt
@@ -80,7 +80,9 @@ data class Bounds(val minLat: Double, val minLon: Double, val maxLat: Double, va
 }
 
 fun BoundingBox.toBounds(): Bounds {
-  Log.i("BoundingBox", " searching at n:$latNorth, e:$lonEast, s:$latSouth, w:$lonWest")
+  Log.i(
+      "BoundingBox",
+      "Converting BoundingBox to Bounds(n:$latNorth, e:$lonEast, s:$latSouth, w:$lonWest)")
   return Bounds(latSouth, lonWest, latNorth, lonEast)
 }
 

--- a/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpass.kt
@@ -332,7 +332,8 @@ class HikeRoutesRepositoryOverpass(private val client: OkHttpClient) : HikeRoute
       }
       val flattenWays = flattenHikeWays(ways)
       // If there is no way in the route regardless of the reason, we discard the route
-      if (flattenWays.isEmpty()) {
+      // Also, if the bounds are crossing the date line, we discard the route
+      if (flattenWays.isEmpty() || boundsBuilder.isCrossingDateLine()) {
         return null
       }
       return HikeRoute(id, boundsBuilder.build(), flattenWays, elementName, description)

--- a/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
@@ -8,6 +8,7 @@ import ch.hikemate.app.model.elevation.ElevationService
 import ch.hikemate.app.model.elevation.ElevationServiceRepository
 import ch.hikemate.app.model.extensions.crossesDateLine
 import ch.hikemate.app.model.extensions.splitByDateLine
+import ch.hikemate.app.model.extensions.toBounds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import ch.hikemate.app.model.elevation.ElevationService
 import ch.hikemate.app.model.elevation.ElevationServiceRepository
+import ch.hikemate.app.model.extensions.crossesDateLine
+import ch.hikemate.app.model.extensions.splitByDateLine
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,9 +55,8 @@ open class ListOfHikeRoutesViewModel(
       val area = area_.value ?: return@withContext
 
       // Check if the area is on the date line
-      if (area.lonEast < area.lonWest) {
-        val bounds1 = BoundingBox(area.latNorth, 180.0, area.latSouth, area.lonWest)
-        val bounds2 = BoundingBox(area.latNorth, area.lonEast, area.latSouth, -180.0)
+      if (area.crossesDateLine()) {
+        val (bounds1, bounds2) = area.splitByDateLine()
         hikeRoutesRepository.getRoutes(
             bounds = bounds1.toBounds(),
             onSuccess = { routes1 ->

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRouteTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRouteTest.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.model.route
 
+import ch.hikemate.app.model.extensions.toBounds
 import org.junit.Assert.*
 import org.junit.Test
 import org.osmdroid.util.BoundingBox

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRouteTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRouteTest.kt
@@ -52,6 +52,17 @@ class HikeRouteTest {
   }
 
   @Test
+  fun boundsBuilderIsCrossingDateLine() {
+    val bounds = Bounds.Builder().setMinLat(0.0).setMinLon(170.0).setMaxLat(0.0).setMaxLon(-170.0)
+
+    assertTrue(bounds.isCrossingDateLine())
+
+    val bounds2 = Bounds.Builder().setMinLat(0.0).setMinLon(-170.0).setMaxLat(0.0).setMaxLon(170.0)
+
+    assertFalse(bounds2.isCrossingDateLine())
+  }
+
+  @Test
   fun getColorsIsDeterministic() {
     val bounds = Bounds(0.0, 0.0, 0.0, 0.0)
     val hikes =

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeRoutesRepositoryOverpassTest.kt
@@ -1341,10 +1341,18 @@ class HikeRoutesRepositoryOverpassTest {
       callbackCapture.firstValue.onResponse(mockCall, responseCrossingTheDateLine)
     }
 
+    var successCalled = false
+
     hikingRouteProviderRepositoryOverpass.getRoutes(
-        bounds, { routes -> assertEquals(0, routes.size) }) {
+        bounds,
+        { routes ->
+          assertEquals(0, routes.size)
+          successCalled = true
+        }) {
           fail("Failed to fetch routes from Overpass API")
         }
+
+    assert(successCalled)
   }
 
   @Test

--- a/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.model.route
 
 import ch.hikemate.app.model.elevation.ElevationService
+import ch.hikemate.app.model.extensions.toBounds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher

--- a/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/ListOfHikeRoutesViewModelTest.kt
@@ -146,6 +146,20 @@ class ListOfHikeRoutesViewModelTest {
   }
 
   @Test
+  fun setAreaCrossingDateLineCallsRepositoryTwice() {
+    // When the hike repository calls the getRoutes method, return on success
+    `when`(hikesRepository.getRoutes(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(List<HikeRoute>) -> Unit>(1)
+      onSuccess(emptyList())
+    }
+
+    // Since we use UnconfinedTestDispatcher, we don't need to wait for the coroutine to finish
+    listOfHikeRoutesViewModel.setArea(BoundingBox(50.0, -170.0, 40.0, 170.0))
+
+    verify(hikesRepository, times(2)).getRoutes(any(), any(), any())
+  }
+
+  @Test
   fun selectRouteByIdCallsRepoAndSelectsHike() {
     // Given
     val hike =


### PR DESCRIPTION
# Summary
There was 2 issues about the date line:
1. Searching when showing the date line would make the app crash. For this, I changed it to make 2 requests, one on the left side and one on the right side.
2. Displaying a hike crossing the date line would make the app crash. For this, I filtered out the hikes doing this in the API.

# Details
I've not found any hikes in such conditions. This is prevention only.