### PR TITLE
refactor: use jsonReader in facilities repo

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,7 +174,6 @@ dependencies {
     implementation(libs.googleid)
     implementation(libs.accompanist.permissions)
     implementation(libs.play.services.location)
-    implementation(libs.gson)
 
 
     // Global test dependencies

--- a/app/src/main/java/ch/hikemate/app/model/facilities/FacilitiesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/facilities/FacilitiesRepositoryOverpass.kt
@@ -62,7 +62,6 @@ class FacilitiesRepositoryOverpass(private val client: OkHttpClient) :
           Log.d("FacilitiesRepository", "Got ${facilities.size} facilities")
           onSuccess(facilities)
         }
-
       } catch (e: Exception) {
         onFailure(e)
       } finally {

--- a/app/src/main/java/ch/hikemate/app/model/facilities/FacilitiesRepositoryOverpass.kt
+++ b/app/src/main/java/ch/hikemate/app/model/facilities/FacilitiesRepositoryOverpass.kt
@@ -1,11 +1,11 @@
 package ch.hikemate.app.model.facilities
 
+import android.util.JsonReader
 import android.util.Log
 import ch.hikemate.app.model.overpassAPI.OverpassRepository
 import ch.hikemate.app.model.route.Bounds
 import ch.hikemate.app.model.route.LatLong
-import com.google.gson.Gson
-import com.google.gson.JsonObject
+import java.io.Reader
 import okhttp3.Callback
 import okhttp3.OkHttpClient
 
@@ -57,8 +57,9 @@ class FacilitiesRepositoryOverpass(private val client: OkHttpClient) :
           return
         }
 
-        val responseJsonString = response.body?.string() ?: throw Exception("Response body is null")
-        val facilities = parseAmenities(responseJsonString)
+        val responseJsonReader =
+            response.body?.charStream() ?: throw Exception("Response body is null")
+        val facilities = parseAmenities(responseJsonReader)
         Log.d("FacilitiesRepository", "Got ${facilities.size} facilities")
         onSuccess(facilities)
       } catch (e: Exception) {
@@ -70,31 +71,76 @@ class FacilitiesRepositoryOverpass(private val client: OkHttpClient) :
      * Parses and filters JSON response from Overpass API into a list of Facility objects. Filters
      * out amenities that have an invalid latitude, longitude or facility type.
      *
-     * @param jsonString JSON response string from Overpass API
+     * @param responseReader The Reader object to parse the JSON response from
      * @return List of parsed Facility objects
      */
-    fun parseAmenities(jsonString: String): List<Facility> {
-      val gson = Gson()
-      val facilities = mutableListOf<Facility>()
+    fun parseAmenities(responseReader: Reader): List<Facility> {
+      val facilities = mutableListOf<Facility?>()
+      val jsonReader = JsonReader(responseReader)
+      jsonReader.beginObject() // We're in the root object
+      while (jsonReader.hasNext()) {
+        val name = jsonReader.nextName()
+        if (name == "elements") {
+          // Parse the elements array
+          jsonReader.beginArray()
+          while (jsonReader.hasNext()) {
+            jsonReader.beginObject() // We're in an element object
 
-      // Parse the root JSON object
-      val rootObject = gson.fromJson(jsonString, JsonObject::class.java)
-      val elements = rootObject.getAsJsonArray("elements") ?: return facilities
+            facilities.add(parseAmenity(jsonReader))
 
-      // Process each element in the "elements" array
-      elements.forEach { element ->
-        val obj = element.asJsonObject
-        val lat = obj["lat"]?.asDouble
-        val lon = obj["lon"]?.asDouble
-        val tags = obj.getAsJsonObject("tags")
-        val amenity = tags?.get("amenity")?.asString?.let { FacilityType.fromString(it) }
+            jsonReader.endObject()
+          }
+          jsonReader.endArray()
+        } else {
+          jsonReader.skipValue()
+        }
+      }
+      jsonReader.endObject()
+      return facilities.filterNotNull()
+    }
 
-        if (lat != null && lon != null && amenity != null) {
-          facilities.add(Facility(amenity, LatLong(lat, lon)))
+    /**
+     * Parses a single amenity element from the JSON response.
+     *
+     * @param jsonReader The JsonReader object to parse the amenity from
+     * @return The Facility object parsed from the JSON response, or null if the amenity is invalid
+     */
+    fun parseAmenity(jsonReader: JsonReader): Facility? {
+      var lat = 0.0
+      var lon = 0.0
+      var amenity: FacilityType? = null
+
+      while (jsonReader.hasNext()) {
+        val name = jsonReader.nextName()
+        when (name) {
+          "lat" -> lat = jsonReader.nextDouble()
+          "lon" -> lon = jsonReader.nextDouble()
+          "tags" -> {
+            jsonReader.beginObject() // We're in the tags object of the element
+
+            while (jsonReader.hasNext()) {
+              val typeName = jsonReader.nextName()
+
+              when (typeName) {
+                "amenity" -> {
+                  val amenityName = jsonReader.nextString()
+                  amenity = FacilityType.fromString(amenityName)
+                }
+                else -> jsonReader.skipValue()
+              }
+            }
+
+            jsonReader.endObject()
+          }
+          else -> jsonReader.skipValue()
         }
       }
 
-      return facilities
+      if (lat != 0.0 && lon != 0.0 && amenity != null) {
+        return Facility(amenity, LatLong(lat, lon))
+      }
+
+      return null
     }
   }
 }

--- a/app/src/test/java/ch/hikemate/app/model/facilities/FacilitiesRepositoryOverpassTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/facilities/FacilitiesRepositoryOverpassTest.kt
@@ -64,7 +64,7 @@ class FacilitiesRepositoryOverpassTest {
         }
       }"""
 
-    private const val VALID_RESPONSE_ELEMENT_WITH_MULTIPLE_TAGS =
+    private const val VALID_RESPONSE_ELEMENT_2 =
         """
       {
         "type": "node",
@@ -167,7 +167,7 @@ class FacilitiesRepositoryOverpassTest {
             VALID_RESPONSE_HEADER +
                 VALID_RESPONSE_ELEMENT +
                 "," +
-                VALID_RESPONSE_ELEMENT_WITH_MULTIPLE_TAGS +
+                VALID_RESPONSE_ELEMENT_2 +
                 VALID_RESPONSE_FOOTER)
 
     val callbackCaptor = argumentCaptor<okhttp3.Callback>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 accompanistPermissions = "0.36.0"
 agp = "8.7.0"
 firebaseBom = "33.4.0"
-gson = "2.11.0"
 kotlin =  "1.8.10"
 coreKtx = "1.13.1"
 kotlinxSerializationJson = "1.6.3"
@@ -53,7 +52,6 @@ accompanist-permissions = { module = "com.google.accompanist:accompanist-permiss
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
# Summary
The facilities repository was using a dependency called `gson`. This works but when we retrieve a lot of data, this library won't handle it and would throw an out of memory error.

To manage this, I changed the facilities repository to use the JSON reader.