### PR TITLE
chore: sanitize inputs to limit their length

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/CreateAccountScreen.kt
@@ -9,11 +9,7 @@ import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,8 +22,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.hikemate.app.R
@@ -35,10 +29,10 @@ import ch.hikemate.app.model.authentication.AuthViewModel
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.CustomTextField
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
-import ch.hikemate.app.ui.theme.primaryColor
 
 object CreateAccountScreen {
   const val TEST_TAG_TITLE = "create_account_title"
@@ -70,19 +64,6 @@ fun CreateAccountScreen(
   val emailWrongFormatErrorMessage = stringResource(R.string.create_account_email_format_error)
   val fieldMustBeFilledErrorMessage =
       stringResource(R.string.create_account_fields_must_be_filled_error)
-
-  // Define the colors for the input fields
-  val inputColors =
-      OutlinedTextFieldDefaults.colors()
-          .copy(
-              focusedLabelColor = primaryColor,
-              focusedIndicatorColor = primaryColor,
-              cursorColor = primaryColor,
-              textSelectionColors =
-                  TextSelectionColors(
-                      handleColor = primaryColor,
-                      backgroundColor = primaryColor,
-                  ))
 
   var name by remember { mutableStateOf("") }
   var email by remember { mutableStateOf("") }
@@ -135,42 +116,39 @@ fun CreateAccountScreen(
             style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 32.sp),
             modifier = Modifier.testTag(CreateAccountScreen.TEST_TAG_TITLE))
 
-        OutlinedTextField(
-            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_NAME_INPUT),
-            colors = inputColors,
+        CustomTextField(
             value = name,
             onValueChange = { name = it },
-            label = { Text(stringResource(R.string.create_account_name_label)) },
-            singleLine = true)
+            label = stringResource(R.string.create_account_name_label),
+            maxLength = CustomTextField.MAX_NAME_LENGTH,
+            modifier = Modifier.testTag(CreateAccountScreen.TEST_TAG_NAME_INPUT),
+        )
 
-        OutlinedTextField(
-            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-            colors = inputColors,
+        CustomTextField(
             value = email,
             onValueChange = { email = it },
-            label = { Text(stringResource(R.string.create_account_email_label)) },
-            singleLine = true)
+            label = stringResource(R.string.create_account_email_label),
+            maxLength = CustomTextField.MAX_EMAIL_LENGTH,
+            modifier = Modifier.testTag(CreateAccountScreen.TEST_TAG_EMAIL_INPUT),
+        )
 
-        OutlinedTextField(
-            modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT),
-            visualTransformation = PasswordVisualTransformation(),
-            colors = inputColors,
+        CustomTextField(
             value = password,
             onValueChange = { password = it },
-            label = { Text(stringResource(R.string.create_account_password_label)) },
-            singleLine = true)
+            isPassword = true,
+            label = stringResource(R.string.create_account_password_label),
+            maxLength = CustomTextField.MAX_PASSWORD_LENGTH,
+            modifier = Modifier.testTag(CreateAccountScreen.TEST_TAG_PASSWORD_INPUT),
+        )
 
