### PR TITLE
feat: add details to run hike screen

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
@@ -22,13 +22,12 @@ import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.model.route.saved.SavedHikesViewModel
 import ch.hikemate.app.ui.components.BackButton.BACK_BUTTON_TEST_TAG
+import ch.hikemate.app.ui.components.DetailRow
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ADD_DATE_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_HIKE_NAME
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_MAP
@@ -208,8 +207,8 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(5)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
   }
 
   @Test
@@ -234,8 +233,8 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
     composeTestRule.onNodeWithTag(TEST_TAG_ADD_DATE_BUTTON).assertIsDisplayed()
   }
 
@@ -265,8 +264,8 @@ class HikeDetailScreenTest {
           {})
     }
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(6)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(5)
     composeTestRule.onNodeWithTag(TEST_TAG_PLANNED_DATE_TEXT_BOX).assertIsDisplayed()
   }
 
@@ -398,16 +397,16 @@ class HikeDetailScreenTest {
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime % 60).roundToInt())
 
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${distanceString}km"))
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${elevationGainString}m"))
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${hourString}h${minuteString}"))
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(
             hasText(
                 ApplicationProvider.getApplicationContext<Context>()
@@ -431,7 +430,7 @@ class HikeDetailScreenTest {
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime % 60).roundToInt())
 
     composeTestRule
-        .onAllNodesWithTag(TEST_TAG_DETAIL_ROW_VALUE)
+        .onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE)
         .assertAny(hasText("${minuteString}min"))
   }
 

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -149,6 +149,7 @@ class RunHikeScreenTest {
     composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_SHEET).assertExists()
   }
 
+  /** Test all details which do not change during the hike run. */
   @Test
   fun runHikeScreen_displaysStaticDetails() = runTest {
     composeTestRule.setContent {

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -1,7 +1,11 @@
 package ch.hikemate.app.ui.map
 
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import ch.hikemate.app.model.elevation.ElevationService
 import ch.hikemate.app.model.profile.HikingLevel
@@ -9,13 +13,19 @@ import ch.hikemate.app.model.profile.Profile
 import ch.hikemate.app.model.profile.ProfileRepository
 import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.model.route.Bounds
+import ch.hikemate.app.model.route.DetailedHikeRoute
+import ch.hikemate.app.model.route.HikeDifficulty
 import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.LatLong
 import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
+import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BACK_BUTTON
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BOTTOM_SHEET
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ELEVATION_GRAPH
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_HIKE_NAME
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_MAP
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ZOOM_BUTTONS
 import ch.hikemate.app.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
@@ -48,6 +58,14 @@ class RunHikeScreenTest {
           name = "Sample Hike",
           description =
               "A scenic trail with breathtaking views of the Matterhorn and surrounding glaciers.")
+
+  private val detailedRoute =
+      DetailedHikeRoute(
+          route = route,
+          totalDistance = 13.543077559212616,
+          elevationGain = 68.0,
+          estimatedTime = 169.3169307105514,
+          difficulty = HikeDifficulty.DIFFICULT)
 
   private val profile =
       Profile(
@@ -115,7 +133,7 @@ class RunHikeScreenTest {
   }
 
   @Test
-  fun runHikeScreen_displaysBottomSheet() {
+  fun runHikeScreen_displaysBottomSheet() = runTest {
     composeTestRule.setContent {
       RunHikeScreen(
           listOfHikeRoutesViewModel = listOfHikeRoutesViewModel,
@@ -125,4 +143,40 @@ class RunHikeScreenTest {
     }
     composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_SHEET).assertExists()
   }
+
+  @Test
+  fun runHikeScreen_displaysStaticDetails() = runTest {
+    composeTestRule.setContent {
+      RunHikeScreen(
+          listOfHikeRoutesViewModel = listOfHikeRoutesViewModel,
+          profileViewModel = profileViewModel,
+          navigationActions = mockNavigationActions,
+      )
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_HIKE_NAME).assertIsDisplayed()
+
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
+    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
+
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_TOTAL_DISTANCE_TEXT)
+        .assertIsDisplayed()
+        .assert(hasText("13.54km"))
+  }
+
+  @Test
+  fun runHikeScreen_displaysElevationGraph() = runTest {
+    composeTestRule.setContent {
+      RunHikeScreen(
+          listOfHikeRoutesViewModel = listOfHikeRoutesViewModel,
+          profileViewModel = profileViewModel,
+          navigationActions = mockNavigationActions,
+      )
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
+  }
+
+  @Test fun runHikeScreen_displaysStopHikeButton() = runTest {}
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -18,16 +18,6 @@ import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.LatLong
 import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BACK_BUTTON
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BOTTOM_SHEET
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ELEVATION_GRAPH
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_HIKE_NAME
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_MAP
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_PROGRESS_TEXT
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ZOOM_BUTTONS
 import ch.hikemate.app.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -100,7 +90,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_MAP).assertIsDisplayed()
   }
 
   @Test
@@ -112,7 +102,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_BACK_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_BACK_BUTTON).assertIsDisplayed()
   }
 
   @Test
@@ -124,7 +114,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_ZOOM_BUTTONS).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_ZOOM_BUTTONS).assertIsDisplayed()
   }
 
   @Test
