### PR TITLE
fix: add a back button on HikeDetails and RunHike loading screen

### DIFF
--- a/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
@@ -57,6 +57,7 @@ fun WithDetailedHike(
 
   if (detailedHike != null) {
     withDetailedHike(detailedHike!!)
+    return
   }
 
   Column(Modifier.fillMaxSize().safeDrawingPadding()) {

--- a/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
@@ -10,9 +10,6 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -53,10 +50,8 @@ fun WithDetailedHike(
 ) {
   val loadingErrorMessageId by hikesViewModel.loadingErrorMessageId.collectAsState()
 
-  var detailedHike: DetailedHike? by remember { mutableStateOf(null) }
-
   Column(Modifier.fillMaxSize().safeDrawingPadding()) {
-    if (detailedHike == null && !hike.isFullyLoaded()) {
+    if (!hike.isFullyLoaded()) {
       BackButton(
           navigationActions,
           modifier = Modifier.padding(start = 16.dp, end = 16.dp),
@@ -77,7 +72,6 @@ fun WithDetailedHike(
         if (fetchedDetailedHike == null) {
           whenError()
         } else {
-          detailedHike = fetchedDetailedHike
           withDetailedHike(fetchedDetailedHike)
         }
       }

--- a/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
@@ -55,16 +55,13 @@ fun WithDetailedHike(
 
   var detailedHike: DetailedHike? by remember { mutableStateOf(null) }
 
-  if (detailedHike != null) {
-    withDetailedHike(detailedHike!!)
-    return
-  }
-
   Column(Modifier.fillMaxSize().safeDrawingPadding()) {
-    BackButton(
-        navigationActions,
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-        onClick = onBackAction)
+    if (detailedHike == null) {
+      BackButton(
+          navigationActions,
+          modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+          onClick = onBackAction)
+    }
 
     when {
       // All the details of the hike have been computed, pass them on to the content callback
@@ -81,6 +78,7 @@ fun WithDetailedHike(
           whenError()
         } else {
           detailedHike = fetchedDetailedHike
+          withDetailedHike(fetchedDetailedHike)
         }
       }
 

--- a/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/components/WithDetailedHike.kt
@@ -56,7 +56,7 @@ fun WithDetailedHike(
   var detailedHike: DetailedHike? by remember { mutableStateOf(null) }
 
   Column(Modifier.fillMaxSize().safeDrawingPadding()) {
-    if (detailedHike == null) {
+    if (detailedHike == null && !hike.isFullyLoaded()) {
       BackButton(
           navigationActions,
           modifier = Modifier.padding(start = 16.dp, end = 16.dp),

--- a/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailsScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/HikeDetailsScreen.kt
@@ -221,7 +221,9 @@ fun HikeDetailScreen(
             actionIcon = Icons.AutoMirrored.Filled.ArrowBack,
             actionContentDescriptionStringId = R.string.go_back,
             onAction = { hikesViewModel.unselectHike() })
-      })
+      },
+      navigationActions = navigationActions,
+      onBackAction = { hikesViewModel.unselectHike() })
 }
 
 @Composable

--- a/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/map/RunHikeScreen.kt
@@ -1,5 +1,6 @@
 package ch.hikemate.app.ui.map
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.location.Location
@@ -124,7 +125,9 @@ fun RunHikeScreen(
             actionIcon = Icons.AutoMirrored.Filled.ArrowBack,
             actionContentDescriptionStringId = R.string.go_back,
             onAction = { navigationActions.goBack() })
-      })
+      },
+      navigationActions = navigationActions,
+      onBackAction = { hikesViewModel.unselectHike() })
 }
 
 @SuppressLint("ClickableViewAccessibility")
@@ -143,8 +146,8 @@ private fun RunHikeContent(
       rememberMultiplePermissionsState(
           permissions =
               listOf(
-                  android.Manifest.permission.ACCESS_FINE_LOCATION,
-                  android.Manifest.permission.ACCESS_COARSE_LOCATION))
+                  Manifest.permission.ACCESS_FINE_LOCATION,
+                  Manifest.permission.ACCESS_COARSE_LOCATION))
   var showLocationPermissionDialog by remember { mutableStateOf(false) }
   var centerMapOnUserPosition by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
# Summary

- This fixes #299 where a user could be stuck in a soft loop in case their internet was not working, while trying to go on the HikeDetails screen.
- This does the same thing on the RunHikeScreen, even though the bug should never happen here since we already have the details

# Details
Paths to recreate the bug:

- Online search for hikes.
- Disable your internet connection.
- Try to go to the HikeDetailsScreen of a Hike.
- User is stuck

This now adds a BackButton for the user to escape.

# Old UI

![Screenshot_20241217_165010](https://github.com/user-attachments/assets/94ce0638-b6fa-4a32-b049-9b4b8b12c939)
![Screenshot_20241217_165016](https://github.com/user-attachments/assets/72b9bf93-d5d2-42a1-9322-f00bc78eca81)

# New UI

![Screenshot_20241217_164650](https://github.com/user-attachments/assets/bc1caac4-7a8f-45ce-89e6-7da8633ac752)
![Screenshot_20241217_164708](https://github.com/user-attachments/assets/549cfc4c-f7ef-45d7-a21d-bf500ed2e25a)
