### PR TITLE
feat: implement run this hike button

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -184,25 +184,19 @@ class EndToEndTest2 : TestCase() {
 
     // Wait for the transition to complete
     composeTestRule.waitUntilExactlyOneExists(
-        hasTestTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP), timeoutMillis = 10000)
+        hasTestTag(HikeDetailScreen.TEST_TAG_MAP), timeoutMillis = 10000)
 
     // ==========================================
     // DETAILS SCREENS
     // ==========================================
 
     // Check we are on the hike details screen
-    composeTestRule.onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_HIKE_NAME)
-        .assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON)
-        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_HIKE_NAME).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_BOOKMARK_ICON).assertIsDisplayed()
 
     // Click on the bookmark icon
-    composeTestRule
-        .onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON)
-        .performClick()
+    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_BOOKMARK_ICON).performClick()
 
     // Wait for the bookmark to be saved
     composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -184,19 +184,25 @@ class EndToEndTest2 : TestCase() {
 
     // Wait for the transition to complete
     composeTestRule.waitUntilExactlyOneExists(
-        hasTestTag(HikeDetailScreen.TEST_TAG_MAP), timeoutMillis = 10000)
+        hasTestTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP), timeoutMillis = 10000)
 
     // ==========================================
     // DETAILS SCREENS
     // ==========================================
 
     // Check we are on the hike details screen
-    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_MAP).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_HIKE_NAME).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_BOOKMARK_ICON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_HIKE_NAME)
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON)
+        .assertIsDisplayed()
 
     // Click on the bookmark icon
-    composeTestRule.onNodeWithTag(HikeDetailScreen.TEST_TAG_BOOKMARK_ICON).performClick()
+    composeTestRule
+        .onNodeWithTag(HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON)
+        .performClick()
 
     // Wait for the bookmark to be saved
     composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
@@ -22,18 +22,18 @@ import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.model.route.saved.SavedHikesViewModel
 import ch.hikemate.app.ui.components.BackButton.BACK_BUTTON_TEST_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_HIKE_NAME
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_HIKE_NAME
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_MAP
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_PLANNED_DATE_TEXT_BOX
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_RUN_HIKE_BUTTON
 import ch.hikemate.app.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.util.Locale
@@ -130,7 +130,7 @@ class HikeDetailScreenTest {
           navigationActions = mockNavigationActions)
     }
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
   }
 
   @Test
@@ -146,8 +146,8 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_HIKE_NAME).assertTextEquals(route.name!!)
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_HIKE_NAME).assertTextEquals(route.name!!)
+    composeTestRule.onNodeWithTag(TEST_TAG_BOOKMARK_ICON).assertIsDisplayed()
   }
 
   @Test
@@ -163,7 +163,7 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
   }
 
   @Test
@@ -192,7 +192,7 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
   }
 
   @Test
@@ -208,8 +208,8 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(5)
-    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
   }
 
   @Test
@@ -234,9 +234,9 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
-    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON).assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertIsDisplayed()
   }
 
   @Test
@@ -265,9 +265,9 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
-    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onNodeWithTag(TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
   }
 
   @Test
@@ -315,11 +315,8 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule
-        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON)
-        .assertHasClickAction()
-        .performClick()
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
   }
 
   @Test
@@ -344,15 +341,12 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule
-        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON)
-        .assertHasClickAction()
-        .performClick()
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER_CANCEL_BUTTON).performClick()
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
   }
 
   @Test
@@ -377,15 +371,12 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule
-        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON)
-        .assertHasClickAction()
-        .performClick()
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER_CONFIRM_BUTTON).performClick()
 
-    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
   }
 
   @Test
@@ -407,16 +398,16 @@ class HikeDetailScreenTest {
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime % 60).roundToInt())
 
     composeTestRule
-        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${distanceString}km"))
     composeTestRule
-        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${elevationGainString}m"))
     composeTestRule
-        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${hourString}h${minuteString}"))
     composeTestRule
-        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(
             hasText(
                 ApplicationProvider.getApplicationContext<Context>()
@@ -440,7 +431,7 @@ class HikeDetailScreenTest {
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime % 60).roundToInt())
 
     composeTestRule
-        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${minuteString}min"))
   }
 
@@ -456,10 +447,7 @@ class HikeDetailScreenTest {
           { onRunThisHike() })
     }
 
