### PR TITLE
Fix/too big osm hike queries

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/endtoend/EndToEndTest2.kt
@@ -162,11 +162,31 @@ class EndToEndTest2 : TestCase() {
     // Check that we are on the map
     composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_MAP).assertIsDisplayed()
 
+    // Check that the zoom out button is displayed
+    composeTestRule.onNodeWithTag(ZoomMapButton.ZOOM_OUT_BUTTON).assertIsDisplayed()
+
+    // Click once on the zoom out button
+    composeTestRule.onNodeWithTag(ZoomMapButton.ZOOM_OUT_BUTTON).performClick()
+
+    // Wait for animation
+    composeTestRule.waitForIdle()
+
     // Check that the zoom in button is displayed
     composeTestRule.onNodeWithTag(ZoomMapButton.ZOOM_IN_BUTTON).assertIsDisplayed()
 
-    // Click once on the zoom in button
+    // Click twice (one here and one below) on the zoom in button, since we need to zoom in twice to
+    // enable
+    // the search hike here button
     composeTestRule.onNodeWithTag(ZoomMapButton.ZOOM_IN_BUTTON).performClick()
+
+    // Wait for animation
+    composeTestRule.waitForIdle()
+
+    // Click a second time (see above)
+    composeTestRule.onNodeWithTag(ZoomMapButton.ZOOM_IN_BUTTON).performClick()
+
+    // Wait for animation
+    composeTestRule.waitForIdle()
 
     // Check that the search hike here button is displayed
     composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_SEARCH_BUTTON).assertIsDisplayed()

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/HikeDetailsScreenTest.kt
@@ -390,7 +390,7 @@ class HikeDetailScreenTest {
           {})
     }
 
-    val distanceString = String.format(Locale.ENGLISH, "%.2f", detailedRoute.totalDistance)
+    val distanceString = String.format(Locale.getDefault(), "%.2f", detailedRoute.totalDistance)
     val elevationGainString = detailedRoute.elevationGain.roundToInt().toString()
     val hourString =
         String.format(Locale.getDefault(), "%02d", (detailedRoute.estimatedTime / 60).toInt())

--- a/app/src/main/java/ch/hikemate/app/model/overpassAPI/OverpassRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/overpassAPI/OverpassRepository.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.model.overpassAPI
 
 import android.util.Log
+import ch.hikemate.app.ui.map.MapScreen
 import okhttp3.Callback
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -18,8 +19,16 @@ abstract class OverpassRepository {
     /** The type of format to request from the Overpass API, written in OverpassQL. */
     const val JSON_OVERPASS_FORMAT_TAG = "[out:json];"
 
+    /**
+     * The maximum number of hikes that can be requested in a single Overpass API request
+     *
+     * We limit in the [MapScreen], but since some hikes are filtered out, we need to request more
+     * hikes than we actually want to display.
+     */
+    private const val MAX_HIKES_PER_REQUEST = MapScreen.MAX_HIKES_DRAWN_ON_MAP * 3
+
     /** The output modifier for the Overpass API to return geometry information. */
-    const val GEOM_OUTPUT_MODIFIER = "out geom;"
+    const val GEOM_OUTPUT_MODIFIER = "out geom $MAX_HIKES_PER_REQUEST;"
   }
 
   /**

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -296,7 +296,7 @@ fun MapScreen(
     profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
   }
 
-  var zoomLevel by remember { mutableDoubleStateOf(0.0) }
+  var zoomLevel by remember { mutableDoubleStateOf(MapScreen.MAP_INITIAL_ZOOM) }
 
   // Avoid re-creating the MapView on every recomposition
   val mapView = remember {

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.ui.map
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -32,6 +33,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -69,6 +71,7 @@ import com.google.accompanist.permissions.MultiplePermissionsState
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationResult
+import kotlin.math.abs
 import org.osmdroid.config.Configuration
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.CustomZoomButtonsController
@@ -110,6 +113,24 @@ object MapScreen {
    * still being able to see a reasonable area of the world map.
    */
   const val MAP_MIN_ZOOM = 3.0
+
+  /**
+   * (Config) Maximum zoom level at which the search button is disabled. The zoom level is defined
+   * empirically to avoid the user launching a search when the map is zoomed out too much and the
+   * search would not be relevant.
+   *
+   * The value is arbitrary and can be adjusted based on the user's experience.
+   *
+   * The button will be enabled when the zoom level is greater than or equal to this value.
+   */
+  const val DISABLED_SEARCH_BUTTON_MAX_ZOOM_LEVEL = 11.5
+
+  /**
+   * (Config) Threshold to trigger an update (and a recomposition) of the zoom value when the user
+   * zooms in or out. The value is defined empirically to avoid unnecessary recompositions when the
+   * user zooms in or out slightly.
+   */
+  const val ZOOM_UPDATE_THRESHOLD = 0.5
 
   /** (Config) Initial position of the center of the map. */
   val MAP_INITIAL_CENTER = GeoPoint(46.5, 6.6)