@@ -136,7 +126,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_SHEET).assertExists()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_BOTTOM_SHEET).assertExists()
   }
 
   /** Test all details which do not change during the hike run. */
@@ -150,13 +140,15 @@ class RunHikeScreenTest {
       )
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_HIKE_NAME).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_HIKE_NAME).assertIsDisplayed()
 
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
-    composeTestRule.onAllNodesWithTag(TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
+    composeTestRule.onAllNodesWithTag(HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
+    composeTestRule
+        .onAllNodesWithTag(HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE)
+        .assertCountEquals(4)
 
     composeTestRule
-        .onNodeWithTag(TEST_TAG_TOTAL_DISTANCE_TEXT)
+        .onNodeWithTag(RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT)
         .assertIsDisplayed()
         .assert(hasText("13.54km"))
   }
@@ -171,7 +163,7 @@ class RunHikeScreenTest {
       )
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
   }
 
   @Test
@@ -184,7 +176,7 @@ class RunHikeScreenTest {
       )
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_STOP_HIKE_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON).assertIsDisplayed()
   }
 
   @Test
@@ -198,7 +190,10 @@ class RunHikeScreenTest {
     }
     doNothing().`when`(mockNavigationActions).goBack()
 
-    composeTestRule.onNodeWithTag(TEST_TAG_STOP_HIKE_BUTTON).assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag(RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON)
+        .assertIsDisplayed()
+        .performClick()
 
     composeTestRule.waitForIdle()
 
@@ -220,7 +215,7 @@ class RunHikeScreenTest {
     }
 
     composeTestRule
-        .onNodeWithTag(TEST_TAG_PROGRESS_TEXT)
+        .onNodeWithTag(RunHikeScreen.TEST_TAG_PROGRESS_TEXT)
         .assertIsDisplayed()
         .assert(hasText("23% complete"))
   }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -171,7 +171,7 @@ class RunHikeScreenTest {
       )
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertExists()
   }
 
   @Test
@@ -222,6 +222,6 @@ class RunHikeScreenTest {
     composeTestRule
         .onNodeWithTag(TEST_TAG_PROGRESS_TEXT)
         .assertIsDisplayed()
-        .assert(hasText("23% completed"))
+        .assert(hasText("23% complete"))
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -18,6 +18,7 @@ import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.LatLong
 import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
+import ch.hikemate.app.ui.components.DetailRow
 import ch.hikemate.app.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -142,10 +143,8 @@ class RunHikeScreenTest {
 
     composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_HIKE_NAME).assertIsDisplayed()
 
-    composeTestRule.onAllNodesWithTag(HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
-    composeTestRule
-        .onAllNodesWithTag(HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE)
-        .assertCountEquals(4)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG).assertCountEquals(4)
+    composeTestRule.onAllNodesWithTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE).assertCountEquals(4)
 
     composeTestRule
         .onNodeWithTag(RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT)

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -13,10 +13,10 @@ import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.LatLong
 import ch.hikemate.app.model.route.ListOfHikeRoutesViewModel
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_RUN_HIKE_SCREEN_BACK_BUTTON
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_RUN_HIKE_SCREEN_BOTTOM_SHEET
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_RUN_HIKE_SCREEN_MAP
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_RUN_HIKE_SCREEN_ZOOM_BUTTONS
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BACK_BUTTON
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BOTTOM_SHEET
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_MAP
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ZOOM_BUTTONS
 import ch.hikemate.app.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -87,7 +87,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_RUN_HIKE_SCREEN_MAP).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_MAP).assertIsDisplayed()
   }
 
   @Test
@@ -99,7 +99,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_RUN_HIKE_SCREEN_BACK_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_BACK_BUTTON).assertIsDisplayed()
   }
 
   @Test
@@ -111,7 +111,7 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_RUN_HIKE_SCREEN_ZOOM_BUTTONS).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TEST_TAG_ZOOM_BUTTONS).assertIsDisplayed()
   }
 
   @Test
@@ -123,6 +123,6 @@ class RunHikeScreenTest {
           navigationActions = mockNavigationActions,
       )
     }
-    composeTestRule.onNodeWithTag(TEST_TAG_RUN_HIKE_SCREEN_BOTTOM_SHEET).assertExists()
+    composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_SHEET).assertExists()
   }
 }

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -171,7 +171,7 @@ class RunHikeScreenTest {
       )
     }
 
