### PR TITLE
feat(hikes): HikesViewModel factory

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -2,13 +2,18 @@ package ch.hikemate.app.model.route
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import ch.hikemate.app.model.elevation.ElevationService
+import ch.hikemate.app.model.elevation.ElevationServiceRepository
 import ch.hikemate.app.model.extensions.toBounds
 import ch.hikemate.app.model.route.saved.SavedHike
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
+import ch.hikemate.app.model.route.saved.SavedHikesRepositoryFirestore
 import ch.hikemate.app.utils.RouteUtils
 import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -21,6 +26,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
 import org.osmdroid.util.BoundingBox
 
 /**
@@ -40,6 +46,20 @@ class HikesViewModel(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
   companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return HikesViewModel(
+                savedHikesRepo =
+                    SavedHikesRepositoryFirestore(
+                        FirebaseFirestore.getInstance(), FirebaseAuth.getInstance()),
+                osmHikesRepo = HikeRoutesRepositoryOverpass(OkHttpClient()),
+                elevationService = ElevationServiceRepository(OkHttpClient()))
+                as T
+          }
+        }
+
     private const val LOG_TAG = "HikesViewModel"
   }
 

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -6,12 +6,15 @@ import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.utils.RouteUtils
 import ch.hikemate.app.utils.from
 import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -135,6 +138,24 @@ class HikesViewModelTest {
           estimatedTime = DeferredData.Obtained(expectedEstimatedTime),
           elevationGain = DeferredData.Obtained(expectedElevationGain),
           difficulty = DeferredData.Obtained(expectedDifficulty))
+
+  // ==========================================================================
+  // CREATION OF AN INSTANCE USING THE FACTORY
+  // ==========================================================================
+
+  @Test
+  fun canBeCreatedAsFactory() {
+    val firebaseFirestore: FirebaseFirestore = mockk()
+    mockkStatic(FirebaseFirestore::class)
+    every { FirebaseFirestore.getInstance() } returns firebaseFirestore
+    val firebaseAuth: FirebaseAuth = mockk()
+    mockkStatic(FirebaseAuth::class)
+    every { FirebaseAuth.getInstance() } returns firebaseAuth
+
+    val factory = HikesViewModel.Factory
+    val viewModel = factory.create(HikesViewModel::class.java)
+    assertNotNull(viewModel)
+  }
 
   // ==========================================================================
   // HikesViewModel.selectHike


### PR DESCRIPTION
# Summary

#192 introduces a new view model but does not implement a factory to initialize it. This quick PR adds a factory to the view model to create it properly in `MainActivity` like the others.

## Details

Pretty standard stuff, I copied the factory logic and test from `ListOfHikeRoutesViewModel`, with the difference that it needed to mock `FirebaseFirestore` and `FirebaseAuth` since it uses it to instantiate the `SavedHikesRepository` used internally.