@@ -231,6 +252,7 @@ data class MapInitialValues(
     val mapInitialCenter: GeoPoint = MapScreen.MAP_INITIAL_CENTER,
 )
 
+@SuppressLint("ClickableViewAccessibility")
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun MapScreen(
@@ -274,6 +296,8 @@ fun MapScreen(
     profileViewModel.getProfileById(authViewModel.currentUser.value!!.uid)
   }
 
+  var zoomLevel by remember { mutableDoubleStateOf(0.0) }
+
   // Avoid re-creating the MapView on every recomposition
   val mapView = remember {
     MapView(context).apply {
@@ -294,8 +318,16 @@ fun MapScreen(
       setMultiTouchControls(true)
       // Limit the vertical scrollable area to avoid the user scrolling too far
       setScrollableAreaLimitLatitude(MapScreen.MAP_MAX_LATITUDE, MapScreen.MAP_MIN_LATITUDE, 0)
+
+      // Update the zoom level when the user zooms in or out
+      setOnTouchListener { _, _ ->
+        if (abs(zoomLevelDouble - zoomLevel) >= MapScreen.ZOOM_UPDATE_THRESHOLD)
+            zoomLevel = zoomLevelDouble
+        false
+      }
     }
   }
+
   var userLocationMarker: Marker? by remember { mutableStateOf(null) }
 
   // We need to keep a reference to the instance of location callback, this way we can unregister
@@ -385,15 +417,6 @@ fun MapScreen(
       locationPermissionState = locationPermissionState,
       context = context)
 
-  DisposableEffect(Unit) {
-    onDispose {
-      LocationUtils.stopUserLocationUpdates(context, locationUpdatedCallback)
-      mapView.overlays.clear()
-      mapView.onPause()
-      mapView.onDetach()
-    }
-  }
-
   val errorMessageIdState = profileViewModel.errorMessageId.collectAsState()
   val profileState = profileViewModel.profile.collectAsState()
 
@@ -447,14 +470,21 @@ fun MapScreen(
                       onClick = {
                         MapScreen.launchSearch(isSearching, hikingRoutesViewModel, mapView, context)
                       },
+                      enabled = zoomLevel >= MapScreen.DISABLED_SEARCH_BUTTON_MAX_ZOOM_LEVEL,
                       modifier =
                           Modifier.align(Alignment.BottomCenter)
                               .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp))
                 }
                 // The zoom buttons are displayed on the bottom left of the screen
                 ZoomMapButton(
-                    onZoomIn = { mapView.controller.zoomIn() },
-                    onZoomOut = { mapView.controller.zoomOut() },
+                    onZoomIn = {
+                      zoomLevel = mapView.zoomLevelDouble + 1
+                      mapView.controller.zoomIn()
+                    },
+                    onZoomOut = {
+                      zoomLevel = mapView.zoomLevelDouble - 1
+                      mapView.controller.zoomOut()
+                    },
                     modifier =
                         Modifier.align(Alignment.BottomEnd)
                             .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp))
@@ -532,11 +562,16 @@ fun LocationPermissionAlertDialog(
 }
 
 @Composable
-fun MapSearchButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+fun MapSearchButton(onClick: () -> Unit, modifier: Modifier = Modifier, enabled: Boolean = true) {
   Button(
       onClick = onClick,
       modifier = modifier.testTag(MapScreen.TEST_TAG_SEARCH_BUTTON),
-      colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surface)) {
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.surface,
+              disabledContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+          ),
+      enabled = enabled) {
         Text(
             text = LocalContext.current.getString(R.string.map_screen_search_button_text),
             color = MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -323,6 +323,7 @@ fun MapScreen(
       setOnTouchListener { _, _ ->
         if (abs(zoomLevelDouble - zoomLevel) >= MapScreen.ZOOM_UPDATE_THRESHOLD)
             zoomLevel = zoomLevelDouble
+        // We do not consume the event, so the map can handle it
         false
       }
     }


### PR DESCRIPTION
# Summary
- Queries were too big for OSM, leading to app not being stable enough, this PR fixes it by two means:
   - It limits the number of hikes we ask the Overpass API
   - It disables the search button if too zoomed out on the map 
# Details
- The limitation for the Overpass API is dependent on the max number of hike we show on the map, and is slightly bigger since some hikes are discarded when incomplete
- The zoom level at which the search button is deactivated is set completely arbitrarily 
- I edited the End2End test to make it uses the zoom button and is at the correct zoom level to be able to search

# Other issue fixed
- One of the tests got an issue with a Locale, I fixed it while testing on my phone (in French)