### PR TITLE
fix: bottom-bar nav overlapping with hikes

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -440,8 +440,8 @@ fun MapScreen(
         BottomBarNavigation(
             onTabSelect = { navigationActions.navigateTo(it) },
             tabList = LIST_TOP_LEVEL_DESTINATIONS,
-            selectedItem = Route.MAP) {
-              Box(modifier = Modifier.fillMaxSize().testTag(Screen.MAP)) {
+            selectedItem = Route.MAP) { p ->
+              Box(modifier = Modifier.fillMaxSize().padding(p).testTag(Screen.MAP)) {
                 // Jetpack Compose is a relatively recent framework for implementing Android UIs.
                 // OSMDroid
                 // is


### PR DESCRIPTION
# Summary
The last hike of the list was hidden behind the bottom bar. I fixed it by using the padding given my the latter.