### PR TITLE
feat: project user location on hike in run hike

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
@@ -29,6 +29,7 @@ import ch.hikemate.app.model.route.HikesViewModel
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.ui.components.CenteredErrorAction
 import ch.hikemate.app.ui.components.HikeCard
+import ch.hikemate.app.ui.components.LocationPermissionAlertDialog
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Route
 import ch.hikemate.app.ui.navigation.TEST_TAG_BOTTOM_BAR
@@ -378,14 +379,18 @@ class MapScreenTest : TestCase() {
     composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_CENTER_MAP_BUTTON).performClick()
 
     // Then an alert will be shown to ask for the permission
-    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_LOCATION_PERMISSION_ALERT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(LocationPermissionAlertDialog.TEST_TAG_LOCATION_PERMISSION_ALERT)
+        .assertIsDisplayed()
 
     // When the user clicks on the "No thanks" button
-    composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_NO_THANKS_ALERT_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(LocationPermissionAlertDialog.TEST_TAG_NO_THANKS_ALERT_BUTTON)
+        .performClick()
 
     // Then the alert disappears
     composeTestRule
-        .onNodeWithTag(MapScreen.TEST_TAG_LOCATION_PERMISSION_ALERT)
+        .onNodeWithTag(LocationPermissionAlertDialog.TEST_TAG_LOCATION_PERMISSION_ALERT)
         .assertIsNotDisplayed()
   }
 

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
@@ -357,13 +357,13 @@ class MapScreenTest : TestCase() {
     mockkObject(LocationUtils)
     every { LocationUtils.hasLocationPermission(any()) } returns true
     mockkObject(MapUtils)
-    every { MapUtils.centerMapOnUserLocation(any(), any(), any()) } returns Unit
+    every { MapUtils.centerMapOnLocation(any(), any(), any()) } returns Unit
 
     // When
     composeTestRule.onNodeWithTag(MapScreen.TEST_TAG_CENTER_MAP_BUTTON).performClick()
 
     // Then
-    io.mockk.verify { MapUtils.centerMapOnUserLocation(any(), any(), any()) }
+    io.mockk.verify { MapUtils.centerMapOnLocation(any(), any(), any()) }
   }
 
   @OptIn(ExperimentalPermissionsApi::class)

--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -379,29 +379,4 @@ class RunHikeScreenTest {
 
         verify(mockNavigationActions).goBack()
       }
-
-  @OptIn(ExperimentalPermissionsApi::class)
-  @Test
-  fun runHikeScreen_permissionGrantCenterTheMap() =
-      runTest(timeout = 5.seconds) {
-        // Given the user did not grant location permission to the app
-        mockkObject(LocationUtils)
-        every { LocationUtils.hasLocationPermission(any()) } returns false
-
-        setupCompleteScreenWithSelected(detailedHike)
-
-        // Then an alert will be shown to ask for the permission
-        composeTestRule
-            .onNodeWithTag(LocationPermissionAlertDialog.TEST_TAG_LOCATION_PERMISSION_ALERT)
-            .assertIsDisplayed()
-
-        // When the user clicks on the "No thanks" button
-        composeTestRule
-            .onNodeWithTag(LocationPermissionAlertDialog.TEST_TAG_GRANT_ALERT_BUTTON)
-            .performClick()
-
-        composeTestRule.waitForIdle()
-
-        verify(mockNavigationActions).goBack()
-      }
 }

