### PR TITLE
feat: display actual progression and user elevation in run

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/RunHikeScreenTest.kt
@@ -372,10 +372,7 @@ class RunHikeScreenTest {
       runTest(timeout = 5.seconds) {
         setupCompleteScreenWithSelected(detailedHike)
 
-        composeTestRule
-            .onNodeWithTag(RunHikeScreen.TEST_TAG_PROGRESS_TEXT)
-            .assertIsDisplayed()
-            .assert(hasText("23% complete"))
+        composeTestRule.onNodeWithTag(RunHikeScreen.TEST_TAG_PROGRESS_TEXT).assertIsDisplayed()
       }
 
   @Test

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -170,14 +170,19 @@ private fun RunHikeContent(
     }
 
     var userLocationMarker: Marker? by remember { mutableStateOf(null) }
+    var completionPercentage: Int? by remember { mutableStateOf(null) }
+    var userElevation: Double? by remember { mutableStateOf(null) }
 
     // We need to keep a reference to the instance of location callback, this way we can unregister
     // it using the same reference, for example when the permission is revoked.
     val locationUpdatedCallback = remember {
       object : LocationCallback() {
         override fun onLocationResult(locationResult: LocationResult) {
-          userLocationMarker =
+          val locationParsed =
               parseLocationUpdate(locationResult, userLocationMarker, mapView, hike)
+          userLocationMarker = locationParsed.first
+          completionPercentage = locationParsed.second
+          userElevation = locationParsed.third
           if (centerMapOnUserPosition &&
               userLocationMarker != null &&
               userLocationMarker?.position != null)
@@ -269,7 +274,11 @@ private fun RunHikeContent(
                   .testTag(RunHikeScreen.TEST_TAG_ZOOM_BUTTONS))
 
       // Display the bottom sheet with the hike details
-      RunHikeBottomSheet(hike = hike, onStopTheRun = { wantToNavigateBack = true })
+      RunHikeBottomSheet(
+          hike = hike,
+          completionPercentage = completionPercentage,
+          userElevation = userElevation,
+          onStopTheRun = { wantToNavigateBack = true })
     }
   }
 }
@@ -281,21 +290,24 @@ private fun RunHikeContent(
  * @param userLocationMarker The marker representing the previous user's location on the map
  * @param mapView The map view where the user's location is displayed
  * @param hike The hike where the user is running
+ * @return A triple with the updated user's location marker, the completion percentage of the hike
+ *   and the elevation of the user's location.
  */
 private fun parseLocationUpdate(
     locationResult: LocationResult,
     userLocationMarker: Marker?,
     mapView: MapView,
     hike: DetailedHike
-): Marker? {
+): Triple<Marker?, Int?, Double?> {
   if (locationResult.lastLocation == null) {
     MapUtils.clearUserPosition(userLocationMarker, mapView, invalidate = true)
-    return null
+    return Triple(null, null, null)
   }
 
   val loc = locationResult.lastLocation!!
   val routeProjectionResponse =
-      LocationUtils.projectLocationOnHike(LatLong(loc.latitude, loc.longitude), hike) ?: return null
+      LocationUtils.projectLocationOnHike(LatLong(loc.latitude, loc.longitude), hike)
+          ?: return Triple(null, null, null)
 
   val newLocation =
       if (routeProjectionResponse.distanceFromRoute > RunHikeScreen.MAX_DISTANCE_TO_CONSIDER_HIKE) {
@@ -314,7 +326,17 @@ private fun parseLocationUpdate(
         }
       }
 
-  return MapUtils.updateUserPosition(userLocationMarker, mapView, newLocation)
+  val marker = MapUtils.updateUserPosition(userLocationMarker, mapView, newLocation)
+  // Progress distance is in meters, hike distance is in kilometers
+  val completionPercentage =
+      if (routeProjectionResponse.distanceFromRoute > RunHikeScreen.MAX_DISTANCE_TO_CONSIDER_HIKE)
+          null
+      else (routeProjectionResponse.progressDistance * 0.1 / hike.distance).toInt()
+  val currentElevation =
+      if (routeProjectionResponse.distanceFromRoute > RunHikeScreen.MAX_DISTANCE_TO_CONSIDER_HIKE)
+          null
+      else routeProjectionResponse.projectedLocationElevation
+  return Triple(marker, completionPercentage, currentElevation)
 }
 
 @Composable
@@ -470,6 +492,8 @@ private fun launchedEffectLoadingOfFacilities(
 @Composable
 private fun RunHikeBottomSheet(
     hike: DetailedHike,
+    completionPercentage: Int? = null,
+    userElevation: Double? = null,
     onStopTheRun: () -> Unit,
 ) {
   val scaffoldState = rememberBottomSheetScaffoldState()
@@ -515,9 +539,13 @@ private fun RunHikeBottomSheet(
                   )
                   Text(
                       // Displays the progress percentage below the graph
-                      // TODO hardcoded as 23% for now
                       text =
-                          stringResource(R.string.run_hike_screen_progress_percentage_format, 23),
+                          if (completionPercentage == null)
+                              stringResource(R.string.run_hike_screen_progress_percentage_no_data)
+                          else
+                              stringResource(
+                                  R.string.run_hike_screen_progress_percentage_format,
+                                  completionPercentage),
                       style = MaterialTheme.typography.bodyLarge,
                       color = hikeColor,
                       fontWeight = FontWeight.Bold,
@@ -541,8 +569,13 @@ private fun RunHikeBottomSheet(
 
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_current_elevation),
-                // TODO hardcoded to 50m for now
-                value = stringResource(R.string.run_hike_screen_value_format_current_elevation, 50))
+                value =
+                    if (userElevation == null)
+                        stringResource(R.string.run_hike_screen_value_current_elevation_no_data)
+                    else
+                        stringResource(
+                            R.string.run_hike_screen_value_format_current_elevation,
+                            userElevation.roundToInt()))
             DetailRow(
                 label = stringResource(R.string.run_hike_screen_label_elevation_gain),
                 value =

--- a/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
@@ -245,7 +245,8 @@ object LocationUtils {
           progressDistance = projected.distanceTo(segment.start),
           distanceFromRoute = location.distanceTo(projected),
           segment = segment,
-          indexToSegment = 0)
+          indexToSegment = 0,
+          projectedLocationElevation = route.elevation[0])
     }
 
     // Find closest segment by checking all segment
@@ -277,7 +278,8 @@ object LocationUtils {
         progressDistance = progressDistance,
         distanceFromRoute = minDistance,
         segment = closestSegment,
-        indexToSegment = closestSegmentIndex)
+        indexToSegment = closestSegmentIndex,
+        projectedLocationElevation = route.elevation[closestSegmentIndex])
   }
 
   /**

--- a/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/LocationUtils.kt
@@ -246,7 +246,7 @@ object LocationUtils {
           distanceFromRoute = location.distanceTo(projected),
           segment = segment,
           indexToSegment = 0,
-          projectedLocationElevation = route.elevation[0])
+          projectedLocationElevation = route.elevation.getOrNull(0))
     }
 
     // Find closest segment by checking all segment
@@ -279,7 +279,7 @@ object LocationUtils {
         distanceFromRoute = minDistance,
         segment = closestSegment,
         indexToSegment = closestSegmentIndex,
-        projectedLocationElevation = route.elevation[closestSegmentIndex])
+        projectedLocationElevation = route.elevation.getOrNull(closestSegmentIndex))
   }
 
   /**

--- a/app/src/main/java/ch/hikemate/app/utils/RouteUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/RouteUtils.kt
@@ -113,6 +113,6 @@ object RouteUtils {
       val distanceFromRoute: Double,
       val segment: RouteSegment,
       val indexToSegment: Int,
-      val projectedLocationElevation: Double
+      val projectedLocationElevation: Double?
   )
 }

--- a/app/src/main/java/ch/hikemate/app/utils/RouteUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/RouteUtils.kt
@@ -112,6 +112,7 @@ object RouteUtils {
       val progressDistance: Double,
       val distanceFromRoute: Double,
       val segment: RouteSegment,
-      val indexToSegment: Int
+      val indexToSegment: Int,
+      val projectedLocationElevation: Double
   )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,8 +111,10 @@
     <string name="run_hike_screen_zero_distance_progress_value">0km</string>
     <string name="run_hike_screen_distance_progress_value_format">%.2fkm</string>
     <string name="run_hike_screen_progress_percentage_format">%d%% complete</string>
+    <string name="run_hike_screen_progress_percentage_no_data">-</string>
     <string name="run_hike_screen_label_current_elevation">Current Elevation</string>
     <string name="run_hike_screen_value_format_current_elevation">%dm</string>
+    <string name="run_hike_screen_value_current_elevation_no_data">-</string>
     <string name="run_hike_screen_label_elevation_gain">Elevation Gain</string>
     <string name="run_hike_screen_value_format_elevation_gain">%dm</string>
     <string name="run_hike_screen_label_estimated_time">Estimated time</string>

--- a/app/src/test/java/ch/hikemate/app/utils/LocationUtilsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/utils/LocationUtilsTest.kt
@@ -229,7 +229,8 @@ class LocationUtilsTest {
 
     // Progress should be distance from start to projection
     assertEquals(distanceFromSegmentStart, result.progressDistance, EPSILON)
-    assertEquals(result.projectedLocationElevation, 150.0, EPSILON)
+    assertNotNull(result.projectedLocationElevation)
+    assertEquals(result.projectedLocationElevation!!, 150.0, EPSILON)
   }
 
   @Test
@@ -269,7 +270,8 @@ class LocationUtilsTest {
       // Progress should only be distance from start of first segment
       val expectedProgress = result.projectedLocation.distanceTo(route.segments[0].start)
       assertEquals(expectedProgress, result.progressDistance, EPSILON)
-      assertEquals(result.projectedLocationElevation, 10.0, EPSILON)
+      assertNotNull(result.projectedLocationElevation)
+      assertEquals(result.projectedLocationElevation!!, 10.0, EPSILON)
     }
 
     run {
@@ -285,7 +287,8 @@ class LocationUtilsTest {
       val expectedProgress =
           route.segments[0].length + result.projectedLocation.distanceTo(result.segment.start)
       assertEquals(expectedProgress, result.progressDistance, EPSILON)
-      assertEquals(result.projectedLocationElevation, 20.0, EPSILON)
+      assertNotNull(result.projectedLocationElevation)
+      assertEquals(result.projectedLocationElevation!!, 20.0, EPSILON)
     }
 
     run {
@@ -303,7 +306,8 @@ class LocationUtilsTest {
               route.segments[1].length +
               result.projectedLocation.distanceTo(result.segment.start)
       assertEquals(expectedProgress, result.progressDistance, EPSILON)
-      assertEquals(result.projectedLocationElevation, 30.0, EPSILON)
+      assertNotNull(result.projectedLocationElevation)
+      assertEquals(result.projectedLocationElevation!!, 30.0, EPSILON)
     }
   }
 

--- a/app/src/test/java/ch/hikemate/app/utils/LocationUtilsTest.kt
+++ b/app/src/test/java/ch/hikemate/app/utils/LocationUtilsTest.kt
@@ -203,7 +203,7 @@ class LocationUtilsTest {
             description = null,
             bounds = Bounds(44.0, 6.0, 46.0, 8.0),
             waypoints = listOf(LatLong(45.0, 7.0), LatLong(45.0, 8.0)),
-            elevation = listOf(0.0, 0.0),
+            elevation = listOf(150.0, 150.0),
             distance = 0.0,
             estimatedTime = 0.0,
             elevationGain = 0.0,
@@ -229,6 +229,7 @@ class LocationUtilsTest {
 
     // Progress should be distance from start to projection
     assertEquals(distanceFromSegmentStart, result.progressDistance, EPSILON)
+    assertEquals(result.projectedLocationElevation, 150.0, EPSILON)
   }
 
   @Test
@@ -249,7 +250,7 @@ class LocationUtilsTest {
                     LatLong(45.5, 7.5), // End of second segment (vertical)
                     LatLong(45.5, 8.0) // End of third segment (horizontal)
                     ),
-            elevation = listOf(0.0, 0.0, 0.0, 0.0),
+            elevation = listOf(10.0, 20.0, 30.0, 40.0),
             distance = 0.0,
             estimatedTime = 0.0,
             elevationGain = 0.0,
@@ -268,6 +269,7 @@ class LocationUtilsTest {
       // Progress should only be distance from start of first segment
       val expectedProgress = result.projectedLocation.distanceTo(route.segments[0].start)
       assertEquals(expectedProgress, result.progressDistance, EPSILON)
+      assertEquals(result.projectedLocationElevation, 10.0, EPSILON)
     }
 
     run {
@@ -283,6 +285,7 @@ class LocationUtilsTest {
       val expectedProgress =
           route.segments[0].length + result.projectedLocation.distanceTo(result.segment.start)
       assertEquals(expectedProgress, result.progressDistance, EPSILON)
+      assertEquals(result.projectedLocationElevation, 20.0, EPSILON)
     }
 
     run {
@@ -300,6 +303,7 @@ class LocationUtilsTest {
               route.segments[1].length +
               result.projectedLocation.distanceTo(result.segment.start)
       assertEquals(expectedProgress, result.progressDistance, EPSILON)
+      assertEquals(result.projectedLocationElevation, 30.0, EPSILON)
     }
   }
 


### PR DESCRIPTION
# Summary
The current elevation and progress were fake in the run hike screen. This PR changed this to display the actual progression and user elevation.

To get the elevation of the user, I retrieve the elevation of the **starting point of the segment on which the user is projected on**. This is some sort of estimation but is way faster than actually retrieving the elevation of the user from the API.