### PR TITLE
fix: fix back buttons double clicks

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/profile/DeleteAccountScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/profile/DeleteAccountScreenTest.kt
@@ -68,6 +68,8 @@ class DeleteAccountScreenTest : TestCase() {
     setUpActivityEmailProvider()
     composeTestRule.onNodeWithTag(BackButton.BACK_BUTTON_TEST_TAG).performClick()
 
+    composeTestRule.waitForIdle()
+
     verify { navigationActions.goBack() }
   }
 

--- a/app/src/main/java/ch/hikemate/app/ui/components/BackButton.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/BackButton.kt
@@ -12,6 +12,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -34,8 +39,18 @@ fun BackButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = { navigationActions.goBack() }
 ) {
+
+  var wantsToClick by remember { mutableStateOf(false) }
+
+  LaunchedEffect(wantsToClick) {
+    if (wantsToClick) {
+      onClick()
+      wantsToClick = false
+    }
+  }
+
   IconButton(
-      onClick = { onClick() },
+      onClick = { wantsToClick = true },
       modifier =
           modifier
               .testTag(BackButton.BACK_BUTTON_TEST_TAG)


### PR DESCRIPTION
# Summary
- This PR simply removes the ability to multi go back by multi clicking on the back button.

# Details
- Clicking too fast on the BackButton would trigger multiple goBack, and raise logical issues