-        OutlinedTextField(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .testTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT),
-            visualTransformation = PasswordVisualTransformation(),
-            colors = inputColors,
+        CustomTextField(
             value = confirmPassword,
             onValueChange = { confirmPassword = it },
-            label = { Text(stringResource(R.string.create_account_repeat_password_label)) },
-            singleLine = true)
+            isPassword = true,
+            label = stringResource(R.string.create_account_repeat_password_label),
+            maxLength = CustomTextField.MAX_PASSWORD_LENGTH,
+            modifier = Modifier.testTag(CreateAccountScreen.TEST_TAG_CONFIRM_PASSWORD_INPUT),
+        )
 
         BigButton(
             modifier = Modifier.fillMaxWidth().testTag(CreateAccountScreen.TEST_TAG_SIGN_UP_BUTTON),

--- a/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/auth/SignInWithEmailScreen.kt
@@ -12,11 +12,7 @@ import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -31,8 +27,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.hikemate.app.R
@@ -40,10 +34,10 @@ import ch.hikemate.app.model.authentication.AuthViewModel
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.CustomTextField
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
-import ch.hikemate.app.ui.theme.primaryColor
 
 object SignInWithEmailScreen {
   const val TEST_TAG_TITLE = "sign_in_with_email_title"
@@ -69,19 +63,6 @@ fun SignInWithEmailScreen(
 
   val scrollState = rememberScrollState()
 
-  // Define the colors for the input fields
-  val inputColors =
-      OutlinedTextFieldDefaults.colors()
-          .copy(
-              focusedLabelColor = primaryColor,
-              focusedIndicatorColor = primaryColor,
-              cursorColor = primaryColor,
-              textSelectionColors =
-                  TextSelectionColors(
-                      handleColor = primaryColor,
-                      backgroundColor = primaryColor,
-                  ))
-
   // Define the email and password state
   var email by remember { mutableStateOf("") }
   var password by remember { mutableStateOf("") }
@@ -104,24 +85,22 @@ fun SignInWithEmailScreen(
             style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 32.sp),
             modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_TITLE))
 
-        OutlinedTextField(
-            modifier = Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-            colors = inputColors,
+        CustomTextField(
             value = email,
             onValueChange = { email = it },
-            label = { Text(stringResource(R.string.sign_in_with_email_email_label)) },
-            singleLine = true)
+            label = stringResource(R.string.sign_in_with_email_email_label),
+            maxLength = CustomTextField.MAX_EMAIL_LENGTH,
+            modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_EMAIL_INPUT),
+        )
 
-        OutlinedTextField(
-            modifier =
-                Modifier.fillMaxWidth().testTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT),
-            visualTransformation = PasswordVisualTransformation(),
-            colors = inputColors,
+        CustomTextField(
             value = password,
             onValueChange = { password = it },
-            label = { Text(stringResource(R.string.sign_in_with_email_password_label)) },
-            singleLine = true)
+            label = stringResource(R.string.sign_in_with_email_password_label),
+            isPassword = true,
+            maxLength = CustomTextField.MAX_PASSWORD_LENGTH,
+            modifier = Modifier.testTag(SignInWithEmailScreen.TEST_TAG_PASSWORD_INPUT),
+        )
 
         BigButton(
             modifier =

--- a/app/src/main/java/ch/hikemate/app/ui/components/CustomTextField.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/CustomTextField.kt
@@ -1,0 +1,75 @@
+package ch.hikemate.app.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import ch.hikemate.app.ui.theme.primaryColor
+
+object CustomTextField {
+  const val MAX_NAME_LENGTH = 40
+  const val MAX_EMAIL_LENGTH = 50
+  const val MAX_PASSWORD_LENGTH = 50
+}
+
+/**
+ * Custom text field with custom colors and optional max length.
+ *
+ * @param value The value of the text field.
+ * @param onValueChange The callback when the value changes.
+ * @param label The label of the text field.
+ * @param isPassword Whether the text field is a password field.
+ * @param maxLength The maximum length of the text field.
+ * @param modifier The modifier of the text field.
+ */
+@Composable
+fun CustomTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    isPassword: Boolean = false,
+    maxLength: Int? = null,
+    modifier: Modifier = Modifier,
+) {
+
+  OutlinedTextField(
+      modifier = modifier.fillMaxWidth(),
+      colors =
+          OutlinedTextFieldDefaults.colors()
+              .copy(
+                  focusedLabelColor = primaryColor,
+                  focusedIndicatorColor = primaryColor,
+                  cursorColor = primaryColor,
+                  textSelectionColors =
+                      TextSelectionColors(
+                          handleColor = primaryColor,
+                          backgroundColor = primaryColor,
+                      )),
+      value = value,
+      visualTransformation =
+          if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
+      onValueChange = {
+        if (maxLength == null || it.length <= maxLength) {
+          onValueChange(it)
+        }
+      },
+      supportingText =
+          if (maxLength != null) {
+            {
+              Text(
+                  text = "${value.length} / $maxLength",
+                  modifier = Modifier.fillMaxWidth(),
+                  textAlign = TextAlign.End,
+              )
+            }
+          } else null,
+      label = { Text(label) },
+      singleLine = true,
+  )
+}