-    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertExists()
+    composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -14,8 +14,6 @@ import ch.hikemate.app.model.profile.Profile
 import ch.hikemate.app.model.profile.ProfileRepository
 import ch.hikemate.app.model.profile.ProfileViewModel
 import ch.hikemate.app.model.route.Bounds
-import ch.hikemate.app.model.route.DetailedHikeRoute
-import ch.hikemate.app.model.route.HikeDifficulty
 import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.LatLong
@@ -63,14 +61,6 @@ class RunHikeScreenTest {
           name = "Sample Hike",
           description =
               "A scenic trail with breathtaking views of the Matterhorn and surrounding glaciers.")
-
-  private val detailedRoute =
-      DetailedHikeRoute(
-          route = route,
-          totalDistance = 13.543077559212616,
-          elevationGain = 68.0,
-          estimatedTime = 169.3169307105514,
-          difficulty = HikeDifficulty.DIFFICULT)
 
   private val profile =
       Profile(

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import ch.hikemate.app.model.elevation.ElevationService
 import ch.hikemate.app.model.profile.HikingLevel
 import ch.hikemate.app.model.profile.Profile
@@ -25,6 +26,8 @@ import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BOTTOM_SHEET
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ELEVATION_GRAPH
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_HIKE_NAME
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_MAP
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_PROGRESS_TEXT
+import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT
 import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ZOOM_BUTTONS
 import ch.hikemate.app.ui.navigation.NavigationActions
@@ -35,10 +38,12 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 
 class RunHikeScreenTest {
 
@@ -178,5 +183,54 @@ class RunHikeScreenTest {
     composeTestRule.onNodeWithTag(TEST_TAG_ELEVATION_GRAPH).assertIsDisplayed()
   }
 
-  @Test fun runHikeScreen_displaysStopHikeButton() = runTest {}
+  @Test
+  fun runHikeScreen_displaysStopHikeButton() = runTest {
+    composeTestRule.setContent {
+      RunHikeScreen(
+          listOfHikeRoutesViewModel = listOfHikeRoutesViewModel,
+          profileViewModel = profileViewModel,
+          navigationActions = mockNavigationActions,
+      )
+    }
+
+    composeTestRule.onNodeWithTag(TEST_TAG_STOP_HIKE_BUTTON).assertIsDisplayed()
+  }
+
+  @Test
+  fun runHikeScreen_stopHikeButton_navigatesBack() = runTest {
+    composeTestRule.setContent {
+      RunHikeScreen(
+          listOfHikeRoutesViewModel = listOfHikeRoutesViewModel,
+          profileViewModel = profileViewModel,
+          navigationActions = mockNavigationActions,
+      )
+    }
+    doNothing().`when`(mockNavigationActions).goBack()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_STOP_HIKE_BUTTON).assertIsDisplayed().performClick()
+
+    composeTestRule.waitForIdle()
+
+    verify(mockNavigationActions).goBack()
+  }
+
+  /**
+   * TODO This test just tests the static hard-coded value for now, but should be updated as soon as
+   * the screen is implemented to display the actual progress indicator.
+   */
+  @Test
+  fun runHikeScreen_displaysProgressIndicator() = runTest {
+    composeTestRule.setContent {
+      RunHikeScreen(
+          listOfHikeRoutesViewModel = listOfHikeRoutesViewModel,
+          profileViewModel = profileViewModel,
+          navigationActions = mockNavigationActions,
+      )
+    }
+
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_PROGRESS_TEXT)
+        .assertIsDisplayed()
+        .assert(hasText("23% completed"))
+  }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/components/BigButton.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/BigButton.kt
@@ -41,13 +41,14 @@ fun BigButton(
     buttonType: ButtonType,
     label: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    fillColor: Color = buttonType.backgroundColor,
 ) {
   Button(
       onClick = onClick,
       colors =
           ButtonDefaults.buttonColors(
-              contentColor = buttonType.textColor, containerColor = buttonType.backgroundColor),
+              contentColor = buttonType.textColor, containerColor = fillColor),
       shape = RoundedCornerShape(20),
       modifier =
           modifier

--- a/app/src/main/java/ch/hikemate/app/ui/components/DetailRow.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/DetailRow.kt
@@ -1,0 +1,48 @@
+package ch.hikemate.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+object DetailRow {
+  const val TEST_TAG_DETAIL_ROW_TAG = "DetailRowTag"
+  const val TEST_TAG_DETAIL_ROW_VALUE = "DetailRowValue"
+}
+
+/**
+ * A composable that displays a row with a label and value. The row spans the full width with the
+ * label aligned to the left and value to the right.
+ *
+ * @param label The text to display as the label on the left side
+ * @param value The text to display as the value on the right side
+ * @param valueColor The color of the value text. Defaults to the current theme's onSurface color
+ */
+@Composable
+fun DetailRow(
+    label: String,
+    value: String,
+    valueColor: Color = MaterialTheme.colorScheme.onSurface
+) {
+  Row(
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.testTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+            color = valueColor,
+            modifier = Modifier.testTag(DetailRow.TEST_TAG_DETAIL_ROW_VALUE))
+      }
+}

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -200,6 +200,10 @@ fun HikeDetailScreen(
     profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
   }
 
