### PR TITLE
feat: display the starting of a hike

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/ui/map/MapScreenTest.kt
@@ -26,6 +26,7 @@ import ch.hikemate.app.model.route.Bounds
 import ch.hikemate.app.model.route.HikeRoute
 import ch.hikemate.app.model.route.HikeRoutesRepository
 import ch.hikemate.app.model.route.HikesViewModel
+import ch.hikemate.app.model.route.LatLong
 import ch.hikemate.app.model.route.saved.SavedHikesRepository
 import ch.hikemate.app.ui.components.CenteredErrorAction
 import ch.hikemate.app.ui.components.HikeCard
@@ -223,7 +224,7 @@ class MapScreenTest : TestCase() {
   @Test
   fun clickingOnHikeItemSelectsHikeRoute() {
     setUpMap()
-    val hikeRoute = HikeRoute("Route 1", Bounds(0.0, 0.0, 0.0, 0.0), emptyList())
+    val hikeRoute = HikeRoute("Route 1", Bounds(0.0, 0.0, 0.0, 0.0), listOf(LatLong(1.0, 2.0)))
     `when`(hikesRepository.getRoutes(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(List<HikeRoute>) -> Unit>(1)
       onSuccess(listOf(hikeRoute))
@@ -256,7 +257,8 @@ class MapScreenTest : TestCase() {
   fun hikesListDisplaysHikeNameIfAvailable() {
     // Given
     val hikeName = "My test hike whatever"
-    val hike = HikeRoute("1", Bounds(-1.0, -1.0, 1.0, 1.0), listOf(), hikeName, null)
+    val hike =
+        HikeRoute("1", Bounds(-1.0, -1.0, 1.0, 1.0), listOf(LatLong(1.0, 2.0)), hikeName, null)
     `when`(hikesRepository.getRoutes(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(List<HikeRoute>) -> Unit>(1)
       onSuccess(listOf(hike))
@@ -278,7 +280,7 @@ class MapScreenTest : TestCase() {
   @Test
   fun hikesListDisplaysDefaultValueIfNameNotAvailable() {
     // Given
-    val hike = HikeRoute("1", Bounds(-1.0, -1.0, 1.0, 1.0), listOf(), null, null)
+    val hike = HikeRoute("1", Bounds(-1.0, -1.0, 1.0, 1.0), listOf(LatLong(1.0, 2.0)), null, null)
     `when`(hikesRepository.getRoutes(any(), any(), any())).thenAnswer {
       val onSuccess = it.getArgument<(List<HikeRoute>) -> Unit>(1)
       onSuccess(listOf(hike))

--- a/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/MapScreen.kt
@@ -169,6 +169,12 @@ object MapScreen {
    */
   const val USER_LOCATION_MARKER_ICON_SIZE = 40
 
+  /**
+   * (Config) Size of the icon representing the starting point of a hike on the map. The size is
+   * defined empirically to make the icon visible and not too big.
+   */
+  const val HIKE_STARTING_MARKER_ICON_SIZE = 40
+
   // These are the limits of the map. They are defined by the
   // latitude values that the map can display.
   // The latitude goes from -85 to 85, because going beyond

--- a/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
@@ -226,7 +226,7 @@ object MapUtils {
     val bitmap =
         Bitmap.createBitmap(
             MapScreen.HIKE_STARTING_MARKER_ICON_SIZE,
-            MapScreen.USER_LOCATION_MARKER_ICON_SIZE,
+            MapScreen.HIKE_STARTING_MARKER_ICON_SIZE,
             Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
 

--- a/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
@@ -2,6 +2,8 @@ package ch.hikemate.app.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.location.Location
@@ -57,7 +59,21 @@ object MapUtils {
       true
     }
 
+    val startingMarker =
+        Marker(mapView).apply {
+          // Dynamically create the custom icon
+          icon =
+              createCircularIcon(
+                  context = mapView.context,
+                  fillColor = color,
+              )
+
+          position = GeoPoint(waypoints.first().lat, waypoints.first().lon)
+          setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
+        }
+
     mapView.overlays.add(line)
+    mapView.overlays.add(startingMarker)
   }
 
   /**
@@ -117,7 +133,7 @@ object MapUtils {
     val adjustedLongDiff = longDiff * cos(Math.toRadians(centerLat))
 
     // Calculate the maximum degree difference between lat and adjusted long
-    val maxDegreeDiff = kotlin.math.max(latDiff, adjustedLongDiff)
+    val maxDegreeDiff = max(latDiff, adjustedLongDiff)
 
     // The coverage of each zoom level in degrees. The Index is the OSM Zoom leve, as per the
     // documentation
@@ -186,10 +202,45 @@ object MapUtils {
             MapScreen.USER_LOCATION_MARKER_ICON_SIZE,
             MapScreen.USER_LOCATION_MARKER_ICON_SIZE,
             Bitmap.Config.ARGB_8888)
-    val canvas = android.graphics.Canvas(bitmap)
+    val canvas = Canvas(bitmap)
     originalDrawable?.setBounds(0, 0, canvas.width, canvas.height)
     originalDrawable?.draw(canvas)
 
+    return BitmapDrawable(context.resources, bitmap)
+  }
+
+  /**
+   * Creates a circular icon with a fill color and a stroke color. The icon is used to represent the
+   * starting point of a hike on the map.
+   *
+   * @param context The context where the icon will be used
+   * @param fillColor The color to fill the circle
+   * @return The circular icon with the specified fill and stroke colors
+   */
+  private fun createCircularIcon(context: Context, fillColor: Int): BitmapDrawable {
+    // Create a mutable bitmap
+    val bitmap =
+        Bitmap.createBitmap(
+            MapScreen.HIKE_STARTING_MARKER_ICON_SIZE,
+            MapScreen.USER_LOCATION_MARKER_ICON_SIZE,
+            Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    // Paint for fill color
+    val fillPaint =
+        Paint().apply {
+          style = Paint.Style.FILL
+          color = fillColor
+          isAntiAlias = true
+        }
+
+    // Calculate center and radius
+    val center = MapScreen.HIKE_STARTING_MARKER_ICON_SIZE / 2f
+
+    // Draw the circle
+    canvas.drawCircle(center, center, center, fillPaint) // Filled circle
+
+    // Convert bitmap to drawable
     return BitmapDrawable(context.resources, bitmap)
   }
 

--- a/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
+++ b/app/src/main/java/ch/hikemate/app/utils/MapUtils.kt
@@ -70,6 +70,10 @@ object MapUtils {
 
           position = GeoPoint(waypoints.first().lat, waypoints.first().lon)
           setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
+          setOnMarkerClickListener({ _, _ ->
+            onLineClick()
+            true
+          })
         }
 
     mapView.overlays.add(line)


### PR DESCRIPTION
# Summary
It was previously very hard to know which end of the hike was the start or the end of it. For this, I added a little circle at the start of it.

# Details
We could discuss if this could still be confusing for the user as he could believe this is the end of the hike.

Before:
![before](https://github.com/user-attachments/assets/cc2720dc-818a-46b8-814c-45e68c7a5a3a)

After:
![after](https://github.com/user-attachments/assets/b0e1d67b-3d34-41ae-905b-cc5c8ddbd17d)