-    composeTestRule
-        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON)
-        .assertIsDisplayed()
-        .performClick()
+    composeTestRule.onNodeWithTag(TEST_TAG_RUN_HIKE_BUTTON).assertIsDisplayed().performClick()
 
     verify(onRunThisHike).invoke()
   }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
@@ -22,17 +22,18 @@ import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.model.route.saved.SavedHikesViewModel
 import ch.hikemate.app.ui.components.BackButton.BACK_BUTTON_TEST_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_HIKE_NAME
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_MAP
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_PLANNED_DATE_TEXT_BOX
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_HIKE_NAME
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON
 import ch.hikemate.app.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.util.Locale
@@ -129,7 +130,7 @@ class HikeDetailScreenTest {
           navigationActions = mockNavigationActions)
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_MAP).assertIsDisplayed()
   }
 
   @Test
@@ -141,11 +142,12 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_HIKE_NAME).assertTextEquals(route.name!!)
-    composeTestRule.onNodeWithTag(TEST_TAG_BOOKMARK_ICON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_HIKE_NAME).assertTextEquals(route.name!!)
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON).assertIsDisplayed()
   }
 
   @Test
@@ -157,10 +159,11 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
   }
 
   @Test
@@ -185,10 +188,11 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
   }
 
   @Test
@@ -200,11 +204,12 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(5)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
   }
 
   @Test
@@ -225,12 +230,13 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
-    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
+    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON).assertIsDisplayed()
   }
 
   @Test
@@ -255,12 +261,13 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
-    composeTestRule.onNodeWithTag(TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
+    composeTestRule.onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
   }
 
   @Test
@@ -304,11 +311,15 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON)
+        .assertHasClickAction()
+        .performClick()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsDisplayed()
   }
 
   @Test
@@ -329,15 +340,19 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON)
+        .assertHasClickAction()
+        .performClick()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER_CANCEL_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON).performClick()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
   }
 
   @Test
@@ -358,15 +373,19 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertHasClickAction().performClick()
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON)
+        .assertHasClickAction()
+        .performClick()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER_CONFIRM_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON).performClick()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER).assertIsNotDisplayed()
   }
 
   @Test
@@ -376,7 +395,8 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
     val distanceString = String.format(Locale.ENGLISH, "%.2f", detailedRoute.totalDistance)
@@ -387,16 +407,16 @@ class HikeDetailScreenTest {
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime % 60).roundToInt())
 
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${distanceString}km"))
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${elevationGainString}m"))
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${hourString}h${minuteString}"))
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(
             hasText(
                 ApplicationProvider.getApplicationContext<Context>()
@@ -412,14 +432,35 @@ class HikeDetailScreenTest {
           detailedRoute = detailedRoute,
           savedHikesViewModel = savedHikesViewModel,
           emptyList(),
-          HikingLevel.BEGINNER)
+          HikingLevel.BEGINNER,
+          {})
     }
 
     val minuteString =
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime % 60).roundToInt())
 
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${minuteString}min"))
+  }
+
+  @Test
+  fun hikeDetails_showsRunThisHikeButton_andTriggersOnRunThisHike() {
+    val onRunThisHike = mock<() -> Unit>()
+    composeTestRule.setContent {
+      HikeDetails(
+          detailedRoute = detailedRoute,
+          savedHikesViewModel = savedHikesViewModel,
+          emptyList(),
+          HikingLevel.BEGINNER,
+          { onRunThisHike() })
+    }
+
+    composeTestRule
+        .onNodeWithTag(HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON)
+        .assertIsDisplayed()
+        .performClick()
+
+    verify(onRunThisHike).invoke()
   }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -59,20 +59,23 @@ import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
 import ch.hikemate.app.model.route.saved.SavedHikesViewModel
 import ch.hikemate.app.ui.components.AsyncStateHandler
 import ch.hikemate.app.ui.components.BackButton
