### PR TITLE
feat: increase location updates freq

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -145,7 +145,7 @@ object MapScreen {
    * defined empirically to avoid draining the battery too much while still providing a good
    * experience to the user.
    */
-  const val USER_LOCATION_UPDATE_INTERVAL = 5000L
+  const val USER_LOCATION_UPDATE_INTERVAL = 500L
 
   /**
    * (Config) Duration in milliseconds of the animation when centering the map on the user's


### PR DESCRIPTION
# Summary

When using the run hikes screen, updating the user's location every 5 seconds is a bit slow, does not feel smooth. We empirically observed that a delay of `500` milliseconds is fine in terms of performance and provides a way better user experience in terms of smoothness.