### PR TITLE
fix: unplan this hike color

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailsScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailsScreen.kt
@@ -93,12 +93,12 @@ import ch.hikemate.app.ui.navigation.Screen
 import ch.hikemate.app.utils.MapUtils
 import ch.hikemate.app.utils.humanReadableFormat
 import com.google.firebase.Timestamp
-import kotlinx.coroutines.FlowPreview
 import java.util.Date
 import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
 
     <!-- Hike Details Screen - Date Picker -->
     <string name="hike_detail_screen_date_picker_cancel_button">Cancel</string>
-    <string name="hike_detail_screen_date_picker_confirm_button">Plan this hike!</string>
+    <string name="hike_detail_screen_date_picker_confirm_button">Plan this hike</string>
     <string name="hike_detail_screen_date_picker_unplan_hike_button">Un-plan this hike</string>
 
     <!--Run Hike Screen -->


### PR DESCRIPTION
# Summary
As stated by the coaches, when the button is "Un-plan this hike", it should be in a red color to show the user it's not the same type of action as planning a hike.
![image](https://github.com/user-attachments/assets/00d37134-5519-4008-9463-f786b0b25246)


# Details
I also added a little improvement: when showing the dialog, the default day would be the planned date if set. This make the button "Un-plan this hike" by default.