### PR TITLE
fix: ui glitching when clicking on already selected bottom item

### DIFF
--- a/app/src/androidTest/java/ch/hikemate/app/navigation/BottomBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/BottomBarNavigationTest.kt
@@ -1,0 +1,84 @@
+package ch.hikemate.app.navigation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.hikemate.app.ui.navigation.BottomBarNavigation
+import ch.hikemate.app.ui.navigation.LIST_TOP_LEVEL_DESTINATIONS
+import ch.hikemate.app.ui.navigation.Route
+import ch.hikemate.app.ui.navigation.TEST_TAG_BOTTOM_BAR
+import ch.hikemate.app.ui.navigation.TEST_TAG_MENU_ITEM_PREFIX
+import ch.hikemate.app.ui.navigation.TopLevelDestinations
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BottomBarNavigationTest {
+  // Set up the Compose test rule
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun clickingOnAItemChangeScreen() {
+    var wantedRoute = Route.MAP
+    var countDownLatch = 3
+    composeTestRule.setContent {
+      BottomBarNavigation(
+          onTabSelect = {
+            if (it.route != wantedRoute) {
+              fail("Expected route $wantedRoute but got ${it.route}")
+            } else {
+              countDownLatch--
+            }
+          },
+          tabList = LIST_TOP_LEVEL_DESTINATIONS,
+          selectedItem = Route.MAP) {}
+    }
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_BAR).assertIsDisplayed()
+
+    wantedRoute = Route.SAVED_HIKES
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.SAVED_HIKES.route)
+        .performClick()
+
+    wantedRoute = Route.PROFILE
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.PROFILE.route)
+        .performClick()
+
+    wantedRoute = Route.TUTORIAL
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.TUTORIAL.route)
+        .performClick()
+
+    composeTestRule.waitForIdle()
+    assertEquals(0, countDownLatch)
+  }
+
+  @Test
+  fun clickingTwiceOnTheSameItemDoesNotChangeTheScreen() {
+    composeTestRule.setContent {
+      BottomBarNavigation(
+          onTabSelect = { fail("The screen should not change") },
+          tabList = LIST_TOP_LEVEL_DESTINATIONS,
+          selectedItem = Route.MAP) {}
+    }
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag(TEST_TAG_BOTTOM_BAR).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(TEST_TAG_MENU_ITEM_PREFIX + TopLevelDestinations.MAP.route)
+        .performClick()
+
+    composeTestRule.waitForIdle()
+  }
+}

--- a/app/src/androidTest/java/ch/hikemate/app/navigation/BottomBarNavigationTest.kt
+++ b/app/src/androidTest/java/ch/hikemate/app/navigation/BottomBarNavigationTest.kt
@@ -23,7 +23,7 @@ class BottomBarNavigationTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun clickingOnAItemChangeScreen() {
+  fun clickingOnAnItemChangesScreen() {
     var wantedRoute = Route.MAP
     var countDownLatch = 3
     composeTestRule.setContent {

--- a/app/src/main/java/ch/hikemate/app/ui/navigation/BottomBarNavigation.kt
+++ b/app/src/main/java/ch/hikemate/app/ui/navigation/BottomBarNavigation.kt
@@ -36,6 +36,7 @@ fun BottomBarNavigation(
             modifier = Modifier.testTag(TEST_TAG_BOTTOM_BAR),
         ) {
           tabList.forEach { tab ->
+            val selected = tab.route == selectedItem
             NavigationBarItem(
                 icon = {
                   Icon(
@@ -44,8 +45,8 @@ fun BottomBarNavigation(
                   )
                 },
                 label = { Text(stringResource(tab.textId)) },
-                selected = tab.route == selectedItem,
-                onClick = { onTabSelect(tab) },
+                selected = selected,
+                onClick = { if (!selected) onTabSelect(tab) },
                 modifier = Modifier.testTag(TEST_TAG_MENU_ITEM_PREFIX + tab.route),
             )
           }


### PR DESCRIPTION
# Summary
- Fixes a UI Glitch bug when clicking on currently selected bottom navigation item 

# Details
- When the user clicked on the current selected bottom navigation item, the navigation actions are triggered and re-render the screen, which leads to a UI glitch. 
- I fixed it by making the navigation actions be triggered only when needed

# Old behavior


https://github.com/user-attachments/assets/f785d91e-7142-4dc1-8856-7208c11a3e9e

# New behavior

https://github.com/user-attachments/assets/204b735a-1497-440f-9f9e-63a3bd5b2816
