### PR TITLE
fix: planned hikes also appear in the saved hikes screen

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -211,4 +211,37 @@ class SavedHikesScreenTest : TestCase() {
 
         verify(savedHikesRepository, times(2)).loadSavedHikes()
       }
+
+  @Test
+  fun savedHikeThatIsPlannedIsStillInSavedHikesScreen() =
+      runTest(timeout = 5.seconds) {
+        val savedHikes =
+            listOf(
+                SavedHike(id = "1", name = "Hike 1", date = null),
+                SavedHike(id = "2", name = "Hike 2", date = null))
+        `when`(savedHikesRepository.loadSavedHikes()).thenReturn(savedHikes)
+
+        composeTestRule.setContent { SavedHikesScreen(savedHikesViewModel, navigationActions) }
+
+        // Select the saved hikes tab
+        composeTestRule
+            .onNodeWithTag(
+                SavedHikesScreen.TEST_TAG_SAVED_HIKES_TABS_MENU_ITEM_PREFIX +
+                    SavedHikesSection.Saved.name)
+            .performClick()
+
+        val savedHikes2 =
+            listOf(
+                SavedHike(id = "1", name = "Hike 1", date = Timestamp.now()),
+                SavedHike(id = "2", name = "Hike 2", date = null))
+
+        `when`(savedHikesRepository.loadSavedHikes()).thenReturn(savedHikes2)
+        // Verify that the hike is still displayed in the saved hikes screen
+        composeTestRule
+            .onNodeWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE)
+            .assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD)
+            .assertCountEquals(2)
+      }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/saved/SavedHikesScreenTest.kt
@@ -190,7 +190,7 @@ class SavedHikesScreenTest : TestCase() {
             .assertIsNotDisplayed()
         composeTestRule
             .onAllNodesWithTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_HIKE_CARD)
-            .assertCountEquals(2)
+            .assertCountEquals(3)
       }
 
   @Test

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -173,14 +173,12 @@ private fun PlannedHikes(hikes: List<SavedHike>?) {
 }
 
 @Composable
-private fun SavedHikes(hikes: List<SavedHike>?) {
+private fun SavedHikes(savedHikes: List<SavedHike>?) {
   val context = LocalContext.current
   Text(
       context.getString(R.string.saved_hikes_screen_saved_section_title),
       style = MaterialTheme.typography.titleLarge,
       modifier = Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE))
-
-  val savedHikes = hikes?.filter { it.date == null }
 
   if (savedHikes.isNullOrEmpty()) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
# Summary
Little fix for the `SavedHikes` screen: now a planned hike also appears in the `SavedHikes` screen. This is possible by simply changing the filtering of the `savedHike` in the `savedHikesViewModel`.