+  var wantToRunHike = false
+
+  LaunchedEffect(wantToRunHike) { navigationActions.navigateTo(Screen.RUN_HIKE) }
+
   val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
 
@@ -236,7 +240,7 @@ fun HikeDetailScreen(
           savedHikesViewModel = savedHikesViewModel,
           elevationData = elevationData,
           userHikingLevel = profile.hikingLevel,
-          onRunThisHike = { navigationActions.navigateTo(Screen.RUN_HIKE) },
+          onRunThisHike = { wantToRunHike = true },
       )
     }
   }

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailScreen.kt
@@ -34,8 +34,10 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -61,6 +63,7 @@ import ch.hikemate.app.ui.components.AsyncStateHandler
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.DetailRow
 import ch.hikemate.app.ui.components.ElevationGraph
 import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
 import ch.hikemate.app.ui.map.HikeDetailScreen.MAP_MAX_ZOOM
@@ -69,8 +72,6 @@ import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_BOOKMARK_ICON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CANCEL_BUTTON
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DATE_PICKER_CONFIRM_BUTTON
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_TAG
-import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_DETAIL_ROW_VALUE
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_ELEVATION_GRAPH
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_HIKE_NAME
 import ch.hikemate.app.ui.map.HikeDetailScreen.TEST_TAG_MAP
@@ -100,8 +101,6 @@ object HikeDetailScreen {
   const val TEST_TAG_HIKE_NAME = "HikeDetailScreenHikeName"
   const val TEST_TAG_BOOKMARK_ICON = "HikeDetailScreenBookmarkIcon"
   const val TEST_TAG_ELEVATION_GRAPH = "HikeDetailScreenElevationGraph"
-  const val TEST_TAG_DETAIL_ROW_TAG = "HikeDetailScreenDetailRowTag"
-  const val TEST_TAG_DETAIL_ROW_VALUE = "HikeDetailScreenDetailRowValue"
   const val TEST_TAG_ADD_DATE_BUTTON = "HikeDetailScreenAddDateButton"
   const val TEST_TAG_PLANNED_DATE_TEXT_BOX = "HikeDetailScreenPlannedDateTextBox"
   const val TEST_TAG_DATE_PICKER = "HikeDetailDatePicker"
@@ -200,9 +199,8 @@ fun HikeDetailScreen(
     profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
   }
 
-  var wantToRunHike = false
-
-  LaunchedEffect(wantToRunHike) { navigationActions.navigateTo(Screen.RUN_HIKE) }
+  var wantToRunHike by remember { mutableStateOf(false) }
+  LaunchedEffect(wantToRunHike) { if (wantToRunHike) navigationActions.navigateTo(Screen.RUN_HIKE) }
 
   val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
@@ -432,7 +430,7 @@ fun DateDetailRow(
         Text(
             text = stringResource(R.string.hike_detail_screen_label_planned_for),
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG))
 
         Button(
             modifier = Modifier.width(90.dp).height(25.dp).testTag(TEST_TAG_ADD_DATE_BUTTON),
@@ -462,7 +460,7 @@ fun DateDetailRow(
         Text(
             text = stringResource(R.string.hike_detail_screen_label_planned_for),
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
+            modifier = Modifier.testTag(DetailRow.TEST_TAG_DETAIL_ROW_TAG))
         Box(
             modifier =
                 Modifier.border(
@@ -485,27 +483,6 @@ fun DateDetailRow(
         value = stringResource(R.string.hike_detail_screen_value_not_saved),
         valueColor = MaterialTheme.colorScheme.onSurface)
   }
-}
-
-@Composable
-fun DetailRow(
-    label: String,
-    value: String,
-    valueColor: Color = MaterialTheme.colorScheme.onSurface
-) {
-  Row(
-      horizontalArrangement = Arrangement.SpaceBetween,
-      modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_TAG))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
-            color = valueColor,
-            modifier = Modifier.testTag(TEST_TAG_DETAIL_ROW_VALUE))
-      }
 }
 
 @Composable

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -199,7 +199,7 @@ fun RunHikeBottomSheet(
       scaffoldState = scaffoldState,
       sheetContainerColor = MaterialTheme.colorScheme.surface,
       sheetPeekHeight = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT,
-      modifier = Modifier.testTag(TEST_TAG_BOTTOM_SHEET),
+      modifier = Modifier.testTag(RunHikeScreen.TEST_TAG_BOTTOM_SHEET),
       sheetContent = {
         Column(
             modifier = Modifier.padding(16.dp).weight(1f),

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -175,7 +175,7 @@ fun RunHikeScreen(
           modifier =
               Modifier.align(Alignment.BottomEnd)
                   .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp)
-                  .testTag(TEST_TAG_ZOOM_BUTTONS))
+                  .testTag(RunHikeScreen.TEST_TAG_ZOOM_BUTTONS))
 
       RunHikeBottomSheet(
           hikeRoute = DetailedHikeRoute.create(route, ElevationServiceRepository(OkHttpClient())),

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -41,12 +41,12 @@ import ch.hikemate.app.ui.components.AsyncStateHandler
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.DetailRow
 import ch.hikemate.app.ui.components.ElevationGraph
 import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.utils.MapUtils
-import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -229,8 +229,7 @@ fun RunHikeBottomSheet(
                       // Displays the progress percentage below the graph
                       // TODO hardcoded as 23% for now
                       text =
-                          stringResource(R.string.run_hike_screen_progress_percentage_format)
-                              .format(23),
+                          stringResource(R.string.run_hike_screen_progress_percentage_format, 23),
                       style = MaterialTheme.typography.bodyLarge,
                       color = hikeColor,
                       fontWeight = FontWeight.Bold,
@@ -239,8 +238,9 @@ fun RunHikeBottomSheet(
                   )
                   Text(
                       text =
-                          stringResource(R.string.run_hike_screen_distance_progress_value_format)
-                              .format(hikeRoute.totalDistance),
+                          stringResource(
+                              R.string.run_hike_screen_distance_progress_value_format,
+                              hikeRoute.totalDistance),
                       style = MaterialTheme.typography.bodyLarge,
                       fontWeight = FontWeight.Bold,
                       textAlign = TextAlign.Right,
@@ -248,36 +248,30 @@ fun RunHikeBottomSheet(
                   )
                 }
 
-            val hourString =
-                String.format(Locale.getDefault(), "%02d", (hikeRoute.estimatedTime / 60).toInt())
-            val minuteString =
-                String.format(
-                    Locale.getDefault(), "%02d", (hikeRoute.estimatedTime % 60).roundToInt())
+            val hours = (hikeRoute.estimatedTime / 60).toInt()
+            val minutes = (hikeRoute.estimatedTime % 60).roundToInt()
 
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_current_elevation),
                 // TODO hardcoded to 50m for now
-                value =
-                    stringResource(R.string.run_hike_screen_value_format_current_elevation)
-                        .format(50))
+                value = stringResource(R.string.run_hike_screen_value_format_current_elevation, 50))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_elevation_gain),
                 value =