--- a/app/src/main/java/ch/hikemate/app/ui/components/LocationPermissionAlertDialog.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/LocationPermissionAlertDialog.kt
@@ -1,0 +1,95 @@
+package ch.hikemate.app.ui.components
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import ch.hikemate.app.R
+import ch.hikemate.app.utils.PermissionUtils
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+
+object LocationPermissionAlertDialog {
+  const val TEST_TAG_LOCATION_PERMISSION_ALERT =
+      "LocationPermissionAlertDialogLocationPermissionAlert"
+  const val TEST_TAG_NO_THANKS_ALERT_BUTTON = "LocationPermissionAlertDialogNoThanksAlertButton"
+  const val TEST_TAG_GRANT_ALERT_BUTTON = "LocationPermissionAlertDialogGrantAlertButton"
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun LocationPermissionAlertDialog(
+    show: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    simpleMessage: Boolean,
+    locationPermissionState: MultiplePermissionsState,
+    context: Context = LocalContext.current,
+    modifier: Modifier = Modifier
+) {
+  if (!show) return
+
+  AlertDialog(
+      modifier = modifier.testTag(LocationPermissionAlertDialog.TEST_TAG_LOCATION_PERMISSION_ALERT),
+      icon = {
+        Icon(painter = painterResource(id = R.drawable.my_location), contentDescription = null)
+      },
+      title = { Text(text = stringResource(R.string.map_screen_location_rationale_title)) },
+      text = {
+        Text(
+            text =
+                stringResource(
+                    if (simpleMessage) R.string.map_screen_location_rationale_simple
+                    else R.string.map_screen_location_rationale))
+      },
+      onDismissRequest = onDismiss,
+      confirmButton = {
+        Button(
+            modifier = modifier.testTag(LocationPermissionAlertDialog.TEST_TAG_GRANT_ALERT_BUTTON),
+            onClick = {
+              onConfirm()
+              // If should show rationale is true, it is safe to launch permission requests
+              if (locationPermissionState.shouldShowRationale) {
+                locationPermissionState.launchMultiplePermissionRequest()
+              }
+
+              // If the user is asked for the first time, it is safe to launch permission requests
+              else if (PermissionUtils.firstTimeAskingPermission(
+                  context, android.Manifest.permission.ACCESS_FINE_LOCATION)) {
+                PermissionUtils.setFirstTimeAskingPermission(
+                    context, android.Manifest.permission.ACCESS_FINE_LOCATION, false)
+                PermissionUtils.setFirstTimeAskingPermission(
+                    context, android.Manifest.permission.ACCESS_COARSE_LOCATION, false)
+                locationPermissionState.launchMultiplePermissionRequest()
+              }
+
+              // Otherwise, the user should be brought to the settings page
+              else {
+                context.startActivity(
+                    Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.fromParts("package", context.packageName, null)))
+              }
+            }) {
+              Text(text = stringResource(R.string.map_screen_location_rationale_grant_button))
+            }
+      },
+      dismissButton = {
+        Button(
+            modifier =
+                modifier.testTag(LocationPermissionAlertDialog.TEST_TAG_NO_THANKS_ALERT_BUTTON),
+            onClick = onDismiss) {
+              Text(text = stringResource(R.string.map_screen_location_rationale_cancel_button))
+            }
+      })
+}

