### PR TITLE
docs(hikes): fix typo in HikesViewModel docs

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -742,7 +742,7 @@ class HikesViewModel(
    * This function requires [_hikesMutex]'s lock to be acquired before being called. It is the
    * caller's responsibility to acquire the lock.
    *
-   * @param hikeFlow The flow of the hike to update.
+   * @param hikeId The unique ID of the hike to set the planned date for.
    * @return True if the operation was successful, false otherwise.
    */
   private suspend fun updateHikePlannedDateAsync(hikeId: String, date: Timestamp?): Boolean {


### PR DESCRIPTION
# Summary

Corrected the name of a parameter in the documentation of `updateHikePlannedDateAsync`, an internal method of `HikesViewModel`. I agree, it's not that important, but it's a very quick fix so I went for it anyway.