--- a/app/src/main/java/ch/hikemate/app/ui/profile/DeleteAccountScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/DeleteAccountScreen.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.foundation.text.selection.TextSelectionColors
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,7 +19,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.hikemate.app.R
@@ -30,10 +26,10 @@ import ch.hikemate.app.model.authentication.AuthViewModel
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
+import ch.hikemate.app.ui.components.CustomTextField
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
-import ch.hikemate.app.ui.theme.primaryColor
 
 object DeleteAccountScreen {
   const val TEST_TAG_TITLE = "delete_account_title"
@@ -54,19 +50,6 @@ fun DeleteAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
 
   val passwordMustNotBeEmptyError =
       stringResource(R.string.delete_account_password_must_be_filled_error)
-
-  // Define the colors for the input fields
-  val inputColors =
-      OutlinedTextFieldDefaults.colors()
-          .copy(
-              focusedLabelColor = primaryColor,
-              focusedIndicatorColor = primaryColor,
-              cursorColor = primaryColor,
-              textSelectionColors =
-                  TextSelectionColors(
-                      handleColor = primaryColor,
-                      backgroundColor = primaryColor,
-                  ))
 
   var password by remember { mutableStateOf("") }
 
@@ -92,14 +75,13 @@ fun DeleteAccountScreen(navigationActions: NavigationActions, authViewModel: Aut
             modifier = Modifier.testTag(DeleteAccountScreen.TEST_TAG_INFO_TEXT))
 
         if (authViewModel.isEmailProvider())
-            OutlinedTextField(
-                modifier =
-                    Modifier.fillMaxWidth().testTag(DeleteAccountScreen.TEST_TAG_PASSWORD_INPUT),
-                visualTransformation = PasswordVisualTransformation(),
-                colors = inputColors,
+            CustomTextField(
                 value = password,
                 onValueChange = { password = it },
-                label = { Text(stringResource(R.string.delete_account_password_label)) })
+                label = stringResource(R.string.delete_account_password_label),
+                maxLength = CustomTextField.MAX_PASSWORD_LENGTH,
+                isPassword = true,
+                modifier = Modifier.testTag(DeleteAccountScreen.TEST_TAG_PASSWORD_INPUT))
 
         BigButton(
             modifier =

--- a/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/profile/EditProfileScreen.kt
@@ -8,10 +8,7 @@ import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -41,6 +38,7 @@ import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
 import ch.hikemate.app.ui.components.CenteredLoadingAnimation
+import ch.hikemate.app.ui.components.CustomTextField
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.Screen
@@ -120,23 +118,13 @@ fun EditProfileScreen(
               style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 32.sp),
               modifier = Modifier.testTag(EditProfileScreen.TEST_TAG_TITLE))
 
-          OutlinedTextField(
-              modifier = Modifier.fillMaxWidth().testTag(EditProfileScreen.TEST_TAG_NAME_INPUT),
-              colors =
-                  OutlinedTextFieldDefaults.colors()
-                      .copy(
-                          focusedLabelColor = primaryColor,
-                          focusedIndicatorColor = primaryColor,
-                          cursorColor = primaryColor,
-                          textSelectionColors =
-                              TextSelectionColors(
-                                  handleColor = primaryColor,
-                                  backgroundColor = primaryColor,
-                              )),
+          CustomTextField(
               value = name,
               onValueChange = { name = it },
-              label = { Text(context.getString(R.string.profile_screen_name_label)) },
-              singleLine = true)
+              label = context.getString(R.string.profile_screen_name_label),
+              maxLength = 40,
+              modifier = Modifier.testTag(EditProfileScreen.TEST_TAG_NAME_INPUT),
+          )
 
           Column(
               verticalArrangement = Arrangement.spacedBy(2.dp),


### PR DESCRIPTION
# Summary
The feedback from M2 mentioned:

> All user inputs should be sanitized to prevent long strings from breaking the UI. Currently, someone can input a very long name while signing up.

As a result, I limit the number of character of all inputs in the app.

# Details
To prevent reuse of code, I refactored an input in a new `CustomTextField` in order to have this configuration in one place only.