### PR TITLE
fix: change date picker to compose one

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
@@ -24,6 +24,9 @@ import ch.hikemate.app.model.route.saved.SavedHikesViewModel
 import ch.hikemate.app.ui.components.BackButton.BACK_BUTTON_TEST_TAG
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
@@ -305,6 +308,65 @@ class HikeDetailScreenTest {
     }
 
     composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
+  }
+
+  @Test
+  fun hikeDetails_datePickerDismisses_whenClickedOnCancel() = runTest {
+    listOfHikeRoutesViewModel.selectRoute(route)
+
+    // Mock the necessary functions
+    whenever(mockSavedHikesRepository.loadSavedHikes()).thenReturn(emptyList())
+    whenever(mockSavedHikesRepository.addSavedHike(any())).thenReturn(Unit)
+    whenever(mockSavedHikesRepository.removeSavedHike(any())).thenReturn(Unit)
+
+    // Update the hike detail state
+    savedHikesViewModel.updateHikeDetailState(route)
+    savedHikesViewModel.toggleSaveState()
+
+    composeTestRule.setContent {
+      HikeDetails(
+          detailedRoute = detailedRoute,
+          savedHikesViewModel = savedHikesViewModel,
+          emptyList(),
+          HikingLevel.BEGINNER)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER_CANCEL_BUTTON).performClick()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun hikeDetails_datePickerDismisses_whenClickedOnConfirm() = runTest {
+    listOfHikeRoutesViewModel.selectRoute(route)
+
+    // Mock the necessary functions
+    whenever(mockSavedHikesRepository.loadSavedHikes()).thenReturn(emptyList())
+    whenever(mockSavedHikesRepository.addSavedHike(any())).thenReturn(Unit)
+    whenever(mockSavedHikesRepository.removeSavedHike(any())).thenReturn(Unit)
+
+    // Update the hike detail state
+    savedHikesViewModel.updateHikeDetailState(route)
+    savedHikesViewModel.toggleSaveState()
+
+    composeTestRule.setContent {
+      HikeDetails(
+          detailedRoute = detailedRoute,
+          savedHikesViewModel = savedHikesViewModel,
+          emptyList(),
+          HikingLevel.BEGINNER)
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER_CONFIRM_BUTTON).performClick()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
   }
 
   @Test

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -1,7 +1,6 @@
 package ch.hikemate.app.ui.map
 
 import android.annotation.SuppressLint
-import android.app.DatePickerDialog
 import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
@@ -23,14 +22,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,10 +73,9 @@ import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.utils.MapUtils
-import ch.hikemate.app.utils.from
 import ch.hikemate.app.utils.toFormattedString
 import com.google.firebase.Timestamp
-import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
@@ -344,6 +346,7 @@ fun HikeDetails(
       sheetPeekHeight = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT) {}
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun DateDetailRow(
@@ -351,28 +354,42 @@ fun DateDetailRow(
     plannedDate: Timestamp?,
     updatePlannedDate: (Timestamp?) -> Unit
 ) {
-  // Row to display and change the date
+  val showingDatePicker = remember { mutableStateOf(false) }
+  val datePickerState = rememberDatePickerState()
 
-  val context = LocalContext.current
-
-  // Needed for the pop-up that allows the user to show the date
-  fun showDatePickerDialog() {
-    val calendar = Calendar.getInstance()
-    val year = calendar[Calendar.YEAR]
-    val month = calendar[Calendar.MONTH]
-    val day = calendar[Calendar.DAY_OF_MONTH]
-
-    DatePickerDialog(
-            context,
-            { _, selectedYear, selectedMonth, selectedDay ->
-              val timestamp = Timestamp.from(selectedYear, selectedMonth + 1, selectedDay)
-              updatePlannedDate(timestamp)
-            },
-            year,
-            month,
-            day)
-        .show()
+  fun showDatePicker() {
+    showingDatePicker.value = true
   }
+
+  fun dismissDatePicker() {
+    showingDatePicker.value = false
+  }
+
+  if (showingDatePicker.value) {
+    DatePickerDialog(
+        onDismissRequest = { dismissDatePicker() },
+        dismissButton = {
+          Button(onClick = { dismissDatePicker() }) {
+            Text(text = stringResource(R.string.hike_detail_screen_date_picker_cancel_button))
+          }
+        },
+        confirmButton = {
+          Button(
+              onClick = {
+                if (datePickerState.selectedDateMillis != null) {
+                  updatePlannedDate(Timestamp(Date(datePickerState.selectedDateMillis!!)))
+                }
+
+                dismissDatePicker()
+              }) {
+                Text(text = stringResource(R.string.hike_detail_screen_date_picker_confirm_button))
+              }
+        },
+    ) {
+      DatePicker(state = datePickerState)
+    }
+  }
+
   if (isSaved) {
     if (plannedDate == null) {
       DetailRow(
@@ -395,7 +412,7 @@ fun DateDetailRow(
                 ButtonDefaults.buttonColors(
                     containerColor = Color(0xFF4285F4), // Blue color to match the image
                     contentColor = Color.White),
-            onClick = { showDatePickerDialog() },
+            onClick = { showDatePicker() },
         ) {
           Text(
               text = stringResource(R.string.hike_detail_screen_add_a_date_button_text),
@@ -426,7 +443,7 @@ fun DateDetailRow(
                   // saved Date
                   style = MaterialTheme.typography.bodySmall,
                   modifier =
-                      Modifier.clickable { showDatePickerDialog() }
+                      Modifier.clickable { showDatePicker() }
                           .testTag(TEST_TAG_PLANNED_DATE_TEXT_BOX))
             }
       }

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -63,6 +63,9 @@ import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
 import ch.hikemate.app.ui.map.HikeDetailScreen.MAP_MAX_ZOOM
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
@@ -98,6 +101,9 @@ object HikeDetailScreen {
   const val TEST_TAG_DETAIL_ROW_VALUE = "detailRowValue"
   const val TEST_TAG_ADD_DATE_BUTTON = "addDateButton"
   const val TEST_TAG_PLANNED_DATE_TEXT_BOX = "plannedDateTextBox"
+  const val TEST_TAG_DATE_PICKER = "datePicker"
+  const val TEST_TAG_DATE_PICKER_CANCEL_BUTTON = "datePickerCancelButton"
+  const val TEST_TAG_DATE_PICKER_CONFIRM_BUTTON = "datePickerConfirmButton"
 }
 
 @Composable
@@ -367,14 +373,18 @@ fun DateDetailRow(
 
   if (showingDatePicker.value) {
     DatePickerDialog(
+        modifier = Modifier.testTag(TEST_TAG_DATE_PICKER),
         onDismissRequest = { dismissDatePicker() },
         dismissButton = {
-          Button(onClick = { dismissDatePicker() }) {
-            Text(text = stringResource(R.string.hike_detail_screen_date_picker_cancel_button))
-          }
+          Button(
+              modifier = Modifier.testTag(TEST_TAG_DATE_PICKER_CANCEL_BUTTON),
+              onClick = { dismissDatePicker() }) {
+                Text(text = stringResource(R.string.hike_detail_screen_date_picker_cancel_button))
+              }
         },
         confirmButton = {
           Button(
+              modifier = Modifier.testTag(TEST_TAG_DATE_PICKER_CONFIRM_BUTTON),
               onClick = {
                 if (datePickerState.selectedDateMillis != null) {
                   updatePlannedDate(Timestamp(Date(datePickerState.selectedDateMillis!!)))

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -436,7 +436,9 @@ fun DateDetailRow(
             modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
         Box(
             modifier =
-                Modifier.border(BorderStroke(1.dp, Color.Black), shape = RoundedCornerShape(4.dp))
+                Modifier.border(
+                        BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+                        shape = RoundedCornerShape(4.dp))
                     .padding(horizontal = 8.dp, vertical = 4.dp)) {
               Text(
                   text = plannedDate.toFormattedString(),

--- a/app/src/main/java/ch/hikemate/app/ui/theme/Theme.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/theme/Theme.kt
@@ -27,7 +27,8 @@ fun HikeMateTheme(
       when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
           val context = LocalContext.current
-          if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+          if (darkTheme) dynamicDarkColorScheme(context)
+          else dynamicLightColorScheme(context).copy(primary = primaryColor)
         }
         else -> colorScheme
       }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,10 @@
     <string name="hike_detail_screen_value_planned">Planned</string>
     <string name="hike_detail_screen_add_a_date_button_text">Add a date</string>
 
+    <!-- Hike Details Screen - Date Picker -->
+    <string name="hike_detail_screen_date_picker_cancel_button">Cancel</string>
+    <string name="hike_detail_screen_date_picker_confirm_button">Plan my hike!</string>
+
     <!-- Hike Difficulty Levels -->
     <string name="hike_difficulty_easy">Easy</string>
     <string name="hike_difficulty_moderate">Moderate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
 
     <!-- Hike Details Screen - Date Picker -->
     <string name="hike_detail_screen_date_picker_cancel_button">Cancel</string>
-    <string name="hike_detail_screen_date_picker_confirm_button">Plan my hike!</string>
+    <string name="hike_detail_screen_date_picker_confirm_button">Plan this hike!</string>
 
     <!-- Hike Difficulty Levels -->
     <string name="hike_difficulty_easy">Easy</string>


### PR DESCRIPTION
# Summary
The issue was that the calendar had ugly colors. We needed to use the primary color.

# Details
As I investigated the issue, I found out we used the wrong `DatePickerDialog`. I changed it to use the compose dialog one.
Also, I updated the them in order to use the primary color app-wide. This changes most of the colors to use the correct one.