+import ch.hikemate.app.ui.components.BigButton
+import ch.hikemate.app.ui.components.ButtonType
 import ch.hikemate.app.ui.components.ElevationGraph
 import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_HIKE_NAME
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX
+import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.MAP_MAX_ZOOM
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_HIKE_NAME
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_MAP
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_PLANNED_DATE_TEXT_BOX
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
@@ -93,17 +96,18 @@ object HikeDetailScreen {
   const val MAP_MIN_LONGITUDE = -180.0
   const val MAP_BOUNDS_MARGIN: Int = 100
 
-  const val TEST_TAG_MAP = "HikeDetailScreenMap"
-  const val TEST_TAG_HIKE_NAME = "HikeDetailScreenHikeName"
-  const val TEST_TAG_BOOKMARK_ICON = "HikeDetailScreenBookmarkIcon"
-  const val TEST_TAG_ELEVATION_GRAPH = "HikeDetailScreenElevationGraph"
-  const val TEST_TAG_DETAIL_ROW_TAG = "HikeDetailScreenDetailRowTag"
-  const val TEST_TAG_DETAIL_ROW_VALUE = "HikeDetailScreenDetailRowValue"
-  const val TEST_TAG_ADD_DATE_BUTTON = "HikeDetailScreenAddDateButton"
-  const val TEST_TAG_PLANNED_DATE_TEXT_BOX = "HikeDetailScreenPlannedDateTextBox"
-  const val TEST_TAG_DATE_PICKER = "HikeDetailDatePicker"
-  const val TEST_TAG_DATE_PICKER_CANCEL_BUTTON = "HikeDetailDatePickerCancelButton"
-  const val TEST_TAG_DATE_PICKER_CONFIRM_BUTTON = "HikeDetailDatePickerConfirmButton"
+  const val HIKE_DETAILS_TEST_TAG_MAP = "HikeDetailScreenMap"
+  const val HIKE_DETAILS_TEST_TAG_HIKE_NAME = "HikeDetailScreenHikeName"
+  const val HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON = "HikeDetailScreenBookmarkIcon"
+  const val HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH = "HikeDetailScreenElevationGraph"
+  const val HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG = "HikeDetailScreenDetailRowTag"
+  const val HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE = "HikeDetailScreenDetailRowValue"
+  const val HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON = "HikeDetailScreenAddDateButton"
+  const val HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX = "HikeDetailScreenPlannedDateTextBox"
+  const val HIKE_DETAILS_TEST_TAG_DATE_PICKER = "HikeDetailDatePicker"
+  const val HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON = "HikeDetailDatePickerCancelButton"
+  const val HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON = "HikeDetailDatePickerConfirmButton"
+  const val HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON = "HikeDetailRunHikeButton"
 }
 
 @Composable
@@ -212,7 +216,7 @@ fun HikeDetailScreen(
           modifier =
               Modifier.fillMaxWidth()
                   .padding(bottom = 300.dp) // Reserve space for the scaffold at the bottom
-                  .testTag(TEST_TAG_MAP))
+                  .testTag(HIKE_DETAILS_TEST_TAG_MAP))
       // Back Button at the top of the screen
       BackButton(
           navigationActions = navigationActions,
@@ -227,11 +231,26 @@ fun HikeDetailScreen(
                   .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp))
 
       // Hike Details bottom sheet
-      HikeDetails(detailedRoute, savedHikesViewModel, elevationData, profile.hikingLevel)
+      HikeDetails(
+          detailedRoute = detailedRoute,
+          savedHikesViewModel = savedHikesViewModel,
+          elevationData = elevationData,
+          userHikingLevel = profile.hikingLevel,
+          onRunThisHike = { navigationActions.navigateTo(Screen.RUN_HIKE) },
+      )
     }
   }
 }
 
