### PR TITLE
fix: ui jump when going from saved to planned

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -141,6 +141,9 @@ fun SavedHikesScreen(hikesViewModel: HikesViewModel, navigationActions: Navigati
 @Composable
 private fun PlannedHikes(hikes: List<StateFlow<Hike>>?, hikesViewModel: HikesViewModel) {
   val context = LocalContext.current
+  // Use fillMaxSize() to ensure consistent layout when switching between tabs
+  // This prevents unwanted UI resizing that can occur when sections have different
+  // numbers of items, particularly when transitioning between saved and planned hikes
   Column(modifier = Modifier.fillMaxSize()) {
     Text(
         context.getString(R.string.saved_hikes_screen_planned_section_title),
@@ -174,6 +177,9 @@ private fun PlannedHikes(hikes: List<StateFlow<Hike>>?, hikesViewModel: HikesVie
 @Composable
 private fun SavedHikes(savedHikes: List<StateFlow<Hike>>?, hikesViewModel: HikesViewModel) {
   val context = LocalContext.current
+  // Use fillMaxSize() to ensure consistent layout when switching between tabs
+  // This prevents unwanted UI resizing that can occur when sections have different
+  // numbers of items, particularly when transitioning between saved and planned hikes
   Column(modifier = Modifier.fillMaxSize()) {
     Text(
         context.getString(R.string.saved_hikes_screen_saved_section_title),

--- a/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/saved/SavedHikesScreen.kt
@@ -119,10 +119,10 @@ fun SavedHikesScreen(hikesViewModel: HikesViewModel, navigationActions: Navigati
                 Column {
                   // Display either the planned or saved hikes section
                   when (SavedHikesSection.values()[pageIndex]) {
-                    SavedHikesSection.Planned ->
-                        PlannedHikes(hikes = savedHikes, hikesViewModel = hikesViewModel)
                     SavedHikesSection.Saved ->
                         SavedHikes(savedHikes = savedHikes, hikesViewModel = hikesViewModel)
+                    SavedHikesSection.Planned ->
+                        PlannedHikes(hikes = savedHikes, hikesViewModel = hikesViewModel)
                   }
                 }
               }
@@ -141,29 +141,31 @@ fun SavedHikesScreen(hikesViewModel: HikesViewModel, navigationActions: Navigati
 @Composable
 private fun PlannedHikes(hikes: List<StateFlow<Hike>>?, hikesViewModel: HikesViewModel) {
   val context = LocalContext.current
-  Text(
-      context.getString(R.string.saved_hikes_screen_planned_section_title),
-      style = MaterialTheme.typography.titleLarge,
-      modifier =
-          Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE))
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(
+        context.getString(R.string.saved_hikes_screen_planned_section_title),
+        style = MaterialTheme.typography.titleLarge,
+        modifier =
+            Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_TITLE))
 
-  val plannedHikes =
-      hikes?.filter { it.value.plannedDate != null }?.sortedBy { it.value.plannedDate }
+    val plannedHikes =
+        hikes?.filter { it.value.plannedDate != null }?.sortedBy { it.value.plannedDate }
 
-  if (plannedHikes.isNullOrEmpty()) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      Text(
-          text = context.getString(R.string.saved_hikes_screen_planned_section_empty_message),
-          style = MaterialTheme.typography.bodyLarge,
-          modifier =
-              Modifier.padding(16.dp)
-                  .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE))
-    }
-  } else {
-    LazyColumn {
-      items(plannedHikes.size, key = { plannedHikes[it].value.id }) { index ->
-        val hike by plannedHikes[index].collectAsState()
-        SavedHikeCardFor(hike, hikesViewModel)
+    if (plannedHikes.isNullOrEmpty()) {
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = context.getString(R.string.saved_hikes_screen_planned_section_empty_message),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.padding(16.dp)
+                    .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_PLANNED_EMPTY_MESSAGE))
+      }
+    } else {
+      LazyColumn {
+        items(plannedHikes.size, key = { plannedHikes[it].value.id }) { index ->
+          val hike by plannedHikes[index].collectAsState()
+          SavedHikeCardFor(hike, hikesViewModel)
+        }
       }
     }
   }
@@ -172,25 +174,28 @@ private fun PlannedHikes(hikes: List<StateFlow<Hike>>?, hikesViewModel: HikesVie
 @Composable
 private fun SavedHikes(savedHikes: List<StateFlow<Hike>>?, hikesViewModel: HikesViewModel) {
   val context = LocalContext.current
-  Text(
-      context.getString(R.string.saved_hikes_screen_saved_section_title),
-      style = MaterialTheme.typography.titleLarge,
-      modifier = Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE))
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(
+        context.getString(R.string.saved_hikes_screen_saved_section_title),
+        style = MaterialTheme.typography.titleLarge,
+        modifier =
+            Modifier.padding(16.dp).testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_TITLE))
 
-  if (savedHikes.isNullOrEmpty()) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      Text(
-          text = context.getString(R.string.saved_hikes_screen_saved_section_empty_message),
-          style = MaterialTheme.typography.bodyLarge,
-          modifier =
-              Modifier.padding(16.dp)
-                  .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE))
-    }
-  } else {
-    LazyColumn {
-      items(savedHikes.size, key = { savedHikes[it].value.id }) { index ->
-        val hike by savedHikes[index].collectAsState()
-        SavedHikeCardFor(hike, hikesViewModel)
+    if (savedHikes.isNullOrEmpty()) {
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = context.getString(R.string.saved_hikes_screen_saved_section_empty_message),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.padding(16.dp)
+                    .testTag(SavedHikesScreen.TEST_TAG_SAVED_HIKES_SAVED_EMPTY_MESSAGE))
+      }
+    } else {
+      LazyColumn {
+        items(savedHikes.size, key = { savedHikes[it].value.id }) { index ->
+          val hike by savedHikes[index].collectAsState()
+          SavedHikeCardFor(hike, hikesViewModel)
+        }
       }
     }
   }


### PR DESCRIPTION
# Summary
We had a weird UI bug when going from saved to planned hikes. See images:
<img width="455" alt="image" src="https://github.com/user-attachments/assets/4d7c266f-408e-4faf-8bc5-72a9a37c2ae3">
<img width="455" alt="image" src="https://github.com/user-attachments/assets/6cb6c05a-a95f-4c1d-a3f1-0e2867339245">


# Details
The issues was arising when having more saved than planned hikes. I fixed this by adding a `Column` with `fillMaxSize` in order to make sure the title and list will take as much space as possible