--- a/app/src/main/java/ch/hikemate/app/ui/components/LocationPermissionAlertDialog.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/LocationPermissionAlertDialog.kt
@@ -34,8 +34,8 @@ fun LocationPermissionAlertDialog(
     onConfirm: () -> Unit,
     simpleMessage: Boolean,
     locationPermissionState: MultiplePermissionsState,
-    context: Context = LocalContext.current,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    context: Context = LocalContext.current
 ) {
   if (!show) return
 

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailsScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailsScreen.kt
@@ -214,7 +214,7 @@ fun HikeDetailsContent(
     // Display the back button on top of the map
     BackButton(
         navigationActions = navigationActions,
-        modifier = Modifier.padding(top = 40.dp, start = 16.dp, end = 16.dp).safeDrawingPadding(),
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp).safeDrawingPadding(),
         onClick = { hikesViewModel.unselectHike() })
 
     // Zoom buttons at the bottom right of the screen

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -464,7 +464,7 @@ fun MapScreen(
                       // on
                       // the user's location
                       if (hasLocationPermission) {
-                        MapUtils.centerMapOnUserLocation(context, mapView, userLocationMarker)
+                        MapUtils.centerMapOnLocation(context, mapView, userLocationMarker)
                       }
                       // If the user yet needs to grant the permission, show a custom educational
                       // alert

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -1,6 +1,7 @@
 package ch.hikemate.app.ui.map
 
 import android.location.Location
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,6 +47,7 @@ import ch.hikemate.app.ui.components.CenteredErrorAction
 import ch.hikemate.app.ui.components.DetailRow
 import ch.hikemate.app.ui.components.ElevationGraph
 import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
+import ch.hikemate.app.ui.components.LocationPermissionAlertDialog
 import ch.hikemate.app.ui.components.WithDetailedHike
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Screen
@@ -168,6 +170,7 @@ private fun RunHikeContent(hike: DetailedHike, navigationActions: NavigationActi
 
   DisposableEffect(Unit) {
     val hasLocationPermission = LocationUtils.hasLocationPermission(locationPermissionState)
+    Log.d("RunHikeScreen", "Has location permission: $hasLocationPermission")
     // If the user has granted at least one of the two permissions, center the map
     // on the user's location
     if (hasLocationPermission) {

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.ui.map
 
+import android.location.Location
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -36,6 +38,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import ch.hikemate.app.R
 import ch.hikemate.app.model.route.DetailedHike
 import ch.hikemate.app.model.route.HikesViewModel
+import ch.hikemate.app.model.route.LatLong
 import ch.hikemate.app.ui.components.BackButton
 import ch.hikemate.app.ui.components.BigButton
 import ch.hikemate.app.ui.components.ButtonType
@@ -46,12 +49,16 @@ import ch.hikemate.app.ui.components.ElevationGraphStyleProperties
 import ch.hikemate.app.ui.components.WithDetailedHike
 import ch.hikemate.app.ui.navigation.NavigationActions
 import ch.hikemate.app.ui.navigation.Screen
+import ch.hikemate.app.utils.LocationUtils
 import ch.hikemate.app.utils.MapUtils
-import kotlin.math.max
-import kotlin.math.min
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationResult
 import kotlin.math.roundToInt
 import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
 
 object RunHikeScreen {
   const val TEST_TAG_MAP = "runHikeScreenMap"
@@ -63,6 +70,10 @@ object RunHikeScreen {
   const val TEST_TAG_STOP_HIKE_BUTTON = "runHikeScreenStopHikeButton"
   const val TEST_TAG_TOTAL_DISTANCE_TEXT = "runHikeScreenTotalDistanceText"
   const val TEST_TAG_PROGRESS_TEXT = "runHikeScreenProgressText"
+  const val TEST_TAG_CENTER_MAP_BUTTON = "runHikeScreenCenterMapButton"
+
+  // The maximum distance to be considered on a hike
+  const val MAX_DISTANCE_TO_CONSIDER_HIKE = 50.0 // meters
 }
 
 @Composable
@@ -100,8 +111,19 @@ fun RunHikeScreen(
       })
 }
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 private fun RunHikeContent(hike: DetailedHike, navigationActions: NavigationActions) {
+  val context = LocalContext.current
+  val locationPermissionState =
+      rememberMultiplePermissionsState(
+          permissions =
+              listOf(
+                  android.Manifest.permission.ACCESS_FINE_LOCATION,
+                  android.Manifest.permission.ACCESS_COARSE_LOCATION))
+  var showLocationPermissionDialog by remember { mutableStateOf(false) }
+  var centerMapOnUserPosition by remember { mutableStateOf(false) }
+
   // Avoids the app crashing when spamming the back button
   var wantToNavigateBack by remember { mutableStateOf(false) }
   LaunchedEffect(wantToNavigateBack) {
@@ -111,10 +133,77 @@ private fun RunHikeContent(hike: DetailedHike, navigationActions: NavigationActi
     }
   }
 
-  Box(modifier = Modifier.fillMaxSize().testTag(Screen.RUN_HIKE)) {
-    // Display the map
-    val mapView = runHikeMap(hike)
+  // Display the map
+  val mapView = runHikeMap(hike)
 
+  var userLocationMarker: Marker? by remember { mutableStateOf(null) }
+
+  // We need to keep a reference to the instance of location callback, this way we can unregister
+  // it using the same reference, for example when the permission is revoked.
+  val locationUpdatedCallback = remember {
+    object : LocationCallback() {
+      override fun onLocationResult(locationResult: LocationResult) {
+        userLocationMarker = parseLocationUpdate(locationResult, userLocationMarker, mapView, hike)
+        if (centerMapOnUserPosition &&
+            userLocationMarker != null &&
+            userLocationMarker?.position != null)
+            MapUtils.centerMapOnLocation(mapView, userLocationMarker!!.position)
+      }
+    }
+  }
+
+  LaunchedEffect(locationPermissionState.revokedPermissions) {
+    // Update the map and start/stop listening for location updates
+    LocationUtils.onLocationPermissionsUpdated(
+        context,
+        locationPermissionState,
+        mapView,
+        locationUpdatedCallback,
+        centerMapOnUserPosition,
+        userLocationMarker)
+
+    // Once the update has been made, reset the flag to avoid re-centering the map
+    centerMapOnUserPosition = false
+  }
+
+  DisposableEffect(Unit) {
+    val hasLocationPermission = LocationUtils.hasLocationPermission(locationPermissionState)
+    // If the user has granted at least one of the two permissions, center the map
+    // on the user's location
+    if (hasLocationPermission) {
+      MapUtils.centerMapOnLocation(context, mapView, userLocationMarker)
+    }
+    // If the user yet needs to grant the permission, show a custom educational
+    // alert
+    else {
+      showLocationPermissionDialog = true
+    }
+    onDispose {
+      LocationUtils.stopUserLocationUpdates(context, locationUpdatedCallback)
+      mapView.overlays.clear()
+      mapView.onPause()
+      mapView.onDetach()
+    }
+  }
+
+  // Show a dialog to explain the user why the location permission is needed
+  // Only shows when the user has clicked on the "center map on my position" button
+  LocationPermissionAlertDialog(
+      show = showLocationPermissionDialog,
+      onConfirm = {
+        showLocationPermissionDialog = false
+        centerMapOnUserPosition = true
+      },
+      onDismiss = {
+        showLocationPermissionDialog = false
+        centerMapOnUserPosition = false
+        wantToNavigateBack = true
+      },
+      simpleMessage = !locationPermissionState.shouldShowRationale,
+      locationPermissionState = locationPermissionState,
+      context = context)
+
+  Box(modifier = Modifier.fillMaxSize().testTag(Screen.RUN_HIKE)) {
     // Back Button at the top of the screen
     BackButton(
         navigationActions = navigationActions,
@@ -122,6 +211,18 @@ private fun RunHikeContent(hike: DetailedHike, navigationActions: NavigationActi
             Modifier.padding(top = 40.dp, start = 16.dp, end = 16.dp)
                 .testTag(RunHikeScreen.TEST_TAG_BACK_BUTTON),
         onClick = { wantToNavigateBack = true })
+
+    // Button to center the map on the user's location
+    MapMyLocationButton(
+        onClick = {
+          centerMapOnUserPosition = true
+          if (userLocationMarker != null && userLocationMarker?.position != null)
+              MapUtils.centerMapOnLocation(mapView, userLocationMarker!!.position)
+        },
+        modifier =
+            Modifier.align(Alignment.BottomStart)
+                .padding(bottom = MapScreen.BOTTOM_SHEET_SCAFFOLD_MID_HEIGHT + 8.dp)
+                .testTag(RunHikeScreen.TEST_TAG_CENTER_MAP_BUTTON))
 
     // Zoom buttons at the bottom right of the screen
     ZoomMapButton(
@@ -134,6 +235,55 @@ private fun RunHikeContent(hike: DetailedHike, navigationActions: NavigationActi
 
     // Display the bottom sheet with the hike details
     RunHikeBottomSheet(hike = hike, onStopTheRun = { wantToNavigateBack = true })
+  }
+}
+
+/**
+ * Parses a location result and updates the user's position on the map.
+ *
+ * @param locationResult The location result to parse
+ * @param userLocationMarker The marker representing the previous user's location on the map
+ * @param mapView The map view where the user's location is displayed
+ * @param hike The hike where the user is running
+ */
+private fun parseLocationUpdate(
+    locationResult: LocationResult,
+    userLocationMarker: Marker?,
+    mapView: MapView,
+    hike: DetailedHike
+): Marker? {
+  return if (locationResult.lastLocation == null) {
+    MapUtils.clearUserPosition(userLocationMarker, mapView, invalidate = true)
+    null
+  } else {
+    val routeProjectionResponse =
+        LocationUtils.projectLocationOnHike(
+            locationResult.lastLocation!!.let { LatLong(it.latitude, it.longitude) }, hike)
+    if (routeProjectionResponse != null) {
+      if (routeProjectionResponse.distanceFromRoute > RunHikeScreen.MAX_DISTANCE_TO_CONSIDER_HIKE) {
+        MapUtils.updateUserPosition(
+            userLocationMarker,
+            mapView,
+            locationResult.lastLocation!!.let { location ->
+              Location("").apply {
+                latitude = location.latitude
+                longitude = location.longitude
+              }
+            })
+      } else {
+        MapUtils.updateUserPosition(
+            userLocationMarker,
+            mapView,
+            routeProjectionResponse.projectedLocation.let { location ->
+              Location("").apply {
+                latitude = location.lat
+                longitude = location.lon
+              }
+            })
+      }
+    } else {
+      null
+    }
   }
 }
 
@@ -162,22 +312,6 @@ private fun runHikeMap(hike: DetailedHike): MapView {
     }
   }
 
-  // When the map is ready, it will have computed its bounding box
-  mapView.addOnFirstLayoutListener { _, _, _, _, _ ->
-    // Limit the vertical scrollable area to avoid the user scrolling too far from the hike
-    mapView.setScrollableAreaLimitLatitude(
-        min(MapScreen.MAP_MAX_LATITUDE, mapView.boundingBox.latNorth),
-        max(MapScreen.MAP_MIN_LATITUDE, mapView.boundingBox.latSouth),
-        HikeDetailScreen.MAP_BOUNDS_MARGIN)
-    if (hike.bounds.maxLon < HikeDetailScreen.MAP_MAX_LONGITUDE ||
-        hike.bounds.minLon > HikeDetailScreen.MAP_MIN_LONGITUDE) {
-      mapView.setScrollableAreaLimitLongitude(
-          max(HikeDetailScreen.MAP_MIN_LONGITUDE, mapView.boundingBox.lonWest),
-          min(HikeDetailScreen.MAP_MAX_LONGITUDE, mapView.boundingBox.lonEast),
-          HikeDetailScreen.MAP_BOUNDS_MARGIN)
-    }
-  }
-
   MapUtils.showHikeOnMap(
       mapView = mapView, waypoints = hike.waypoints, color = hike.color, onLineClick = {})
 
@@ -192,7 +326,7 @@ private fun runHikeMap(hike: DetailedHike): MapView {
   return mapView
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
 @Composable
 private fun RunHikeBottomSheet(
     hike: DetailedHike,

--- a/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
@@ -211,7 +211,7 @@ object LocationUtils {
             .show()
       }
       if (centerMapOnUserPosition) {
-        MapUtils.centerMapOnUserLocation(context, mapView, userLocationMarker)
+        MapUtils.centerMapOnLocation(context, mapView, userLocationMarker)
       }
     }
 

--- a/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
@@ -190,20 +190,20 @@ object LocationUtils {
       userLocationMarker: Marker?
   ) {
     Log.d(
-        MapScreen.LOG_TAG,
+        LOG_TAG,
         "Location permission changed (revoked: ${locationPermissionState.revokedPermissions})")
     val hasLocationPermission = hasLocationPermission(locationPermissionState)
 
     // The user just enabled location permission for the app, start location features
     if (hasLocationPermission) {
-      Log.d(MapScreen.LOG_TAG, "Location permission granted, requesting location updates")
+      Log.d(LOG_TAG, "Location permission granted, requesting location updates")
       PermissionUtils.setFirstTimeAskingPermission(
           context, android.Manifest.permission.ACCESS_FINE_LOCATION, true)
       PermissionUtils.setFirstTimeAskingPermission(
           context, android.Manifest.permission.ACCESS_COARSE_LOCATION, true)
       val featuresEnabledSuccessfully = startUserLocationUpdates(context, locationUpdatedCallback)
       if (!featuresEnabledSuccessfully) {
-        Log.e(MapScreen.LOG_TAG, "Failed to enable location features")
+        Log.e(LOG_TAG, "Failed to enable location features")
         Toast.makeText(
                 context,
                 context.getString(R.string.map_screen_location_features_failed),

--- a/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
@@ -228,7 +228,7 @@ object MapUtils {
    * @param userLocationMarker The marker representing the user's location on the map
    * @see [LocationUtils.getUserLocation]
    */
-  fun centerMapOnUserLocation(context: Context, mapView: MapView, userLocationMarker: Marker?) {
+  fun centerMapOnLocation(context: Context, mapView: MapView, userLocationMarker: Marker?) {
     LocationUtils.getUserLocation(
         context = context,
         onLocation = { location ->
@@ -246,24 +246,37 @@ object MapUtils {
                 .show()
           } else {
             // Center the map on the user's location
-            centerMapOnUserLocation(mapView, location)
+            centerMapOnLocation(mapView, location)
           }
         })
   }
 
   /**
-   * Centers the map on the user's location.
+   * Centers the map on a given location.
    *
    * Animates the map so that the transition is smooth and not instant.
    *
    * @param mapView The map view to center
-   * @param location The user's location to center the map on
+   * @param location The location to center the map on
    */
-  fun centerMapOnUserLocation(mapView: MapView, location: Location) {
+  fun centerMapOnLocation(mapView: MapView, location: Location) {
     mapView.controller.animateTo(
         GeoPoint(location.latitude, location.longitude),
         mapView.zoomLevelDouble,
         MapScreen.CENTER_MAP_ANIMATION_TIME)
+  }
+
+  /**
+   * Centers the map on a given location.
+   *
+   * Animates the map so that the transition is smooth and not instant.
+   *
+   * @param mapView The map view to center
+   * @param location The location to center the map on
+   */
+  fun centerMapOnLocation(mapView: MapView, location: GeoPoint) {
+    mapView.controller.animateTo(
+        location, mapView.zoomLevelDouble, MapScreen.CENTER_MAP_ANIMATION_TIME)
   }
 
   data class MapViewState(

--- a/app/src/test/java/ch/hikemate/app/utils/MapUtilsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/utils/MapUtilsTest.kt
@@ -147,7 +147,7 @@ class MapUtilsTest {
   fun centerMapOnUserLocationCentersMapIfLocationIsReceived() {
     // Given
     mockkObject(MapUtils)
-    every { MapUtils.centerMapOnUserLocation(any(), any()) } returns Unit
+    every { MapUtils.centerMapOnLocation(any(), any<Location>()) } returns Unit
     mockkObject(LocationUtils)
     val callbackSlot = slot<(Location?) -> Unit>()
     every { LocationUtils.getUserLocation(any(), capture(callbackSlot), any(), any()) } returns Unit
@@ -158,7 +158,7 @@ class MapUtilsTest {
     every { fakeLocation.longitude } returns 7.0
 
     // When
-    MapUtils.centerMapOnUserLocation(context, map, null)
+    MapUtils.centerMapOnLocation(context, map, null)
 
     // Then
     verify { LocationUtils.getUserLocation(context, any(), any(), any()) }
@@ -167,14 +167,14 @@ class MapUtilsTest {
     callbackSlot.captured(fakeLocation)
 
     // Then
-    verify { MapUtils.centerMapOnUserLocation(map, fakeLocation) }
+    verify { MapUtils.centerMapOnLocation(map, fakeLocation) }
   }
 
   @Test
   fun centerMapOnUserLocationClearsUserPositionIfLocationIsNull() {
     // Given
     mockkObject(MapUtils)
-    every { MapUtils.centerMapOnUserLocation(any(), any()) } returns Unit
+    every { MapUtils.centerMapOnLocation(any(), any<Location>()) } returns Unit
     mockkObject(LocationUtils)
     val callbackSlot = slot<(Location?) -> Unit>()
     every { LocationUtils.getUserLocation(any(), capture(callbackSlot), any(), any()) } returns Unit
@@ -187,7 +187,7 @@ class MapUtilsTest {
     every { fakeToast.show() } returns Unit
 
     // When
-    MapUtils.centerMapOnUserLocation(context, map, null)
+    MapUtils.centerMapOnLocation(context, map, null)
 
     // Then
     verify { LocationUtils.getUserLocation(context, any(), any(), any()) }
@@ -209,7 +209,7 @@ class MapUtilsTest {
     every { location.longitude } returns 7.0
 
     // When
-    MapUtils.centerMapOnUserLocation(map, location)
+    MapUtils.centerMapOnLocation(map, location)
     Thread.sleep(500)
 
     // Then


### PR DESCRIPTION
# Summary
- **Objective:** Enhance user location handling on run hike screen and map centering functionality
- **Implementation:** Refactored `RunHikeScreen.kt`, `MapUtils.kt`, and related utility classes to improve location permissions, map interaction, and user experience

# Details
**Code Changes:**
- Added a new button to center the map on the user's location
- Introduced a comprehensive location permission handling mechanism
- Implemented location update management in the `RunHikeScreen`
- Renamed `centerMapOnUserLocation` to `centerMapOnLocation` to support more flexible location centering
- Updated related test files to reflect the new implementation

The changes focus on improving the user's ability to interact with the map during a hike:
- Enhanced location tracking and permission management
- Provided a user-friendly way to center the map on the current location
- Refactored existing location and map utility functions for better flexibility
- Maintained consistent UI and functionality across different screens

The implementation suggests a potential future enhancement for a "follow mode" where the map automatically tracks the user's location, with the ability to switch between automatic and manual map exploration.

# Old UI
![Screenshot_20241212_162544](https://github.com/user-attachments/assets/7d659ecd-50dc-4892-94dc-d59bf76a53c9)

# New UI

## Location asked when arriving at the screen
![Screenshot_20241212_162649](https://github.com/user-attachments/assets/b1ed88b2-cbd8-4be8-8a6d-9693532b9f6a)

## Location on the hike
![Screenshot_20241212_162949](https://github.com/user-attachments/assets/b632ba16-d46f-485c-aa3b-5c4d7b1e2d7f)


