### PR TITLE
feat(hikes): new HikesViewModel flows

### DIFF
--- a/app/src/main/java/ch/hikemate/app/model/route/DeferredData.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/DeferredData.kt
@@ -48,4 +48,12 @@ sealed class DeferredData<out T> {
 
   /** Returns `true` if the data has been obtained, `false` otherwise. */
   fun obtained(): Boolean = this is Obtained
+
+  /** Returns the data if it has been obtained, otherwise returns `null`. */
+  fun getOrNull(): T? {
+    return when (this) {
+      is Obtained -> data
+      else -> null
+    }
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/DeferredData.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/DeferredData.kt
@@ -45,4 +45,7 @@ sealed class DeferredData<out T> {
    * job of [DeferredData].
    */
   data class Obtained<out T>(val data: T) : DeferredData<T>()
+
+  /** Returns `true` if the data has been obtained, `false` otherwise. */
+  fun obtained(): Boolean = this is Obtained
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/DeferredData.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/DeferredData.kt
@@ -56,4 +56,14 @@ sealed class DeferredData<out T> {
       else -> null
     }
   }
+
+  /**
+   * Returns the data if it has been obtained, otherwise throws an [IllegalStateException].
+   *
+   * @throws IllegalStateException If the data hasn't been obtained yet.
+   */
+  fun getOrThrow(): T {
+    check(this is Obtained)
+    return this.data
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -68,24 +68,38 @@ data class Hike(
   }
 
   /**
+   * Indicates whether the hike has all of its data obtained.
+   *
+   * See [DeferredData] for more information about what it means for the data to be obtained.
+   *
+   * If this returns, true, you can safely call [withDetailsOrThrow] to get a [DetailedHike]
+   * instance
+   *
+   * @return True if all data were obtained for the hike, false otherwise.
+   */
+  fun isFullyLoaded(): Boolean =
+      description.obtained() &&
+          bounds.obtained() &&
+          waypoints.obtained() &&
+          elevation.obtained() &&
+          distance.obtained() &&
+          estimatedTime.obtained() &&
+          elevationGain.obtained() &&
+          difficulty.obtained()
+
+  /**
    * If all attributes of the hike are computed, casts everything to their respective data type and
    * returns a [DetailedHike] with the values to work with them directly without needing to perform
    * null checks.
+   *
+   * To make sure all details are loaded before calling this method, use [isFullyLoaded].
    *
    * If one or more attribute is missing, throws an [IllegalStateException].
    *
    * @throws IllegalStateException If one or more attribute of the hike has not been computed yet.
    */
   fun withDetailsOrThrow(): DetailedHike {
-    check(
-        description.obtained() &&
-            bounds.obtained() &&
-            waypoints.obtained() &&
-            elevation.obtained() &&
-            distance.obtained() &&
-            estimatedTime.obtained() &&
-            elevationGain.obtained() &&
-            difficulty.obtained())
+    check(isFullyLoaded())
     return DetailedHike(
         id,
         getColor(),

--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -50,7 +50,12 @@ data class Hike(
   /** Helper to convert this [Hike] to a [SavedHike] object. */
   fun toSavedHike() = SavedHike(id, name ?: "", plannedDate)
 
-  /** Get the color of the route from its id. The color should be the same for the same route id. */
+  /**
+   * Get the color of the route from its id. The color should be the same for the same route id.
+   *
+   * @return The color as an integer. Use [androidx.compose.ui.graphics.Color] to convert it to an
+   *   actual color.
+   */
   fun getColor(): Int {
     return hikeColors[abs(id.hashCode()) % hikeColors.size]
   }

--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -1,7 +1,9 @@
 package ch.hikemate.app.model.route
 
 import ch.hikemate.app.model.route.saved.SavedHike
+import ch.hikemate.app.ui.theme.hikeColors
 import com.google.firebase.Timestamp
+import kotlin.math.abs
 
 /**
  * Represents a hike route with associated information.
@@ -47,4 +49,9 @@ data class Hike(
 ) {
   /** Helper to convert this [Hike] to a [SavedHike] object. */
   fun toSavedHike() = SavedHike(id, name ?: "", plannedDate)
+
+  /** Get the color of the route from its id. The color should be the same for the same route id. */
+  fun getColor(): Int {
+    return hikeColors[abs(id.hashCode()) % hikeColors.size]
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -66,4 +66,62 @@ data class Hike(
   fun hasOsmData(): Boolean {
     return description.obtained() && bounds.obtained() && waypoints.obtained()
   }
+
+  /**
+   * If all attributes of the hike are computed, casts everything to their respective data type and
+   * returns a [DetailedHike] with the values to work with them directly without needing to perform
+   * null checks.
+   *
+   * If one or more attribute is missing, throws an [IllegalStateException].
+   *
+   * @throws IllegalStateException If one or more attribute of the hike has not been computed yet.
+   */
+  fun withDetailsOrThrow(): DetailedHike {
+    check(
+        description.obtained() &&
+            bounds.obtained() &&
+            waypoints.obtained() &&
+            elevation.obtained() &&
+            distance.obtained() &&
+            estimatedTime.obtained() &&
+            elevationGain.obtained() &&
+            difficulty.obtained())
+    return DetailedHike(
+        id,
+        getColor(),
+        isSaved,
+        plannedDate,
+        name,
+        description.getOrThrow(),
+        bounds.getOrThrow(),
+        waypoints.getOrThrow(),
+        elevation.getOrThrow(),
+        distance.getOrThrow(),
+        estimatedTime.getOrThrow(),
+        elevationGain.getOrThrow(),
+        difficulty.getOrThrow())
+  }
 }
+
+/**
+ * A [Hike] equivalent where all data are guaranteed to be available.
+ *
+ * See [Hike]'s documentation for more information about the fields.
+ *
+ * Used in [Hike.withDetailsOrThrow] to provide a [Hike] instance with all its details.
+ */
+data class DetailedHike(
+    val id: String,
+    val color: Int,
+    val isSaved: Boolean,
+    val plannedDate: Timestamp?,
+    val name: String?,
+    val description: String?,
+    val bounds: Bounds,
+    val waypoints: List<LatLong>,
+    val elevation: List<Double>,
+    val distance: Double,
+    val estimatedTime: Double,
+    val elevationGain: Double,
+    val difficulty: HikeDifficulty
+)

--- a/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/Hike.kt
@@ -54,4 +54,16 @@ data class Hike(
   fun getColor(): Int {
     return hikeColors[abs(id.hashCode()) % hikeColors.size]
   }
+
+  /**
+   * Indicates whether the hike has all of its OSM data loaded.
+   *
+   * This includes [description], [bounds], and [waypoints].
+   *
+   * @return True if all OSM data were obtained ([DeferredData.Obtained]) for the hike, false
+   *   otherwise.
+   */
+  fun hasOsmData(): Boolean {
+    return description.obtained() && bounds.obtained() && waypoints.obtained()
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -566,6 +566,8 @@ class HikesViewModel(
    * another function, please set [_loading] to true before calling the function and to false once
    * the call has ended.
    *
+   * @param forceOverwriteHikesList If true, [_savedHikesMap] will be overwritten to contain all and
+   *   only saved hikes. If false, [_savedHikesMap] will be updated according to [_loadedHikesType].
    * @return True if the operation is successful, false otherwise.
    */
   private suspend fun refreshSavedHikesCacheAsync(forceOverwriteHikesList: Boolean): Boolean =

--- a/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/route/HikesViewModel.kt
@@ -70,25 +70,57 @@ class HikesViewModel(
 
   private var _hikeFlowsMap = mutableMapOf<String, MutableStateFlow<Hike>>()
 
+  private val _osmDataRetrievalMutex = Mutex()
+
+  private val _allOsmDataLoaded = MutableStateFlow(true)
+
+  private val _loadingMutex = Mutex()
+
+  private var _ongoingLoadingOperations: Int = 0
+
   private val _loading = MutableStateFlow(false)
 
   private val _hikeFlowsList = MutableStateFlow<List<StateFlow<Hike>>>(emptyList())
 
   private val _selectedHike = MutableStateFlow<Hike?>(null)
 
-  /** Internal type used to store where the hikes in [_hikeFlowsMap] come from. */
-  private enum class LoadedHikes {
+  /**
+   * Enum used to designate where the hikes loaded in [hikeFlows] come from semantically.
+   *
+   * See the possible values for this enum along with [loadedHikesType] for more information.
+   */
+  enum class LoadedHikes {
     /** No hikes have been loaded yet. */
     None,
 
-    /** The hikes loaded in [_hikeFlowsMap] are the saved hikes. */
+    /** The hikes loaded in [hikeFlows] are the saved hikes of the user. */
     FromSaved,
 
-    /** The hikes loaded in [_hikeFlowsMap] were fetched from within a geographical rectangle. */
+    /** The hikes loaded in [hikeFlows] were fetched from within a geographical rectangle. */
     FromBounds
   }
 
-  private var _loadedHikesType: LoadedHikes = LoadedHikes.None
+  private val _loadedHikesType = MutableStateFlow(LoadedHikes.None)
+
+  /**
+   * Indicates what type of hikes are currently loaded inside of [hikeFlows].
+   * - [LoadedHikes.None] if no hikes have been loaded yet.
+   * - [LoadedHikes.FromSaved] if [hikeFlows] contains a list of the user's saved hikes.
+   * - [LoadedHikes.FromBounds] if [hikeFlows] contains hikes fetched from within a geographical
+   *   rectangle.
+   */
+  val loadedHikesType: StateFlow<LoadedHikes> = _loadedHikesType.asStateFlow()
+
+  /**
+   * Indicates whether all the hikes in [hikeFlows] have their OSM data loaded.
+   *
+   * Note that if [hikeFlows] is empty, this value will be true, because there are no hikes that
+   * need to be updated with their OSM data.
+   *
+   * This value is a state flow, so it can be observed for the UI to update directly when the value
+   * changes.
+   */
+  val allOsmDataLoaded: StateFlow<Boolean> = _allOsmDataLoaded.asStateFlow()
 
   /**
    * Whether a new list of hikes is currently being retrieved.
@@ -155,9 +187,8 @@ class HikesViewModel(
    * Downloads the current user's saved hikes from the database and caches them locally.
    *
    * This function updates the saved status of the loaded hikes in [hikeFlows]. If saved hikes are
-   * currently loaded (a call to [loadSavedHikes] has been made and no other loading call has been
-   * performed since), calling this function will update the whole loaded hikes list to match it
-   * with the new saved hikes.
+   * currently loaded (see [loadedHikesType]), calling this function will update the whole loaded
+   * hikes list to match it with the new saved hikes.
    *
    * @param onSuccess To be called when the saved hikes cache has been updated successfully.
    * @param onFailure Will be called if an error is encountered.
@@ -165,9 +196,9 @@ class HikesViewModel(
   fun refreshSavedHikesCache(onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
       viewModelScope.launch {
         // Let the user know a heavy load operation is being performed
-        _loading.value = true
+        setLoading(true)
 
-        val success = refreshSavedHikesCacheAsync()
+        val success = refreshSavedHikesCacheAsync(forceOverwriteHikesList = false)
         if (success) {
           onSuccess()
         } else {
@@ -175,7 +206,7 @@ class HikesViewModel(
         }
 
         // The heavy loading operation is done now
-        _loading.value = false
+        setLoading(false)
       }
 
   /**
@@ -191,9 +222,9 @@ class HikesViewModel(
    */
   fun loadSavedHikes(onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
       viewModelScope.launch {
-        _loading.value = true
+        setLoading(true)
         loadSavedHikesAsync(onSuccess, onFailure)
-        _loading.value = false
+        setLoading(false)
       }
 
   /**
@@ -264,12 +295,12 @@ class HikesViewModel(
   ) =
       viewModelScope.launch {
         // Let the user know a heavy load operation is being performed
-        _loading.value = true
+        setLoading(true)
 
         loadHikesInBoundsAsync(bounds, onSuccess, onFailure)
 
         // The heavy loading operation is done now
-        _loading.value = false
+        setLoading(false)
       }
 
   /**
@@ -296,15 +327,7 @@ class HikesViewModel(
    *   operation.
    */
   fun retrieveLoadedHikesOsmData(onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) =
-      viewModelScope.launch {
-        // Notify the UI that a heavy loading operation is in progress
-        _loading.value = true
-
-        retrieveLoadedHikesOsmDataAsync(onSuccess, onFailure)
-
-        // The heavy loading operation is done now
-        _loading.value = false
-      }
+      viewModelScope.launch { retrieveLoadedHikesOsmDataAsync(onSuccess, onFailure) }
 
   /**
    * Indicates whether [retrieveElevationDataFor] can be called for the provided hike.
@@ -384,6 +407,43 @@ class HikesViewModel(
   /**
    * Internal helper function.
    *
+   * The exposed [loading] state indicates whether a loading operation is ongoing. Simply setting it
+   * to true/false is not enough, because several loading operations might be ongoing.
+   *
+   * To avoid one operation setting [_loading] to false when another operation is still ongoing,
+   * this function uses [_ongoingLoadingOperations] to count how many operations are left. It also
+   * uses [_loadingMutex] to make its checks thread-safe.
+   *
+   * If [value] is true, [_ongoingLoadingOperations] is incremented. Reversely if [value] is false.
+   *
+   * If [_ongoingLoadingOperations] is 0 at the end of the operation, [_loading] is set to false. If
+   * it is positive, [_loading] is set to true.
+   *
+   * If [_ongoingLoadingOperations] becomes negative, it is clamped at 0. [setLoading] should always
+   * be used in pair, one call to set loading to true, and one to set it to false.
+   */
+  private suspend fun setLoading(value: Boolean) =
+      _loadingMutex.withLock {
+        if (value) {
+          // setLoading(true) is called to indicate the start of a new loading operation
+          _ongoingLoadingOperations += 1
+        } else if (_ongoingLoadingOperations > 0) {
+          // setLoading(false) indicates the end of a loading operation. Ensure the counter does not
+          // go below 0.
+          _ongoingLoadingOperations -= 1
+        }
+
+        // Adapt the _loading state flow accordingly
+        if (_ongoingLoadingOperations < 1 && _loading.value) {
+          _loading.value = false
+        } else if (_ongoingLoadingOperations > 0 && !_loading.value) {
+          _loading.value = true
+        }
+      }
+
+  /**
+   * Internal helper function.
+   *
    * The exposed [hikeFlows] list directly mirrors the private mutable state flow [_hikeFlowsList].
    * However, for the view model to work with the hikes in an easier way, it uses [_hikeFlowsMap]
    * internally, which maps hike IDs to their corresponding state flows.
@@ -391,9 +451,39 @@ class HikesViewModel(
    * [_hikeFlowsMap] is the one that actually gets updated during operations. Once it has been
    * updated, we need to update [_hikeFlowsList] to reflect the changes. This is what this helper
    * function does.
+   *
+   * Because [_hikeFlowsList] is updated, this function also updates [_allOsmDataLoaded] to reflect
+   * whether all hikes in [_hikeFlowsList] have their OSM data loaded.
    */
-  private fun updateHikeFlowsList() {
+  private fun updateHikeFlowsListAndOsmDataStatus() {
     _hikeFlowsList.value = _hikeFlowsMap.values.toList()
+    updateOsmDataAvailabilityStatus()
+  }
+
+  /**
+   * Internal helper function.
+   *
+   * The exposed [allOsmDataLoaded] indicates whether all loaded hikes in [hikeFlows] have their OSM
+   * data available. This needs to be updated when either the entire list is updated, or a single
+   * hike is updated.
+   *
+   * This helper function updates the value of [_allOsmDataLoaded] accordingly to [_hikeFlowsList].
+   */
+  private fun updateOsmDataAvailabilityStatus() {
+    _allOsmDataLoaded.value = _hikeFlowsList.value.all { it.value.hasOsmData() }
+  }
+
+  /**
+   * Internal helper function.
+   *
+   * Sets [_loadedHikesType] with the new provided value if not already equal to that value.
+   *
+   * Requires [_hikesMutex] to have been acquired by the caller.
+   */
+  private fun setLoadedHikesType(value: LoadedHikes) {
+    if (_loadedHikesType.value != value) {
+      _loadedHikesType.value = value
+    }
   }
 
   /**
@@ -478,7 +568,7 @@ class HikesViewModel(
    *
    * @return True if the operation is successful, false otherwise.
    */
-  private suspend fun refreshSavedHikesCacheAsync(): Boolean =
+  private suspend fun refreshSavedHikesCacheAsync(forceOverwriteHikesList: Boolean): Boolean =
       withContext(dispatcher) {
         val savedHikes: List<SavedHike>
         try {
@@ -490,7 +580,12 @@ class HikesViewModel(
         }
 
         // Wait for the lock to avoid concurrent modifications
-        _hikesMutex.withLock { updateSavedHikesCache(savedHikes) }
+        _hikesMutex.withLock {
+          updateSavedHikesCache(savedHikes, forceOverwriteHikesList)
+          if (forceOverwriteHikesList) {
+            setLoadedHikesType(LoadedHikes.FromSaved)
+          }
+        }
 
         return@withContext true
       }
@@ -507,7 +602,7 @@ class HikesViewModel(
    *
    * @param newList The list of saved hikes to update the cache with.
    */
-  private fun updateSavedHikesCache(newList: List<SavedHike>) {
+  private fun updateSavedHikesCache(newList: List<SavedHike>, forceOverwriteHikesList: Boolean) {
     // Clear the current saved hikes register
     _savedHikesMap.clear()
 
@@ -516,16 +611,9 @@ class HikesViewModel(
 
     // Now the saved hikes cache was updated, but we still need to update the hike flows list
 
-    when (_loadedHikesType) {
-      // No hikes were loaded yet, do nothing
-      LoadedHikes.None -> return
-      LoadedHikes.FromBounds -> {
-        // Hikes were loaded from bounds, do not remove nor add any hikes, just update existing ones
-        updateExistingHikesSavedStatus()
-      }
-      LoadedHikes.FromSaved -> {
-        // Saved hikes are loaded, remove the ones that were unsaved and add the new saved ones
-
+    when {
+      // Saved hikes are loaded or should be loaded. Remove the unsaved and add the new saved ones.
+      forceOverwriteHikesList || _loadedHikesType.value == LoadedHikes.FromSaved -> {
         // First, remove the hikes that were unsaved
         _hikeFlowsMap = _hikeFlowsMap.filterKeys { _savedHikesMap.containsKey(it) }.toMutableMap()
 
@@ -544,13 +632,21 @@ class HikesViewModel(
                       name = savedHike.name))
         }
       }
+
+      // No hikes were loaded yet, do nothing
+      _loadedHikesType.value == LoadedHikes.None -> return
+
+      // Hikes were loaded from bounds, do not remove nor add any hikes, just update existing ones
+      _loadedHikesType.value == LoadedHikes.FromBounds -> {
+        updateExistingHikesSavedStatus()
+      }
     }
 
     // Update the selected hike's saved status, unselect it if it's not loaded anymore
     updateSelectedHike()
 
     // Update the exposed list of hikes based on the map of hikes
-    updateHikeFlowsList()
+    updateHikeFlowsListAndOsmDataStatus()
   }
 
   /**
@@ -577,11 +673,8 @@ class HikesViewModel(
    */
   private suspend fun loadSavedHikesAsync(onSuccess: () -> Unit, onFailure: () -> Unit) =
       withContext(dispatcher) {
-        // Remember that the loaded hikes list will now only hold saved hikes
-        _loadedHikesType = LoadedHikes.FromSaved
-
         // Update the local cache of saved hikes and add them to _hikeFlows
-        val success = refreshSavedHikesCacheAsync()
+        val success = refreshSavedHikesCacheAsync(forceOverwriteHikesList = true)
 
         if (success) {
           onSuccess()
@@ -712,10 +805,10 @@ class HikesViewModel(
           // Update the saved hikes map
           _savedHikesMap.remove(hikeId)
 
-          if (_loadedHikesType == LoadedHikes.FromSaved) {
+          if (_loadedHikesType.value == LoadedHikes.FromSaved) {
             // Only saved hikes may stay in the list, delete the unsaved hike from the list
             _hikeFlowsMap.remove(hikeId)
-            updateHikeFlowsList()
+            updateHikeFlowsListAndOsmDataStatus()
           } else {
             // The hike can stay even if it is not saved, so update it
             hikeFlow.value = hikeFlow.value.copy(isSaved = false, plannedDate = null)
@@ -824,11 +917,6 @@ class HikesViewModel(
       onFailure: () -> Unit
   ) =
       withContext(dispatcher) {
-        // We are loading hikes from bounds, remember this to avoid overriding loaded hikes with
-        // saved
-        // hikes when those get reloaded.
-        _loadedHikesType = LoadedHikes.FromBounds
-
         // Load the hikes from the repository
         val hikes: List<HikeRoute>
         try {
@@ -892,7 +980,11 @@ class HikesViewModel(
           updateSelectedHike()
 
           // Update the exposed list of hikes based on the map of hikes
-          updateHikeFlowsList()
+          updateHikeFlowsListAndOsmDataStatus()
+
+          // We are loading hikes from bounds, remember this to avoid overriding loaded hikes with
+          // saved hikes when those get refreshed.
+          setLoadedHikesType(LoadedHikes.FromBounds)
         }
 
         // Call the success callback once the mutex has been released to avoid locking for too long
@@ -935,49 +1027,72 @@ class HikesViewModel(
       onFailure: () -> Unit
   ) =
       withContext(dispatcher) {
-        // Prepare a list of hikes for which we need to retrieve the data
-        val idsToRetrieve: List<String>
-        _hikesMutex.withLock {
-          idsToRetrieve = _hikeFlowsMap.values.filter { !hasOsmData(it.value) }.map { it.value.id }
-        }
-
-        // If all routes already have their OSM data, do nothing more
-        if (idsToRetrieve.isEmpty()) {
-          onSuccess()
-          return@withContext
-        }
-
-        // Retrieve the OSM data of the hikes
-        val hikeRoutes: List<HikeRoute>
-        try {
-          hikeRoutes = loadHikesByIdsRepoWrapper(idsToRetrieve)
-        } catch (e: Exception) {
-          Log.e(LOG_TAG, "Error encountered while loading hikes OSM data", e)
-          onFailure()
-          return@withContext
-        }
-
-        // Update the retrieved data for the loaded hikes
-        _hikesMutex.withLock {
-          hikeRoutes.forEach { hikeRoute ->
-            val hikeFlow = _hikeFlowsMap[hikeRoute.id] ?: return@forEach
-            val hike = hikeFlow.value
-
-            val newHike =
-                hike.copy(
-                    name = hikeRoute.name,
-                    description = DeferredData.Obtained(hikeRoute.description),
-                    bounds = DeferredData.Obtained(hikeRoute.bounds),
-                    waypoints = DeferredData.Obtained(hikeRoute.ways))
-            hikeFlow.value = newHike
+        // Allow only one retrieval request to be performed at any given time
+        val success: Boolean
+        _osmDataRetrievalMutex.withLock {
+          // Prepare a list of hikes for which we need to retrieve the data
+          val idsToRetrieve: List<String>
+          val requestNeeded: Boolean
+          _hikesMutex.withLock {
+            requestNeeded = !_allOsmDataLoaded.value
+            idsToRetrieve =
+                _hikeFlowsMap.values.filter { !hasOsmData(it.value) }.map { it.value.id }
           }
 
-          // Update the selected hike if necessary
-          updateSelectedHike()
+          // If all hikes already have their OSM data, do nothing more
+          if (!requestNeeded || idsToRetrieve.isEmpty()) {
+            success = true
+            return@withLock
+          }
+
+          // If the request is needed, indicate a heavy loading operation is being performed
+          setLoading(true)
+
+          // Retrieve the OSM data of the hikes
+          val hikeRoutes: List<HikeRoute>
+          try {
+            hikeRoutes = loadHikesByIdsRepoWrapper(idsToRetrieve)
+          } catch (e: Exception) {
+            Log.e(LOG_TAG, "Error encountered while loading hikes OSM data", e)
+            success = false
+            return@withLock
+          }
+
+          // Update the retrieved data for the loaded hikes
+          _hikesMutex.withLock {
+            hikeRoutes.forEach { hikeRoute ->
+              val hikeFlow = _hikeFlowsMap[hikeRoute.id] ?: return@forEach
+              val hike = hikeFlow.value
+
+              val newHike =
+                  hike.copy(
+                      name = hikeRoute.name,
+                      description = DeferredData.Obtained(hikeRoute.description),
+                      bounds = DeferredData.Obtained(hikeRoute.bounds),
+                      waypoints = DeferredData.Obtained(hikeRoute.ways))
+              hikeFlow.value = newHike
+            }
+
+            // Update whether all hikes have their OSM data loaded
+            updateOsmDataAvailabilityStatus()
+
+            // Update the selected hike if necessary
+            updateSelectedHike()
+          }
+
+          // Release the mutex before calling onSuccess to avoid deadlocks or performance issues
+          success = true
         }
 
-        // Release the mutex before calling onSuccess to avoid deadlocks or performance issues
-        onSuccess()
+        // Indicate the heavy loading operation has terminated
+        setLoading(false)
+
+        // Call the appropriate callback
+        if (success) {
+          onSuccess()
+        } else {
+          onFailure()
+        }
       }
 
   /**

--- a/app/src/test/java/ch/hikemate/app/model/route/DeferredDataTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/DeferredDataTest.kt
@@ -1,0 +1,33 @@
+package ch.hikemate.app.model.route
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class DeferredDataTest {
+  private val data: String = "Hello world"
+
+  private val notRequestedData: DeferredData<String> = DeferredData.NotRequested
+  private val requestedData: DeferredData<String> = DeferredData.Requested
+  private val obtainedData: DeferredData<String> = DeferredData.Obtained(data = data)
+
+  @Test
+  fun obtainedWorksAsExpected() {
+    assertFalse(notRequestedData.obtained())
+    assertFalse(requestedData.obtained())
+    assertTrue(obtainedData.obtained())
+  }
+
+  @Test
+  fun getOrNullWorksAsExpected() {
+    assertNull(notRequestedData.getOrNull())
+    assertNull(requestedData.getOrNull())
+    assertNotNull(obtainedData.getOrNull())
+  }
+
+  @Test
+  fun getOrThrowWorksAsExpected() {
+    assertThrows(IllegalStateException::class.java) { notRequestedData.getOrThrow() }
+    assertThrows(IllegalStateException::class.java) { requestedData.getOrThrow() }
+    assertEquals(data, obtainedData.getOrThrow())
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeTest.kt
@@ -94,6 +94,35 @@ class HikeTest {
   }
 
   @Test
+  fun isFullyLoadedWorksAsExpected() {
+    val description = "Hike description"
+    val bounds = Bounds(0.0, 0.0, 0.0, 0.0)
+    val waypoints = emptyList<LatLong>()
+    val elevation = emptyList<Double>()
+    val distance = 1.0
+    val estimatedTime = 2.0
+    val elevationGain = 3.0
+    val difficulty = HikeDifficulty.MODERATE
+
+    val incomplete1 = createHike()
+    val incomplete2 = createHike(waypoints = waypoints, distance = distance)
+    val complete =
+        createHike(
+            description = description,
+            bounds = bounds,
+            waypoints = waypoints,
+            elevation = elevation,
+            distance = distance,
+            estimatedTime = estimatedTime,
+            elevationGain = elevationGain,
+            difficulty = difficulty)
+
+    assertFalse(incomplete1.isFullyLoaded())
+    assertFalse(incomplete2.isFullyLoaded())
+    assertTrue(complete.isFullyLoaded())
+  }
+
+  @Test
   fun withDetailsOrThrowWorksAsExpected() {
     val description = "Description"
     val bounds = Bounds(0.0, 0.0, 0.0, 0.0)

--- a/app/src/test/java/ch/hikemate/app/model/route/HikeTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikeTest.kt
@@ -1,0 +1,139 @@
+package ch.hikemate.app.model.route
+
+import com.google.firebase.Timestamp
+import org.junit.Assert.*
+import org.junit.Test
+
+class HikeTest {
+
+  private val hikes =
+      listOf(
+          createHike(id = "1", isSaved = false),
+          createHike(id = "2", isSaved = true),
+          createHike(id = "3", isSaved = false),
+          createHike(id = "4", isSaved = true),
+          createHike(id = "5", isSaved = false))
+
+  private fun createHike(
+      id: String = "default",
+      isSaved: Boolean = false,
+      plannedDate: Timestamp? = null,
+      name: String? = null,
+      description: String? = null,
+      bounds: Bounds? = null,
+      waypoints: List<LatLong>? = null,
+      elevation: List<Double>? = null,
+      distance: Double? = null,
+      estimatedTime: Double? = null,
+      elevationGain: Double? = null,
+      difficulty: HikeDifficulty? = null
+  ): Hike {
+    return Hike(
+        id = id,
+        isSaved = isSaved,
+        plannedDate = plannedDate,
+        name = name,
+        description =
+            if (description == null) DeferredData.NotRequested
+            else DeferredData.Obtained(description),
+        bounds = if (bounds == null) DeferredData.NotRequested else DeferredData.Obtained(bounds),
+        waypoints =
+            if (waypoints == null) DeferredData.NotRequested else DeferredData.Obtained(waypoints),
+        elevation =
+            if (elevation == null) DeferredData.NotRequested else DeferredData.Obtained(elevation),
+        distance =
+            if (distance == null) DeferredData.NotRequested else DeferredData.Obtained(distance),
+        estimatedTime =
+            if (estimatedTime == null) DeferredData.NotRequested
+            else DeferredData.Obtained(estimatedTime),
+        elevationGain =
+            if (elevationGain == null) DeferredData.NotRequested
+            else DeferredData.Obtained(elevationGain),
+        difficulty =
+            if (difficulty == null) DeferredData.NotRequested
+            else DeferredData.Obtained(difficulty))
+  }
+
+  @Test
+  fun toSavedHikeWorksAsExpected() {
+    for (hike in hikes) {
+      val saved = hike.toSavedHike()
+      assertEquals(hike.id, saved.id)
+      assertEquals(hike.name ?: "", saved.name)
+      assertEquals(hike.plannedDate, saved.date)
+    }
+  }
+
+  @Test
+  fun getColorIsDeterministic() {
+    for (hike in hikes) {
+      // Compute the hike's color once
+      val color = hike.getColor()
+      for (i in 0..100) {
+        // All consecutive computations of the color should yield the same result
+        assertEquals(color, hike.getColor())
+      }
+    }
+  }
+
+  @Test
+  fun hasOsmDataWorksAsExcepted() {
+    val description = "Hike description"
+    val bounds = Bounds(0.0, 0.0, 0.0, 0.0)
+    val waypoints = emptyList<LatLong>()
+
+    val noDescription = createHike(bounds = bounds, waypoints = waypoints)
+    val noBounds = createHike(description = description, waypoints = waypoints)
+    val noWaypoints = createHike(description = description, bounds = bounds)
+    val complete = createHike(description = description, bounds = bounds, waypoints = waypoints)
+
+    assertFalse(noDescription.hasOsmData())
+    assertFalse(noBounds.hasOsmData())
+    assertFalse(noWaypoints.hasOsmData())
+    assertTrue(complete.hasOsmData())
+  }
+
+  @Test
+  fun withDetailsOrThrowWorksAsExpected() {
+    val description = "Description"
+    val bounds = Bounds(0.0, 0.0, 0.0, 0.0)
+    val waypoints = emptyList<LatLong>()
+    val elevation = emptyList<Double>()
+    val distance = 1.0
+    val estimatedTime = 2.0
+    val elevationGain = 3.0
+    val difficulty = HikeDifficulty.MODERATE
+
+    val deltaForDoubleComparison = 0.0
+
+    val incomplete1 = createHike()
+    val incomplete2 = createHike(waypoints = waypoints, distance = distance)
+    val complete =
+        createHike(
+            description = description,
+            bounds = bounds,
+            waypoints = waypoints,
+            elevation = elevation,
+            distance = distance,
+            estimatedTime = estimatedTime,
+            elevationGain = elevationGain,
+            difficulty = difficulty)
+
+    assertThrows(IllegalStateException::class.java) { incomplete1.withDetailsOrThrow() }
+    assertThrows(IllegalStateException::class.java) { incomplete2.withDetailsOrThrow() }
+    val detailed = complete.withDetailsOrThrow()
+    assertEquals(complete.id, detailed.id)
+    assertEquals(complete.getColor(), detailed.color)
+    assertEquals(complete.isSaved, detailed.isSaved)
+    assertEquals(complete.plannedDate, detailed.plannedDate)
+    assertEquals(complete.name, detailed.name)
+    assertEquals(description, detailed.description)
+    assertEquals(bounds, detailed.bounds)
+    assertEquals(waypoints, detailed.waypoints)
+    assertEquals(elevation, detailed.elevation)
+    assertEquals(distance, detailed.distance, deltaForDoubleComparison)
+    assertEquals(estimatedTime, detailed.estimatedTime, deltaForDoubleComparison)
+    assertEquals(elevationGain, detailed.elevationGain, deltaForDoubleComparison)
+    assertEquals(difficulty, detailed.difficulty)
+  }
+}

--- a/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/model/route/HikesViewModelTest.kt
@@ -503,6 +503,10 @@ class HikesViewModelTest {
         assertTrue(onSuccessCalled)
         // Check that the view model now contains the loaded hikes list
         assertEquals(singleSavedHike1.size, hikesViewModel.hikeFlows.value.size)
+        // Check that the status of the OSM data availability is updated correctly
+        assertFalse(hikesViewModel.allOsmDataLoaded.value)
+        // Check that the type of loaded hikes is updated accordingly
+        assertEquals(HikesViewModel.LoadedHikes.FromSaved, hikesViewModel.loadedHikesType.value)
       }
 
   @Test
@@ -1075,6 +1079,10 @@ class HikesViewModelTest {
         assertEquals(doubleOsmHikes1.size, hikesViewModel.hikeFlows.value.size)
         assertEquals(doubleOsmHikes1[0].id, hikesViewModel.hikeFlows.value[0].value.id)
         assertEquals(doubleOsmHikes1[1].id, hikesViewModel.hikeFlows.value[1].value.id)
+        // Check that the status of the OSM data availability is updated correctly
+        assertTrue(hikesViewModel.allOsmDataLoaded.value)
+        // Check that the type of loaded hikes is updated accordingly
+        assertEquals(HikesViewModel.LoadedHikes.FromBounds, hikesViewModel.loadedHikesType.value)
       }
 
   /**
@@ -1316,6 +1324,8 @@ class HikesViewModelTest {
         assertEquals(
             singleOsmHike1[0].ways,
             (hikesViewModel.hikeFlows.value[0].value.waypoints as DeferredData.Obtained).data)
+        // Make sure the OSM data is marked as available accordingly
+        assertTrue(hikesViewModel.allOsmDataLoaded.value)
       }
 
   @Test


### PR DESCRIPTION
# Summary

I'm currently working on using `HikesViewModel` everywhere in the app instead of `ListOfHikeRoutesViewModel` and `SavedHikesViewModel`, however I realize now that I need some more information made available by `HikesViewModel` to make the app work correctly with it.

To this end, I'm doing this intermediate PR to introduce the needed helper functions and new state flows.

# Details

Three parts of the code have been modified :

- `DeferredData.kt`: added helper functions
- `Hike.kt`: added helper functions
- `HikesViewModel.kt`: improved implementation and new public members

Tests have been added for `DeferredData` and `Hike`, and the existing ones for `HikesViewModel` were updated to reflect the changes.

## `DeferredData.kt`

- Added `DeferredData.obtained()` as a helper to determine whether an instance represents obtained data (it's shorter than doing `myVariable is DeferredData.Obtained` each time.
- Added `DeferredData.getOrNull()` to access the data or `null` if there is no data
- Added `DeferredData.getOrThrow()` to access the data or throw an exception if not available. This is to use when an `obtained()` check was done before.

## `Hike.kt`

- Copied `HikeRoute.getColor()` to `Hike.getColor()` for easier use
- Added `Hike.hasOsmData()` as a helper to check if a hike has a description, bounds and waypoints
- Added `Hike.withDetailsOrThrow()`, which asserts that all properties have been computed, and otherwise throws an exception. If everything was computed, returns an instance of `DetailedHike`, which is basically the same thing as the hike but without the `DeferredData` wrapper.

## `HikesViewModel.kt`

- Improved how `loading` is handled. Now, `loading` will be set to false only when there's no loading operation going on in the view model. This wasn't exactly the case before because of concurrency reasons.
- Added `allOsmDataLoaded`, a state flow that indicates whether all loaded hikes have their OSM data available. This is helpful to implement the Saved Hikes screen.
- Added `loadedHikesType`, a state flow that indicates whether saved hikes are loaded (saved hikes screen) or rather the current hikes are loaded from OSM (map screen)