### PR TITLE
refactor: replace and remove toFormattedDate

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -76,7 +76,7 @@ import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.utils.MapUtils
-import ch.hikemate.app.utils.toFormattedString
+import ch.hikemate.app.utils.humanReadableFormat
 import com.google.firebase.Timestamp
 import java.util.Date
 import java.util.Locale
@@ -451,7 +451,7 @@ fun DateDetailRow(
                         shape = RoundedCornerShape(4.dp))
                     .padding(horizontal = 8.dp, vertical = 4.dp)) {
               Text(
-                  text = plannedDate.toFormattedString(),
+                  text = plannedDate.humanReadableFormat(),
                   // saved Date
                   style = MaterialTheme.typography.bodySmall,
                   modifier =

--- a/app/src/main/java/ch/hikemate/app/utils/DatetimeUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/DatetimeUtils.kt
@@ -3,7 +3,6 @@ package ch.hikemate.app.utils
 import android.content.Context
 import ch.hikemate.app.R
 import com.google.firebase.Timestamp
-import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -83,9 +82,4 @@ fun Timestamp.humanReadablePlannedLabel(
     // Later than next year, for example "Planned on 18th of October 2026"
     else -> context.getString(R.string.datetime_utils_planned_on_date, formattedDate)
   }
-}
-
-fun Timestamp.toFormattedString(locale: Locale = Locale.getDefault()): String {
-  val dateFormat = SimpleDateFormat("dd/MM/yyyy", locale)
-  return dateFormat.format(this.toDate())
 }


### PR DESCRIPTION
This PR removes `DateTimeUtils.toFormattedDate` and replaces it with `DateTimeUtils.humanReadableFormat`.

`DateTimeUtils.toFormattedDate` used a date format that did not adapt to the current Locale. It used the `dd/MM/yyyy` format, but this format can be mistaken for `MM/dd/yyyy` depending on the date, which can be confusing for English speakers who are used to the second option rather than the first.