### PR TITLE
fix: re-authenticate the user in-app instead of browser

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/profile/DeleteAccountScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/profile/DeleteAccountScreenTest.kt
@@ -82,8 +82,8 @@ class DeleteAccountScreenTest : TestCase() {
         .performTextInput(password)
     composeTestRule.onNodeWithTag(DeleteAccountScreen.TEST_TAG_DELETE_ACCOUNT_BUTTON).performClick()
 
-    verify(exactly = 1) { authViewModel.deleteAccount(eq(password), any(), any(), any()) }
-    verify(exactly = 0) { authViewModel.deleteAccount(neq(password), any(), any(), any()) }
+    verify(exactly = 1) { authViewModel.deleteAccount(eq(password), any(), any(), any(), any()) }
+    verify(exactly = 0) { authViewModel.deleteAccount(neq(password), any(), any(), any(), any()) }
   }
 
   @Test
@@ -92,6 +92,6 @@ class DeleteAccountScreenTest : TestCase() {
 
     composeTestRule.onNodeWithTag(DeleteAccountScreen.TEST_TAG_DELETE_ACCOUNT_BUTTON).performClick()
 
-    verify(exactly = 0) { authViewModel.deleteAccount(any(), any(), any(), any()) }
+    verify(exactly = 0) { authViewModel.deleteAccount(any(), any(), any(), any(), any()) }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthRepository.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.model.authentication
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.compose.ManagedActivityResultLauncher
@@ -79,14 +78,16 @@ interface AuthRepository {
    * account.
    *
    * @param password The password of the user.
-   * @param activity The Android Activity, used for launching the re-authentication dialog.
+   * @param context The Android Context, used for accessing resources and system services.
+   * @param coroutineScope The CoroutineScope to launch the account deletion task in a non-blocking
    * @param onSuccess Callback to invoke after the user's account has been successfully deleted.
    * @param onErrorAction Callback to invoke when an error occurs during account deletion. Passes
    *   the Throwable error.
    */
   fun deleteAccount(
       password: String,
-      activity: Activity,
+      context: Context,
+      coroutineScope: CoroutineScope,
       onSuccess: () -> Unit,
       onErrorAction: (Int) -> Unit
   )

--- a/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/AuthViewModel.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.model.authentication
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -193,13 +192,15 @@ class AuthViewModel(
    */
   fun deleteAccount(
       password: String,
-      activity: Activity,
+      context: Context,
+      coroutineScope: CoroutineScope,
       onSuccess: () -> Unit,
       onErrorAction: (Int) -> Unit
   ) {
     repository.deleteAccount(
         password = password,
-        activity = activity,
+        context = context,
+        coroutineScope = coroutineScope,
         onSuccess = {
           _currentUser.value = null
           onSuccess()

--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.model.authentication
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
@@ -20,7 +19,6 @@ import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
-import com.google.firebase.auth.OAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
@@ -39,58 +37,33 @@ class FirebaseAuthRepository : AuthRepository {
   ) {
     // Initialize Firebase authentication and retrieve the web client ID from resources
     val auth = FirebaseAuth.getInstance()
-    val token = context.getString(R.string.default_web_client_id)
 
-    // Configure Google ID options to request credentials from authorized accounts and the server
-    // client ID
-    val googleIdOption: GetGoogleIdOption =
-        GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false) // Allow all kinds of Google accounts
-            .setServerClientId(token) // Server client ID for OAuth
-            .setAutoSelectEnabled(true) // Auto-select if only one account is available
-            .build()
-
-    // Build the credential request with the Google ID option
-    val request: GetCredentialRequest =
-        GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
-
-    // Launch a coroutine for the login process to avoid blocking the main thread
-    coroutineScope.launch {
-      try {
-        // Request credentials from the credential manager
-        val result =
-            credentialManager.getCredential(
-                request = request, // Send the request we built
-                context = context // Provide the context for the request
-                )
-
-        // Extract the ID token from the result and create a Firebase credential
-        val firebaseCredential =
-            GoogleAuthProvider.getCredential(
-                result.credential.data.getString(
-                    "com.google.android.libraries.identity.googleid.BUNDLE_KEY_ID_TOKEN")!!, // Non-null assertion because the token must exist if login is successful
-                null // No access token needed
-                )
-
-        // Sign in with the Firebase credential (async task)
-        auth.signInWithCredential(firebaseCredential).addOnCompleteListener { task ->
-          if (task.isSuccessful) {
-            Log.d("FirebaseAuthRepository", "signInWithCredential:success")
-            onSuccess(auth.currentUser)
+    getGoogleAuthCredential(
+        context,
+        coroutineScope,
+        credentialManager,
+        onSuccess = { firebaseCredential ->
+          // Sign in with the Firebase credential (async task)
+          auth.signInWithCredential(firebaseCredential).addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              Log.d("FirebaseAuthRepository", "signInWithCredential:success")
+              onSuccess(auth.currentUser)
+            } else {
+              Log.d("FirebaseAuthRepository", "signInWithCredential:failure", task.exception)
+              onErrorAction(R.string.error_occurred_while_signing_in_with_google)
+            }
+          }
+        },
+        onFailure = { e ->
+          if (e is NoCredentialException) {
+            Log.e("SignInButton", "No credentials found: ${e.message}")
+            // If there is no Google account connected to the device, prompt the user to add one
+            startAddAccountIntentLauncher?.launch(getAddGoogleAccountIntent())
           } else {
-            Log.d("FirebaseAuthRepository", "signInWithCredential:failure", task.exception)
+            Log.d("SignInButton", "Login error: ${e.message}")
             onErrorAction(R.string.error_occurred_while_signing_in_with_google)
           }
-        }
-      } catch (e: NoCredentialException) {
-        Log.e("SignInButton", "No credentials found: ${e.message}")
-        // If there is no Google account connected to the device, prompt the user to add one
-        startAddAccountIntentLauncher?.launch(getAddGoogleAccountIntent())
-      } catch (e: Exception) {
-        Log.d("SignInButton", "Login error: ${e.message}")
-        onErrorAction(R.string.error_occurred_while_signing_in_with_google)
-      }
-    }
+        })
   }
 
   private fun getAddGoogleAccountIntent(): Intent {
@@ -142,7 +115,8 @@ class FirebaseAuthRepository : AuthRepository {
 
   override fun deleteAccount(
       password: String,
-      activity: Activity,
+      context: Context,
+      coroutineScope: CoroutineScope,
       onSuccess: () -> Unit,
       onErrorAction: (Int) -> Unit
   ) {
@@ -155,7 +129,8 @@ class FirebaseAuthRepository : AuthRepository {
       reauthenticate(
           user,
           password,
-          activity,
+          context,
+          coroutineScope,
           {
             Log.d("DeleteAccount", "User re-authenticated")
 
@@ -203,35 +178,108 @@ class FirebaseAuthRepository : AuthRepository {
   private fun reauthenticate(
       user: FirebaseUser,
       password: String,
-      activity: Activity,
+      context: Context,
+      coroutineScope: CoroutineScope,
       onSuccess: () -> Unit,
       onFailure: () -> Unit
   ) {
     val isEmail = isEmailProvider(user)
 
     if (isEmail) {
-      val email = user.email ?: throw Exception("User email is null")
-      val credential: AuthCredential = EmailAuthProvider.getCredential(email, password)
-      user.reauthenticate(credential).addOnCompleteListener { task ->
-        if (task.isSuccessful) {
-          Log.d("DeleteAccount", "User re-authenticated")
-          onSuccess()
-        } else {
-          onFailure()
-        }
-      }
+      reauthenticateWithEmailAndPassword(user, password, onSuccess, onFailure)
     } else {
-      val googleProvider = OAuthProvider.newBuilder(GoogleAuthProvider.PROVIDER_ID)
-      user
-          .startActivityForReauthenticateWithProvider(activity, googleProvider.build())
-          .addOnFailureListener { e ->
-            Log.e("DeleteAccount", "Re-authentication failed: ${e.message}")
-            onFailure()
+      reauthenticateWithGoogleSignIn(user, context, coroutineScope, onSuccess, onFailure)
+    }
+  }
+
+  private fun reauthenticateWithEmailAndPassword(
+      user: FirebaseUser,
+      password: String,
+      onSuccess: () -> Unit,
+      onFailure: () -> Unit
+  ) {
+    val email = user.email ?: throw Exception("User email is null")
+    val credential: AuthCredential = EmailAuthProvider.getCredential(email, password)
+    user.reauthenticate(credential).addOnCompleteListener { task ->
+      if (task.isSuccessful) {
+        Log.d("DeleteAccount", "User re-authenticated")
+        onSuccess()
+      } else {
+        onFailure()
+      }
+    }
+  }
+
+  private fun reauthenticateWithGoogleSignIn(
+      user: FirebaseUser,
+      context: Context,
+      coroutineScope: CoroutineScope,
+      onSuccess: () -> Unit,
+      onFailure: () -> Unit
+  ) {
+    getGoogleAuthCredential(
+        context,
+        coroutineScope,
+        onSuccess = { firebaseCredential ->
+          user.reauthenticate(firebaseCredential).addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              Log.d("FirebaseAuthRepository", "reauthenticate:success")
+              onSuccess()
+            } else {
+              Log.d("FirebaseAuthRepository", "reauthenticate:failure", task.exception)
+              onFailure()
+            }
           }
-          .addOnSuccessListener { result ->
-            Log.d("DeleteAccount", "Re-authentication successful: $result")
-            onSuccess()
-          }
+        },
+        onFailure = {
+          Log.d("GetGoogleCredential", "Error getting Google credential: ${it.message}")
+          onFailure()
+        })
+  }
+
+  private fun getGoogleAuthCredential(
+      context: Context,
+      coroutineScope: CoroutineScope,
+      credentialManager: CredentialManager = CredentialManager.create(context),
+      onSuccess: (AuthCredential) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val token = context.getString(R.string.default_web_client_id)
+
+    // Configure Google ID options to request credentials from authorized accounts and the server
+    // client ID
+    val googleIdOption: GetGoogleIdOption =
+        GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false) // Allow all kinds of Google accounts
+            .setServerClientId(token) // Server client ID for OAuth
+            .setAutoSelectEnabled(true) // Auto-select if only one account is available
+            .build()
+
+    // Build the credential request with the Google ID option
+    val request: GetCredentialRequest =
+        GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+
+    coroutineScope.launch {
+      try {
+        // Request credentials from the credential manager
+        val result =
+            credentialManager.getCredential(
+                request = request, // Send the request we built
+                context = context // Provide the context for the request
+                )
+
+        // Extract the ID token from the result and create a Firebase credential
+        val firebaseCredential =
+            GoogleAuthProvider.getCredential(
+                result.credential.data.getString(
+                    "com.google.android.libraries.identity.googleid.BUNDLE_KEY_ID_TOKEN")!!, // Non-null assertion because the token must exist if login is successful
+                null // No access token needed
+                )
+
+        onSuccess(firebaseCredential)
+      } catch (e: Exception) {
+        onFailure(e)
+      }
     }
   }
 }

--- a/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
+++ b/app/src/main/java/ch/hikemate/app/model/authentication/FirebaseAuthRepository.kt
@@ -175,6 +175,18 @@ class FirebaseAuthRepository : AuthRepository {
     return user.providerData.any { it.providerId == EmailAuthProvider.PROVIDER_ID }
   }
 
+  /**
+   * Re-authenticate the user with a given passwords. If the user is signed in with an email
+   * provider, re-authenticate with email and password. If the user is signed in with Google, use
+   * Google Sign-In to re-authenticate.
+   *
+   * @param user The user to re-authenticate.
+   * @param password The password to use for re-authentication.
+   * @param context The context to use for Google Sign-In.
+   * @param coroutineScope The coroutine scope to use for Google Sign-In.
+   * @param onSuccess The action to perform if re-authentication is successful.
+   * @param onFailure The action to perform if re-authentication fails.
+   */
   private fun reauthenticate(
       user: FirebaseUser,
       password: String,
@@ -192,6 +204,14 @@ class FirebaseAuthRepository : AuthRepository {
     }
   }
 
+  /**
+   * Re-authenticate the user with email and password.
+   *
+   * @param user The user to re-authenticate.
+   * @param password The password to use for re-authentication.
+   * @param onSuccess The action to perform if re-authentication is successful.
+   * @param onFailure The action to perform if re-authentication fails.
+   */
   private fun reauthenticateWithEmailAndPassword(
       user: FirebaseUser,
       password: String,
@@ -202,14 +222,24 @@ class FirebaseAuthRepository : AuthRepository {
     val credential: AuthCredential = EmailAuthProvider.getCredential(email, password)
     user.reauthenticate(credential).addOnCompleteListener { task ->
       if (task.isSuccessful) {
-        Log.d("DeleteAccount", "User re-authenticated")
+        Log.d("FirebaseAuthRepository", "reauthenticate(email):success")
         onSuccess()
       } else {
+        Log.d("FirebaseAuthRepository", "reauthenticate(email):failure", task.exception)
         onFailure()
       }
     }
   }
 
+  /**
+   * Re-authenticate the user with Google Sign-In.
+   *
+   * @param user The user to re-authenticate.
+   * @param context The context to use for Google Sign-In.
+   * @param coroutineScope The coroutine scope to use for Google Sign-In.
+   * @param onSuccess The action to perform if re-authentication is successful.
+   * @param onFailure The action to perform if re-authentication fails.
+   */
   private fun reauthenticateWithGoogleSignIn(
       user: FirebaseUser,
       context: Context,
@@ -223,10 +253,10 @@ class FirebaseAuthRepository : AuthRepository {
         onSuccess = { firebaseCredential ->
           user.reauthenticate(firebaseCredential).addOnCompleteListener { task ->
             if (task.isSuccessful) {
-              Log.d("FirebaseAuthRepository", "reauthenticate:success")
+              Log.d("FirebaseAuthRepository", "reauthenticate(google):success")
               onSuccess()
             } else {
-              Log.d("FirebaseAuthRepository", "reauthenticate:failure", task.exception)
+              Log.d("FirebaseAuthRepository", "reauthenticate(google):failure", task.exception)
               onFailure()
             }
           }
@@ -237,6 +267,16 @@ class FirebaseAuthRepository : AuthRepository {
         })
   }
 
+  /**
+   * Get a Google credential for Firebase authentication. Useful for Google Sign-In and
+   * re-authentication.
+   *
+   * @param context The context to use for Google Sign-In.
+   * @param coroutineScope The coroutine scope to use for Google Sign-In.
+   * @param credentialManager The credential manager to use for Google Sign-In.
+   * @param onSuccess The action to perform if the credential is successfully retrieved.
+   * @param onFailure The action to perform if the credential retrieval fails.
+   */
   private fun getGoogleAuthCredential(
       context: Context,
       coroutineScope: CoroutineScope,

--- a/app/src/main/java/ch/hikemate/app/ui/profile/DeleteAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/DeleteAccountScreen.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.ui.profile
 
-import android.app.Activity
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -51,6 +51,8 @@ object DeleteAccountScreen {
 @Composable
 fun DeleteAccountScreen(navigationActions: NavigationActions, authViewModel: AuthViewModel) {
   val context = LocalContext.current
+
+  val coroutineScope = rememberCoroutineScope()
 
   val passwordMustNotBeEmptyError =
       stringResource(R.string.delete_account_password_must_be_filled_error)
@@ -112,7 +114,8 @@ fun DeleteAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
               } else {
                 authViewModel.deleteAccount(
                     password,
-                    context as Activity,
+                    context,
+                    coroutineScope,
                     { navigationActions.navigateTo(Route.AUTH) },
                     { Toast.makeText(context, context.getString(it), Toast.LENGTH_SHORT).show() })
               }

--- a/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/AuthViewModelTest.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.authentication
 
-import android.app.Activity
 import android.content.Context
 import ch.hikemate.app.R
 import ch.hikemate.app.model.authentication.AuthViewModel
@@ -371,25 +370,25 @@ class AuthViewModelTest {
 
     // Simulate a successful account deletion by invoking the onSuccess callback
     doAnswer { arguments ->
-          val onSuccess = arguments.getArgument<() -> Unit>(2)
+          val onSuccess = arguments.getArgument<() -> Unit>(3)
           onSuccess()
           null
         }
         .`when`(mockRepository)
-        .deleteAccount(any(), any(), any(), any())
+        .deleteAccount(any(), any(), any(), any(), any())
 
     // Verify that currentUser is initially mockFirebaseUser
     assertEquals(mockFirebaseUser, viewModel.currentUser.value)
 
-    val activity = mock(Activity::class.java)
     viewModel.deleteAccount(
         "password",
-        activity = activity,
+        context = mockContext,
+        coroutineScope = this,
         onSuccess = mockOnSuccess,
         onErrorAction = { fail("Error callback should not be called") })
 
     // Verify that the repository's deleteAccount was called
-    verify(mockRepository).deleteAccount(any(), any(), any(), any())
+    verify(mockRepository).deleteAccount(any(), any(), any(), any(), any())
     // Verify that currentUser is updated to null
     assertEquals(null, viewModel.currentUser.value)
     // Verify that the onSuccess callback was called
@@ -405,25 +404,25 @@ class AuthViewModelTest {
 
       // Simulate an unsuccessful account deletion by invoking the onError callback
       doAnswer { arguments ->
-            val onError = arguments.getArgument<(Int) -> Unit>(3)
+            val onError = arguments.getArgument<(Int) -> Unit>(4)
             onError(R.string.error_occurred_while_signing_in_with_google)
             null
           }
           .`when`(mockRepository)
-          .deleteAccount(any(), any(), any(), any())
+          .deleteAccount(any(), any(), any(), any(), any())
 
       // Verify that currentUser is initially mockFirebaseUser
       assertEquals(mockFirebaseUser, viewModel.currentUser.value)
 
-      val activity = mock(Activity::class.java)
       viewModel.deleteAccount(
           "password",
-          activity = activity,
+          context = mockContext,
+          coroutineScope = this,
           onSuccess = { fail("Success callback should not be called") },
           onErrorAction = mockOnError)
 
       // Verify that the repository's deleteAccount was called
-      verify(mockRepository).deleteAccount(any(), any(), any(), any())
+      verify(mockRepository).deleteAccount(any(), any(), any(), any(), any())
       // Verify that currentUser is still mockFirebaseUser
       assertEquals(mockFirebaseUser, viewModel.currentUser.value)
       // Verify that the onError callback was called

--- a/app/src/test/java/ch/hikemate/app/authentication/FirebaseAuthRepositoryTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/FirebaseAuthRepositoryTest.kt
@@ -1,6 +1,5 @@
 package ch.hikemate.app.authentication
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.compose.ManagedActivityResultLauncher
@@ -31,9 +30,12 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
 import io.mockk.*
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -67,6 +69,8 @@ class FirebaseAuthRepositoryTest {
 
   @Before
   fun setUp() {
+    Dispatchers.setMain(UnconfinedTestDispatcher())
+
     context = ApplicationProvider.getApplicationContext()
 
     // Initialize mocks
@@ -351,9 +355,8 @@ class FirebaseAuthRepositoryTest {
       every { mockDocument.delete() } returns mockVoidTask
 
       val onSuccess: () -> Unit = mockk(relaxed = true)
-      val mockActivity: Activity = mockk(relaxed = true)
 
-      repository.deleteAccount("password", mockActivity, onSuccess, mockOnError)
+      repository.deleteAccount("password", context, this, onSuccess, mockOnError)
 
       verify { mockFirebaseUser.delete() }
       verify(exactly = 2) { mockDocument.delete() }
@@ -372,9 +375,8 @@ class FirebaseAuthRepositoryTest {
       every { mockDocument.delete() } returns mockVoidTask
 
       val onSuccess: () -> Unit = mockk(relaxed = true)
-      val mockActivity: Activity = mockk(relaxed = true)
 
-      repository.deleteAccount("password", mockActivity, onSuccess, mockOnError)
+      repository.deleteAccount("password", context, this, onSuccess, mockOnError)
 
       verify { mockOnError(any()) }
     }

--- a/app/src/test/java/ch/hikemate/app/authentication/FirebaseAuthRepositoryTest.kt
+++ b/app/src/test/java/ch/hikemate/app/authentication/FirebaseAuthRepositoryTest.kt
@@ -358,6 +358,7 @@ class FirebaseAuthRepositoryTest {
 
       repository.deleteAccount("password", context, this, onSuccess, mockOnError)
 
+      verify { mockFirebaseUser.reauthenticate(any()) }
       verify { mockFirebaseUser.delete() }
       verify(exactly = 2) { mockDocument.delete() }
       verify { onSuccess() }
@@ -378,6 +379,7 @@ class FirebaseAuthRepositoryTest {
 
       repository.deleteAccount("password", context, this, onSuccess, mockOnError)
 
+      verify { mockFirebaseUser.reauthenticate(any()) }
       verify { mockOnError(any()) }
     }
   }


### PR DESCRIPTION
# Summary
We had an issue that deleting a account **Signed in with Google** would lead to re-authenticate the user. For this it launched an activity on the browser.

This lead to unexpected behaviors such as not working at all with Opera or Firefox for example.

To remediate to this, I changed it to use the in-app re-authentication (like the sign-in) in order to correctly re-authenticate the user.

# Details
I also refactored the code in `FirebaseAuthRepository` in order to reduce repeated code. I created the following functions:
- `reauthenticateWithEmailAndPassword` -> re-authentication for an email-account
- `reauthenticateWithGoogleSignIn` -> re-authentication for a google-account
- `getGoogleAuthCredential` -> get the google credential to either sign in or re-authenticate