-                    stringResource(R.string.run_hike_screen_value_format_elevation_gain)
-                        .format(hikeRoute.elevationGain.roundToInt()))
+                    stringResource(
+                        R.string.run_hike_screen_value_format_elevation_gain,
+                        hikeRoute.elevationGain.roundToInt()))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_estimated_time),
                 value =
                     if (hikeRoute.estimatedTime / 60 < 1)
-                        stringResource(R.string.run_hike_screen_value_format_estimated_time_minutes)
-                            .format((hikeRoute.estimatedTime % 60).roundToInt())
+                        stringResource(
+                            R.string.run_hike_screen_value_format_estimated_time_minutes, minutes)
                     else
                         stringResource(
-                                R.string
-                                    .run_hike_screen_value_format_estimated_time_hours_and_minutes)
-                            .format(
-                                (hikeRoute.estimatedTime / 60).toInt(),
-                                (hikeRoute.estimatedTime % 60).roundToInt()))
+                            R.string.run_hike_screen_value_format_estimated_time_hours_and_minutes,
+                            hours,
+                            minutes))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_difficulty),
                 value = stringResource(hikeRoute.difficulty.nameResourceId),

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -285,7 +285,7 @@ fun RunHikeBottomSheet(
                 buttonType = ButtonType.PRIMARY,
                 label = stringResource(R.string.run_hike_screen_stop_run_button_label),
                 onClick = onStopTheRun,
-                modifier = Modifier.padding(top = 16.dp).testTag(TEST_TAG_STOP_HIKE_BUTTON),
+                modifier = Modifier.padding(top = 16.dp).testTag(RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON),
                 fillColor = Color(0xFFE83B3D))
           }
         }

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -177,9 +177,10 @@ fun RunHikeScreen(
                   .testTag(TEST_TAG_ZOOM_BUTTONS))
 
       RunHikeBottomSheet(
-          DetailedHikeRoute.create(route, ElevationServiceRepository(OkHttpClient())),
-          elevationData,
-          { wantToNavigateBack = true })
+          hikeRoute = DetailedHikeRoute.create(route, ElevationServiceRepository(OkHttpClient())),
+          elevationData = elevationData,
+          onStopTheRun = { wantToNavigateBack = true },
+      )
     }
   }
 }