+/**
+ * A composable that displays details about a hike in a bottom sheet.
+ *
+ * @param detailedRoute The route for which information is displayed
+ * @param savedHikesViewModel ViewModel managing saved hikes state
+ * @param elevationData List of elevation points for the elevation graph
+ * @param userHikingLevel The user's hiking experience level
+ * @param onRunThisHike Callback triggered when "Run This Hike" button is clicked
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HikeDetails(
@@ -239,6 +258,7 @@ fun HikeDetails(
     savedHikesViewModel: SavedHikesViewModel,
     elevationData: List<Double>,
     userHikingLevel: HikingLevel,
+    onRunThisHike: () -> Unit
 ) {
   val hikeDetailState = savedHikesViewModel.hikeDetailState.collectAsState(null).value
 
@@ -276,7 +296,7 @@ fun HikeDetails(
                           ?: stringResource(R.string.map_screen_hike_title_default),
                   style = MaterialTheme.typography.titleLarge,
                   textAlign = TextAlign.Left,
-                  modifier = Modifier.testTag(TEST_TAG_HIKE_NAME))
+                  modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_HIKE_NAME))
               AppropriatenessMessage(isSuitable)
             }
 
@@ -287,9 +307,9 @@ fun HikeDetails(
                         stringResource(R.string.hike_detail_screen_bookmark_hint_on_isSaved_true)
                     else stringResource(R.string.hike_detail_screen_bookmark_hint_on_isSaved_false),
                 modifier =
-                    Modifier.size(60.dp, 80.dp).testTag(TEST_TAG_BOOKMARK_ICON).clickable {
-                      toggleSaveState()
-                    },
+                    Modifier.size(60.dp, 80.dp)
+                        .testTag(HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON)
+                        .clickable { toggleSaveState() },
                 contentScale = ContentScale.FillBounds,
             )
           }
@@ -300,7 +320,7 @@ fun HikeDetails(
                   Modifier.fillMaxWidth()
                       .height(60.dp)
                       .padding(4.dp)
-                      .testTag(TEST_TAG_ELEVATION_GRAPH),
+                      .testTag(HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH),
               styleProperties =
                   ElevationGraphStyleProperties(
                       strokeColor = hikeColor, fillColor = hikeColor.copy(0.1f)))
@@ -334,6 +354,16 @@ fun HikeDetails(
                           LocalContext.current, detailedRoute.difficulty.colorResourceId)),
           )
           DateDetailRow(isSaved, plannedDate, updatePlannedDate)
+
+          // "Run This Hike" button
+          BigButton(
+              buttonType = ButtonType.PRIMARY,
+              label = stringResource(R.string.hike_detail_screen_run_this_hike_button_label),
+              onClick = { onRunThisHike() },
+              modifier =
+                  Modifier.padding(top = 16.dp)
+                      .fillMaxWidth()
+                      .testTag(HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON))
         }
       },
       sheetPeekHeight = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT) {}
@@ -360,18 +390,18 @@ fun DateDetailRow(
 
   if (showingDatePicker.value) {
     DatePickerDialog(
-        modifier = Modifier.testTag(TEST_TAG_DATE_PICKER),
+        modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER),
         onDismissRequest = { dismissDatePicker() },
         dismissButton = {
           Button(
-              modifier = Modifier.testTag(TEST_TAG_DATE_PICKER_CANCEL_BUTTON),
+              modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON),
               onClick = { dismissDatePicker() }) {
                 Text(text = stringResource(R.string.hike_detail_screen_date_picker_cancel_button))
               }
         },
         confirmButton = {
           Button(
-              modifier = Modifier.testTag(TEST_TAG_DATE_PICKER_CONFIRM_BUTTON),
+              modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON),
               onClick = {
                 if (datePickerState.selectedDateMillis != null) {
                   updatePlannedDate(Timestamp(Date(datePickerState.selectedDateMillis!!)))
@@ -400,10 +430,11 @@ fun DateDetailRow(
         Text(
             text = stringResource(R.string.hike_detail_screen_label_planned_for),
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG))
 
         Button(
-            modifier = Modifier.width(90.dp).height(25.dp).testTag(TEST_TAG_ADD_DATE_BUTTON),
+            modifier =
+                Modifier.width(90.dp).height(25.dp).testTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON),
             contentPadding = PaddingValues(0.dp),
             colors =
                 ButtonDefaults.buttonColors(
@@ -430,7 +461,7 @@ fun DateDetailRow(
         Text(
             text = stringResource(R.string.hike_detail_screen_label_planned_for),
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG))
         Box(
             modifier =
                 Modifier.border(
@@ -443,7 +474,7 @@ fun DateDetailRow(
                   style = MaterialTheme.typography.bodySmall,
                   modifier =
                       Modifier.clickable { showDatePicker() }
-                          .testTag(TEST_TAG_PLANNED_DATE_TEXT_BOX))
+                          .testTag(HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX))
             }
       }
     }
@@ -467,12 +498,12 @@ fun DetailRow(
         Text(
             text = label,
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG))
         Text(
             text = value,
             style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
             color = valueColor,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_VALUE))
+            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE))
       }
 }
 

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -63,19 +63,19 @@ import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
 import ch.hikemate.app.ui.components.ElevationGraph
 import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_HIKE_NAME
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_MAP
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX
-import ch.hikemate.app.ui.map.HikeDetailScreen.HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.MAP_MAX_ZOOM
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_HIKE_NAME
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_MAP
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_PLANNED_DATE_TEXT_BOX
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_RUN_HIKE_BUTTON
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
@@ -96,18 +96,18 @@ object HikeDetailScreen {
   const val MAP_MIN_LONGITUDE = -180.0
   const val MAP_BOUNDS_MARGIN: Int = 100
 
-  const val HIKE_DETAILS_TEST_TAG_MAP = "HikeDetailScreenMap"
-  const val HIKE_DETAILS_TEST_TAG_HIKE_NAME = "HikeDetailScreenHikeName"
-  const val HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON = "HikeDetailScreenBookmarkIcon"
-  const val HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH = "HikeDetailScreenElevationGraph"
-  const val HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG = "HikeDetailScreenDetailRowTag"
-  const val HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE = "HikeDetailScreenDetailRowValue"
-  const val HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON = "HikeDetailScreenAddDateButton"
-  const val HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX = "HikeDetailScreenPlannedDateTextBox"
-  const val HIKE_DETAILS_TEST_TAG_DATE_PICKER = "HikeDetailDatePicker"
-  const val HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON = "HikeDetailDatePickerCancelButton"
-  const val HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON = "HikeDetailDatePickerConfirmButton"
-  const val HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON = "HikeDetailRunHikeButton"
+  const val TEST_TAG_MAP = "HikeDetailScreenMap"
+  const val TEST_TAG_HIKE_NAME = "HikeDetailScreenHikeName"
+  const val TEST_TAG_BOOKMARK_ICON = "HikeDetailScreenBookmarkIcon"
+  const val TEST_TAG_ELEVATION_GRAPH = "HikeDetailScreenElevationGraph"
+  const val TEST_TAG_DETAIL_ROW_TAG = "HikeDetailScreenDetailRowTag"
+  const val TEST_TAG_DETAIL_ROW_VALUE = "HikeDetailScreenDetailRowValue"
+  const val TEST_TAG_ADD_DATE_BUTTON = "HikeDetailScreenAddDateButton"
+  const val TEST_TAG_PLANNED_DATE_TEXT_BOX = "HikeDetailScreenPlannedDateTextBox"
+  const val TEST_TAG_DATE_PICKER = "HikeDetailDatePicker"
+  const val TEST_TAG_DATE_PICKER_CANCEL_BUTTON = "HikeDetailDatePickerCancelButton"
+  const val TEST_TAG_DATE_PICKER_CONFIRM_BUTTON = "HikeDetailDatePickerConfirmButton"
+  const val TEST_TAG_RUN_HIKE_BUTTON = "HikeDetailRunHikeButton"
 }
 
 @Composable
@@ -216,7 +216,7 @@ fun HikeDetailScreen(
           modifier =
               Modifier.fillMaxWidth()
                   .padding(bottom = 300.dp) // Reserve space for the scaffold at the bottom
-                  .testTag(HIKE_DETAILS_TEST_TAG_MAP))
+                  .testTag(TEST_TAG_MAP))
       // Back Button at the top of the screen
       BackButton(
           navigationActions = navigationActions,
@@ -296,7 +296,7 @@ fun HikeDetails(
                           ?: stringResource(R.string.map_screen_hike_title_default),
                   style = MaterialTheme.typography.titleLarge,
                   textAlign = TextAlign.Left,
-                  modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_HIKE_NAME))
+                  modifier = Modifier.testTag(TEST_TAG_HIKE_NAME))
               AppropriatenessMessage(isSuitable)
             }
 
@@ -307,9 +307,9 @@ fun HikeDetails(
                         stringResource(R.string.hike_detail_screen_bookmark_hint_on_isSaved_true)
                     else stringResource(R.string.hike_detail_screen_bookmark_hint_on_isSaved_false),
                 modifier =
-                    Modifier.size(60.dp, 80.dp)
-                        .testTag(HIKE_DETAILS_TEST_TAG_BOOKMARK_ICON)
-                        .clickable { toggleSaveState() },
+                    Modifier.size(60.dp, 80.dp).testTag(TEST_TAG_BOOKMARK_ICON).clickable {
+                      toggleSaveState()
+                    },
                 contentScale = ContentScale.FillBounds,
             )
           }
@@ -320,7 +320,7 @@ fun HikeDetails(
                   Modifier.fillMaxWidth()
                       .height(60.dp)
                       .padding(4.dp)
-                      .testTag(HIKE_DETAILS_TEST_TAG_ELEVATION_GRAPH),
+                      .testTag(TEST_TAG_ELEVATION_GRAPH),
               styleProperties =
                   ElevationGraphStyleProperties(
                       strokeColor = hikeColor, fillColor = hikeColor.copy(0.1f)))
@@ -361,9 +361,7 @@ fun HikeDetails(
               label = stringResource(R.string.hike_detail_screen_run_this_hike_button_label),
               onClick = { onRunThisHike() },
               modifier =
-                  Modifier.padding(top = 16.dp)
-                      .fillMaxWidth()
-                      .testTag(HIKE_DETAILS_TEST_TAG_RUN_HIKE_BUTTON))
+                  Modifier.padding(top = 16.dp).fillMaxWidth().testTag(TEST_TAG_RUN_HIKE_BUTTON))
         }
       },
       sheetPeekHeight = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT) {}
@@ -390,18 +388,18 @@ fun DateDetailRow(
 
   if (showingDatePicker.value) {
     DatePickerDialog(
-        modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER),
+        modifier = Modifier.testTag(TEST_TAG_DATE_PICKER),
         onDismissRequest = { dismissDatePicker() },
         dismissButton = {
           Button(
-              modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CANCEL_BUTTON),
+              modifier = Modifier.testTag(TEST_TAG_DATE_PICKER_CANCEL_BUTTON),
               onClick = { dismissDatePicker() }) {
                 Text(text = stringResource(R.string.hike_detail_screen_date_picker_cancel_button))
               }
         },
         confirmButton = {
           Button(
-              modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DATE_PICKER_CONFIRM_BUTTON),
+              modifier = Modifier.testTag(TEST_TAG_DATE_PICKER_CONFIRM_BUTTON),
               onClick = {
                 if (datePickerState.selectedDateMillis != null) {
                   updatePlannedDate(Timestamp(Date(datePickerState.selectedDateMillis!!)))
@@ -430,11 +428,10 @@ fun DateDetailRow(
         Text(
             text = stringResource(R.string.hike_detail_screen_label_planned_for),
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
 
         Button(
-            modifier =
-                Modifier.width(90.dp).height(25.dp).testTag(HIKE_DETAILS_TEST_TAG_ADD_DATE_BUTTON),
+            modifier = Modifier.width(90.dp).height(25.dp).testTag(TEST_TAG_ADD_DATE_BUTTON),
             contentPadding = PaddingValues(0.dp),
             colors =
                 ButtonDefaults.buttonColors(
@@ -461,7 +458,7 @@ fun DateDetailRow(
         Text(
             text = stringResource(R.string.hike_detail_screen_label_planned_for),
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
         Box(
             modifier =
                 Modifier.border(
@@ -474,7 +471,7 @@ fun DateDetailRow(
                   style = MaterialTheme.typography.bodySmall,
                   modifier =
                       Modifier.clickable { showDatePicker() }
-                          .testTag(HIKE_DETAILS_TEST_TAG_PLANNED_DATE_TEXT_BOX))
+                          .testTag(TEST_TAG_PLANNED_DATE_TEXT_BOX))
             }
       }
     }
@@ -498,12 +495,12 @@ fun DetailRow(
         Text(
             text = label,
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
         Text(
             text = value,
             style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
             color = valueColor,
-            modifier = Modifier.testTag(HIKE_DETAILS_TEST_TAG_DETAIL_ROW_VALUE))
+            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_VALUE))
       }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="hike_detail_screen_value_not_saved">Not saved</string>
     <string name="hike_detail_screen_value_planned">Planned</string>
     <string name="hike_detail_screen_add_a_date_button_text">Add a date</string>
+    <string name="hike_detail_screen_run_this_hike_button_label">Run this hike!</string>
 
     <!-- Hike Details Screen - Date Picker -->
     <string name="hike_detail_screen_date_picker_cancel_button">Cancel</string>


### PR DESCRIPTION
# Summary

I added a "Run this hike" button to the hike details screen, which lets the user trigger our run this hike feature. Instead of passing the `navigationActions` to the composable which contains the button (`HikeDetails`) to then trigger the navigation to the run hike screen, I've passed a `onRunThisHike` callback, since I believe this makes more sense, so the `HikeDetails` composable does not need to worry about how to implement onRunThisHike at all, and the parent, the `HikeDetailScreen` composable has full control. 

# Note
I've changed all test tags in the hike details screen to fit our new naming convention of `{SCREEN}_TEST_TAG_{COMPONENT}` convention. This is since I had to add a new test tag, and it felt a little bit cheeky to add a single one that is conform with our convention, but leave the rest as they are...