@@ -208,6 +209,7 @@ fun RunHikeBottomSheet(
               textAlign = TextAlign.Left,
               modifier = Modifier.testTag(TEST_TAG_HIKE_NAME))
 
+          // Elevation graph and the progress details below the graph
           Column {
             val hikeColor = Color(hikeRoute.route.getColor())
             ElevationGraph(
@@ -215,14 +217,13 @@ fun RunHikeBottomSheet(
                 styleProperties =
                     ElevationGraphStyleProperties(strokeColor = hikeColor, fillColor = hikeColor),
                 modifier = Modifier.fillMaxWidth().padding(16.dp).testTag(TEST_TAG_ELEVATION_GRAPH))
+
+            // Progress details below the graph
             Row(
                 modifier = Modifier.fillMaxWidth().padding(top = 4.dp, bottom = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween) {
-                  val totalDistanceString =
-                      String.format(Locale.getDefault(), "%.2f", hikeRoute.totalDistance)
-
                   Text(
-                      text = "0km",
+                      text = stringResource(R.string.run_hike_screen_zero_distance_progress_value),
                       style = MaterialTheme.typography.bodyLarge,
                       fontWeight = FontWeight.Bold,
                       textAlign = TextAlign.Left,
@@ -237,7 +238,9 @@ fun RunHikeBottomSheet(
                       modifier = Modifier.padding(top = 8.dp).testTag(TEST_TAG_PROGRESS_TEXT),
                   )
                   Text(
-                      text = "${totalDistanceString}km",
+                      text =
+                          stringResource(R.string.run_hike_screen_distance_progress_value_format)
+                              .format(hikeRoute.totalDistance),
                       style = MaterialTheme.typography.bodyLarge,
                       fontWeight = FontWeight.Bold,
                       textAlign = TextAlign.Right,
@@ -252,17 +255,19 @@ fun RunHikeBottomSheet(
                 String.format(
                     Locale.getDefault(), "%02d", (hikeRoute.estimatedTime % 60).roundToInt())
 
-            DetailRow(label = "Current elevation", value = "50m")
             DetailRow(
-                label = stringResource(R.string.hike_detail_screen_label_elevation_gain),
+                label = stringResource(R.string.run_hike_screen_label_current_elevation),
+                value = "50m")
+            DetailRow(
+                label = stringResource(R.string.run_hike_screen_label_elevation_gain),
                 value = "${elevationGainString}m")
             DetailRow(
-                label = stringResource(R.string.hike_detail_screen_label_estimated_time),
+                label = stringResource(R.string.run_hike_screen_label_estimated_time),
                 value =
                     if (hikeRoute.estimatedTime / 60 < 1) "${minuteString}min"
                     else "${hourString}h${minuteString}")
             DetailRow(
-                label = stringResource(R.string.hike_detail_screen_label_difficulty),
+                label = stringResource(R.string.run_hike_screen_label_difficulty),
                 value = stringResource(hikeRoute.difficulty.nameResourceId),
                 valueColor =
                     Color(

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -215,12 +216,17 @@ fun RunHikeBottomSheet(
             ElevationGraph(
                 elevations = elevationData,
                 styleProperties =
-                    ElevationGraphStyleProperties(strokeColor = hikeColor, fillColor = hikeColor),
-                modifier = Modifier.fillMaxWidth().padding(16.dp).testTag(TEST_TAG_ELEVATION_GRAPH))
+                    ElevationGraphStyleProperties(
+                        strokeColor = hikeColor, fillColor = hikeColor.copy(0.1f)),
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .height(60.dp)
+                        .padding(4.dp)
+                        .testTag(TEST_TAG_ELEVATION_GRAPH))
 
             // Progress details below the graph
             Row(
-                modifier = Modifier.fillMaxWidth().padding(top = 4.dp, bottom = 8.dp),
+                modifier = Modifier.fillMaxWidth().padding(bottom = 20.dp),
                 horizontalArrangement = Arrangement.SpaceBetween) {
                   Text(
                       text = stringResource(R.string.run_hike_screen_zero_distance_progress_value),

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -166,7 +166,7 @@ fun RunHikeScreen(
           navigationActions = navigationActions,
           modifier =
               Modifier.padding(top = 40.dp, start = 16.dp, end = 16.dp)
-                  .testTag(TEST_TAG_BACK_BUTTON),
+                  .testTag(RunHikeScreen.TEST_TAG_BACK_BUTTON),
           onClick = { wantToNavigateBack = true })
       // Zoom buttons at the bottom right of the screen
       ZoomMapButton(

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -160,7 +160,7 @@ fun RunHikeScreen(
           modifier =
               Modifier.fillMaxWidth()
                   .padding(bottom = 300.dp) // Reserve space for the scaffold at the bottom
-                  .testTag(TEST_TAG_MAP))
+                  .testTag(RunHikeScreen.TEST_TAG_MAP))
       // Back Button at the top of the screen
       BackButton(
           navigationActions = navigationActions,

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -264,7 +264,7 @@ fun RunHikeBottomSheet(
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_estimated_time),
                 value =
-                    if (hikeRoute.estimatedTime / 60 < 1)
+                    if (hours < 1)
                         stringResource(
                             R.string.run_hike_screen_value_format_estimated_time_minutes, minutes)
                     else

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -26,12 +26,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
 import ch.hikemate.app.R
 import ch.hikemate.app.model.elevation.ElevationServiceRepository
 import ch.hikemate.app.model.profile.ProfileViewModel
@@ -43,15 +43,6 @@ import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
 import ch.hikemate.app.ui.components.ElevationGraph
 import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BACK_BUTTON
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_BOTTOM_SHEET
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ELEVATION_GRAPH
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_HIKE_NAME
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_MAP
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_PROGRESS_TEXT
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT
-import ch.hikemate.app.ui.map.RunHikeScreen.TEST_TAG_ZOOM_BUTTONS
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.utils.MapUtils
@@ -222,26 +213,29 @@ fun RunHikeBottomSheet(
                     Modifier.fillMaxWidth()
                         .height(60.dp)
                         .padding(4.dp)
-                        .testTag(TEST_TAG_ELEVATION_GRAPH))
+                        .testTag(RunHikeScreen.TEST_TAG_ELEVATION_GRAPH))
 
             // Progress details below the graph
             Row(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 20.dp),
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 20.dp),
                 horizontalArrangement = Arrangement.SpaceBetween) {
                   Text(
                       text = stringResource(R.string.run_hike_screen_zero_distance_progress_value),
                       style = MaterialTheme.typography.bodyLarge,
                       fontWeight = FontWeight.Bold,
                       textAlign = TextAlign.Left,
-                      modifier = Modifier.padding(top = 8.dp),
                   )
                   Text(
-                      text = "23% complete",
+                      // Displays the progress percentage below the graph
+                      // TODO hardcoded as 23% for now
+                      text =
+                          stringResource(R.string.run_hike_screen_progress_percentage_format)
+                              .format(23),
                       style = MaterialTheme.typography.bodyLarge,
                       color = hikeColor,
                       fontWeight = FontWeight.Bold,
                       textAlign = TextAlign.Right,
-                      modifier = Modifier.padding(top = 8.dp).testTag(TEST_TAG_PROGRESS_TEXT),
+                      modifier = Modifier.testTag(RunHikeScreen.TEST_TAG_PROGRESS_TEXT),
                   )
                   Text(
                       text =
@@ -250,11 +244,10 @@ fun RunHikeBottomSheet(
                       style = MaterialTheme.typography.bodyLarge,
                       fontWeight = FontWeight.Bold,
                       textAlign = TextAlign.Right,
-                      modifier = Modifier.padding(top = 8.dp).testTag(TEST_TAG_TOTAL_DISTANCE_TEXT),
+                      modifier = Modifier.testTag(RunHikeScreen.TEST_TAG_TOTAL_DISTANCE_TEXT),
                   )
                 }
 
-            val elevationGainString = hikeRoute.elevationGain.roundToInt().toString()
             val hourString =
                 String.format(Locale.getDefault(), "%02d", (hikeRoute.estimatedTime / 60).toInt())
             val minuteString =
@@ -263,30 +256,41 @@ fun RunHikeBottomSheet(
 
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_current_elevation),
-                value = "50m")
+                // TODO hardcoded to 50m for now
+                value =
+                    stringResource(R.string.run_hike_screen_value_format_current_elevation)
+                        .format(50))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_elevation_gain),
-                value = "${elevationGainString}m")
+                value =
+                    stringResource(R.string.run_hike_screen_value_format_elevation_gain)
+                        .format(hikeRoute.elevationGain.roundToInt()))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_estimated_time),
                 value =
-                    if (hikeRoute.estimatedTime / 60 < 1) "${minuteString}min"
-                    else "${hourString}h${minuteString}")
+                    if (hikeRoute.estimatedTime / 60 < 1)
+                        stringResource(R.string.run_hike_screen_value_format_estimated_time_minutes)
+                            .format((hikeRoute.estimatedTime % 60).roundToInt())
+                    else
+                        stringResource(
+                                R.string
+                                    .run_hike_screen_value_format_estimated_time_hours_and_minutes)
+                            .format(
+                                (hikeRoute.estimatedTime / 60).toInt(),
+                                (hikeRoute.estimatedTime % 60).roundToInt()))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_difficulty),
                 value = stringResource(hikeRoute.difficulty.nameResourceId),
-                valueColor =
-                    Color(
-                        ContextCompat.getColor(
-                            LocalContext.current, hikeRoute.difficulty.colorResourceId)),
-            )
+                valueColor = colorResource(hikeRoute.difficulty.colorResourceId))
 
             BigButton(
                 buttonType = ButtonType.PRIMARY,
                 label = stringResource(R.string.run_hike_screen_stop_run_button_label),
                 onClick = onStopTheRun,
-                modifier = Modifier.padding(top = 16.dp).testTag(RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON),
-                fillColor = Color(0xFFE83B3D))
+                modifier =
+                    Modifier.padding(top = 16.dp).testTag(RunHikeScreen.TEST_TAG_STOP_HIKE_BUTTON),
+                fillColor = colorResource(R.color.red),
+            )
           }
         }
       }) {}

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -208,7 +208,7 @@ fun RunHikeBottomSheet(
               text = hikeRoute.route.name ?: stringResource(R.string.map_screen_hike_title_default),
               style = MaterialTheme.typography.titleLarge,
               textAlign = TextAlign.Left,
-              modifier = Modifier.testTag(TEST_TAG_HIKE_NAME))
+              modifier = Modifier.testTag(RunHikeScreen.TEST_TAG_HIKE_NAME))
 
           // Elevation graph and the progress details below the graph
           Column {

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -272,7 +272,7 @@ fun RunHikeBottomSheet(
 
             BigButton(
                 buttonType = ButtonType.PRIMARY,
-                label = "Stop the run",
+                label = stringResource(R.string.run_hike_screen_stop_run_button_label),
                 onClick = onStopTheRun,
                 modifier = Modifier.padding(top = 16.dp).testTag(TEST_TAG_STOP_HIKE_BUTTON),
                 fillColor = Color(0xFFE83B3D))

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="blue">#FF3B9DE8</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="red">#FFE83B3D</color>
 
     <color name="hike_difficulty_easy">#1B9E4D</color>
     <color name="hike_difficulty_moderate">#FCCA03</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,9 @@
     <string name="hike_detail_screen_date_picker_cancel_button">Cancel</string>
     <string name="hike_detail_screen_date_picker_confirm_button">Plan this hike!</string>
 
+    <!--Run Hike Screen -->
+    <string name="run_hike_screen_stop_run_button_label">Stop the run</string>
+
     <!-- Hike Difficulty Levels -->
     <string name="hike_difficulty_easy">Easy</string>
     <string name="hike_difficulty_moderate">Moderate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,12 @@
 
     <!--Run Hike Screen -->
     <string name="run_hike_screen_stop_run_button_label">Stop the run</string>
+    <string name="run_hike_screen_zero_distance_progress_value">0km</string>
+    <string name="run_hike_screen_distance_progress_value_format">%.2fkm</string>
+    <string name="run_hike_screen_label_current_elevation">Current Elevation</string>
+    <string name="run_hike_screen_label_elevation_gain">Elevation Gain</string>
+    <string name="run_hike_screen_label_estimated_time">Estimated time</string>
+    <string name="run_hike_screen_label_difficulty">Difficulty</string>
 
     <!-- Hike Difficulty Levels -->
     <string name="hike_difficulty_easy">Easy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,9 +72,14 @@
     <string name="run_hike_screen_stop_run_button_label">Stop the run</string>
     <string name="run_hike_screen_zero_distance_progress_value">0km</string>
     <string name="run_hike_screen_distance_progress_value_format">%.2fkm</string>
+    <string name="run_hike_screen_progress_percentage_format">%d%% complete</string>
     <string name="run_hike_screen_label_current_elevation">Current Elevation</string>
+    <string name="run_hike_screen_value_format_current_elevation">%dm</string>
     <string name="run_hike_screen_label_elevation_gain">Elevation Gain</string>
+    <string name="run_hike_screen_value_format_elevation_gain">%dm</string>
     <string name="run_hike_screen_label_estimated_time">Estimated time</string>
+    <string name="run_hike_screen_value_format_estimated_time_minutes">%02dmin</string>
+    <string name="run_hike_screen_value_format_estimated_time_hours_and_minutes">%dh%02d</string>
     <string name="run_hike_screen_label_difficulty">Difficulty</string>
 
     <!-- Hike Difficulty Levels -->


### PR DESCRIPTION
# Summary

Added the hike details to the run hike screen bottom sheet as per the Figma design. This includes fetching the elevation data, however this may have to be undone not that the hike classes are unified. Mael agreed to look at this screen once it it merged. Currently, the "current elevation" and "distance progressed" information is hard-coded, since we do not have a location viewModel that provides the UI with location updates. This is being worked on my Rémy.

# Notes
1. I made the naming structure of the run hike screen test tags more clear, since as adding tests for the new features I noticed in this PR that they were quite convoluted. 
2. When adding the stop this hike button I also improved the back-navigation to be more crash resistant, by making the stop this run button and the back button update a `wantToNavigateBack` boolean to false, and on this change to false the back navigation happens. This variable can only be set to false, so even when spamming the buttons, only one back navigation is triggered. 
